### PR TITLE
fix: rename --verbose to stderr output, add --log-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,14 @@ databricks-claude "explain this codebase"
 # With a specific Databricks CLI profile:
 databricks-claude --profile my-workspace "write tests for auth.py"
 
-# Verbose logging:
+# Verbose logging (debug output to stderr):
 databricks-claude --verbose "fix the bug in main.go"
+
+# Log to file:
+databricks-claude --log-file /tmp/dc.log "fix the bug in main.go"
+
+# Both stderr and file:
+databricks-claude -v --log-file /tmp/dc.log "fix the bug in main.go"
 
 # With OTEL telemetry:
 databricks-claude --otel --otel-table main.catalog.table "summarize this PR"
@@ -59,7 +65,8 @@ databricks-claude --otel --otel-table main.catalog.table "summarize this PR"
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--profile` | `DEFAULT` | Databricks CLI profile |
-| `--verbose` | `false` | Log to `~/.claude/logs/databricks-claude.log` |
+| `--verbose`, `-v` | `false` | Enable debug logging to stderr |
+| `--log-file` | | Write debug logs to a file (combinable with `--verbose`) |
 | `--otel` | `false` | Enable OTEL telemetry proxying |
 | `--otel-table` | `main.claude_telemetry.claude_otel_metrics` | UC table for OTEL metrics |
 | `--upstream` | auto-discovered | Override the AI Gateway URL |

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -19,7 +20,7 @@ func main() {
 	// Parse databricks-claude flags, passing everything else through to claude.
 	// Usage: databricks-claude [databricks-claude-flags] [--] [claude-args...]
 	// Unknown flags are forwarded to claude automatically.
-	profile, verbose, version, showHelp, printEnv, otel, otelTable, upstream, claudeArgs := parseArgs(os.Args[1:])
+	profile, verbose, version, showHelp, printEnv, otel, otelTable, upstream, logFile, claudeArgs := parseArgs(os.Args[1:])
 
 	if showHelp {
 		handleHelp(upstream)
@@ -37,18 +38,24 @@ func main() {
 		log.Fatalf("databricks-claude: cannot determine home dir: %v", err)
 	}
 
-	// Set up file-based logging when verbose is enabled.
-	// Logs go to ~/.claude/logs/databricks-claude.log to avoid polluting the REPL.
+	// Default: discard all logs (silent wrapper — identical to vanilla claude).
+	log.SetOutput(io.Discard)
+
 	if verbose {
-		logDir := filepath.Join(homeDir, ".claude", "logs")
-		if err := os.MkdirAll(logDir, 0o755); err == nil {
-			logPath := filepath.Join(logDir, "databricks-claude.log")
-			logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-			if err == nil {
-				log.SetOutput(logFile)
-				defer logFile.Close()
-				fmt.Fprintf(os.Stderr, "databricks-claude: logging to %s\n", logPath)
-			}
+		log.SetOutput(os.Stderr)
+	}
+	if logFile != "" {
+		f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			log.SetOutput(os.Stderr) // ensure this fatal is visible
+			log.Fatalf("databricks-claude: cannot open log file %q: %v", logFile, err)
+		}
+		defer f.Close()
+		if verbose {
+			// Both stderr and file.
+			log.SetOutput(io.MultiWriter(os.Stderr, f))
+		} else {
+			log.SetOutput(f)
 		}
 	}
 	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
@@ -245,10 +252,10 @@ func envBlock(doc map[string]interface{}) map[string]interface{} {
 }
 
 // parseArgs separates databricks-claude flags from claude flags.
-// databricks-claude owns: --profile, --verbose, --version, --otel, --otel-table.
+// databricks-claude owns: --profile, --verbose/-v, --log-file, --version, --otel, --otel-table.
 // Everything else (including unknown flags like --debug) passes through to claude.
 // An explicit "--" separator is supported but not required.
-func parseArgs(args []string) (profile string, verbose bool, version bool, showHelp bool, printEnv bool, otel bool, otelTable string, upstream string, claudeArgs []string) {
+func parseArgs(args []string) (profile string, verbose bool, version bool, showHelp bool, printEnv bool, otel bool, otelTable string, upstream string, logFile string, claudeArgs []string) {
 	otelTable = "main.claude_telemetry.claude_otel_metrics" // default
 
 	knownFlags := map[string]bool{
@@ -260,6 +267,7 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 		"--otel":       true,
 		"--otel-table": true,
 		"--upstream":   true,
+		"--log-file":   true,
 	}
 
 	i := 0
@@ -272,9 +280,14 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 			return
 		}
 
-		// Special case: -h is a short flag for --help.
+		// Special case: -h is a short flag for --help, -v for --verbose.
 		if arg == "-h" {
 			showHelp = true
+			i++
+			continue
+		}
+		if arg == "-v" {
+			verbose = true
 			i++
 			continue
 		}
@@ -312,6 +325,13 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 						i++
 						upstream = args[i]
 					}
+				case "--log-file":
+					if value != "" {
+						logFile = value
+					} else if i+1 < len(args) {
+						i++
+						logFile = args[i]
+					}
 				case "--verbose":
 					verbose = true
 				case "--version":
@@ -347,9 +367,10 @@ Usage:
 
 Databricks-Claude Flags:
   --profile string      Databricks config profile (default "DEFAULT")
-  --upstream string     Path to claude binary (default: auto-discovered)
+  --upstream string     Override the AI Gateway URL (default: auto-discovered)
   --print-env           Print resolved configuration and exit (token redacted)
-  --verbose             Enable verbose logging
+  --verbose, -v         Enable debug logging to stderr
+  --log-file string     Write debug logs to a file (combinable with --verbose)
   --otel                Enable OpenTelemetry tracing
   --otel-table string   Unity Catalog table for OTEL spans
   --version             Print version and exit

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strings"
 	"testing"
@@ -12,73 +13,94 @@ import (
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, _, upstream, claudeArgs := parseArgs([]string{"--help"})
+	profile, verbose, version, showHelp, printEnv, otel, _, upstream, logFile, claudeArgs := parseArgs([]string{"--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true for --help")
 	}
-	if profile != "" || verbose || version || printEnv || otel || upstream != "" || len(claudeArgs) != 0 {
+	if profile != "" || verbose || version || printEnv || otel || upstream != "" || logFile != "" || len(claudeArgs) != 0 {
 		t.Error("unexpected non-default values alongside --help")
 	}
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, _, showHelp, _, _, _, _, _ := parseArgs([]string{"-h"})
+	_, _, _, showHelp, _, _, _, _, _, _ := parseArgs([]string{"-h"})
 	if !showHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, _, printEnv, _, _, _, _ := parseArgs([]string{"--print-env"})
+	_, _, _, _, printEnv, _, _, _, _, _ := parseArgs([]string{"--print-env"})
 	if !printEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, _, version, _, _, _, _, _, _ := parseArgs([]string{"--version"})
+	_, _, version, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
 	if !version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
+	_, verbose, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
 	if !verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
+func TestParseArgs_VerboseShort(t *testing.T) {
+	_, verbose, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
+	if !verbose {
+		t.Error("expected verbose=true for -v")
+	}
+}
+
+func TestParseArgs_LogFile(t *testing.T) {
+	_, _, _, _, _, _, _, _, logFile, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	if logFile != "/tmp/test.log" {
+		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
+	}
+}
+
+func TestParseArgs_LogFileEquals(t *testing.T) {
+	_, _, _, _, _, _, _, _, logFile, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
+	if logFile != "/tmp/test.log" {
+		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
+	}
+}
+
 func TestParseArgs_Profile(t *testing.T) {
-	profile, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "foo"})
+	profile, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "foo"})
 	if profile != "foo" {
 		t.Errorf("expected profile=%q, got %q", "foo", profile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, _, _, upstream, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
+	_, _, _, _, _, _, _, upstream, _, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
 	if upstream != "/path/to/claude" {
 		t.Errorf("expected upstream=%q, got %q", "/path/to/claude", upstream)
 	}
 }
 
 func TestParseArgs_Otel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, otel, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--unknown"})
+	_, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--unknown"})
 	if len(claudeArgs) != 1 || claudeArgs[0] != "--unknown" {
 		t.Errorf("expected claudeArgs=[\"--unknown\"], got %v", claudeArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, otelTable, upstream, claudeArgs := parseArgs([]string{})
+	profile, verbose, version, showHelp, printEnv, otel, otelTable, upstream, logFile, claudeArgs := parseArgs([]string{})
 	if profile != "" {
 		t.Errorf("expected empty profile, got %q", profile)
 	}
@@ -87,6 +109,9 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 	}
 	if upstream != "" {
 		t.Errorf("expected empty upstream, got %q", upstream)
+	}
+	if logFile != "" {
+		t.Errorf("expected empty logFile, got %q", logFile)
 	}
 	if len(claudeArgs) != 0 {
 		t.Errorf("expected no claudeArgs, got %v", claudeArgs)
@@ -98,7 +123,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	profile, verbose, _, showHelp, _, _, _, _, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
+	profile, verbose, _, showHelp, _, _, _, _, _, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -120,6 +145,7 @@ func TestParseArgs_Table(t *testing.T) {
 		printEnv  bool
 		otel      bool
 		upstream  string
+		logFile   string
 		claudeLen int
 	}
 
@@ -152,6 +178,26 @@ func TestParseArgs_Table(t *testing.T) {
 			name: "--verbose sets verbose",
 			args: []string{"--verbose"},
 			want: result{verbose: true},
+		},
+		{
+			name: "-v sets verbose",
+			args: []string{"-v"},
+			want: result{verbose: true},
+		},
+		{
+			name: "--log-file sets logFile",
+			args: []string{"--log-file", "/tmp/test.log"},
+			want: result{logFile: "/tmp/test.log"},
+		},
+		{
+			name: "--log-file=value sets logFile",
+			args: []string{"--log-file=/tmp/test.log"},
+			want: result{logFile: "/tmp/test.log"},
+		},
+		{
+			name: "-v with --log-file sets both",
+			args: []string{"-v", "--log-file", "/tmp/both.log"},
+			want: result{verbose: true, logFile: "/tmp/both.log"},
 		},
 		{
 			name: "--profile foo sets profile",
@@ -187,7 +233,7 @@ func TestParseArgs_Table(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			profile, verbose, version, showHelp, printEnv, otel, _, upstream, claudeArgs := parseArgs(tc.args)
+			profile, verbose, version, showHelp, printEnv, otel, _, upstream, logFile, claudeArgs := parseArgs(tc.args)
 
 			if profile != tc.want.profile {
 				t.Errorf("profile: got %q, want %q", profile, tc.want.profile)
@@ -210,10 +256,35 @@ func TestParseArgs_Table(t *testing.T) {
 			if upstream != tc.want.upstream {
 				t.Errorf("upstream: got %q, want %q", upstream, tc.want.upstream)
 			}
+			if logFile != tc.want.logFile {
+				t.Errorf("logFile: got %q, want %q", logFile, tc.want.logFile)
+			}
 			if len(claudeArgs) != tc.want.claudeLen {
 				t.Errorf("claudeArgs length: got %d, want %d (args: %v)", len(claudeArgs), tc.want.claudeLen, claudeArgs)
 			}
 		})
+	}
+}
+
+// --- default log discard test ---
+
+func TestDefaultLogDiscard(t *testing.T) {
+	// Verify that when no flags are set, log output is discarded.
+	// We simulate the main() logic: default sets log.SetOutput(io.Discard).
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(os.Stderr) // restore after test
+
+	var buf bytes.Buffer
+	// Write a log message — it should go nowhere (Discard).
+	log.SetOutput(io.Discard)
+	log.Print("this should be discarded")
+
+	// Now capture to buf to prove we can switch
+	log.SetOutput(&buf)
+	log.Print("this should appear")
+
+	if !strings.Contains(buf.String(), "this should appear") {
+		t.Error("expected log output after switching from Discard")
 	}
 }
 
@@ -333,7 +404,7 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	flags := []string{"--profile", "--upstream", "--verbose", "--otel", "--version", "--help"}
+	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--version", "--help"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)


### PR DESCRIPTION
## Summary
- *Default (no flags)* now discards all log output — wrapper is completely silent, identical to vanilla `claude`
- *--verbose / -v* sends debug logs to stderr (matches `curl -v`, `git --verbose`, `kubectl` conventions)
- *--log-file <path>* redirects debug logs to a file; combinable with `--verbose` for both
- Removed hardcoded `~/.claude/logs/databricks-claude.log` auto-file behavior

Closes #3

## Test plan
- [ ] `go test ./...` passes (new tests for `-v` alias, `--log-file`, `--log-file=value`, combined flags, default discard)
- [ ] `databricks-claude` with no flags produces zero extra output
- [ ] `databricks-claude -v` shows debug logs on stderr
- [ ] `databricks-claude --log-file /tmp/dc.log` writes logs to file
- [ ] `databricks-claude -v --log-file /tmp/dc.log` writes to both stderr and file

🤖 Generated with [Claude Code](https://claude.com/claude-code)