### PR TITLE
fix: complete OTEL setup — logs support, table differentiation, --print-env

### DIFF
--- a/main.go
+++ b/main.go
@@ -178,10 +178,13 @@ func main() {
 		ucTable = otelTable
 	}
 
+	// Derive logs table name from metrics table name.
+	otelLogsTable := deriveLogsTable(ucTable)
+
 	// --- Print env and exit if requested ---
 	if printEnv {
 		anthropicModel := os.Getenv("ANTHROPIC_MODEL")
-		handlePrintEnv(resolvedProfile, databricksHost, inferenceUpstream, initialToken, anthropicModel, upstream, otel || otelConfigured)
+		handlePrintEnv(resolvedProfile, databricksHost, inferenceUpstream, initialToken, anthropicModel, upstream, otel || otelConfigured, ucTable, otelLogsTable)
 		os.Exit(0)
 	}
 
@@ -189,7 +192,8 @@ func main() {
 	proxyConfig := &ProxyConfig{
 		InferenceUpstream: inferenceUpstream,
 		OTELUpstream:      otelUpstream,
-		UCTable:           ucTable,
+		UCMetricsTable:    ucTable,
+		UCLogsTable:       otelLogsTable,
 		TokenProvider:     tp,
 		Verbose:           verbose,
 	}
@@ -423,7 +427,7 @@ Claude CLI Options:
 }
 
 // handlePrintEnv prints resolved configuration with the token redacted.
-func handlePrintEnv(profile, databricksHost, anthropicBaseURL, token, anthropicModel, upstreamBinary string, otelEnabled bool) {
+func handlePrintEnv(profile, databricksHost, anthropicBaseURL, token, anthropicModel, upstreamBinary string, otelEnabled bool, otelMetricsTable, otelLogsTable string) {
 	// Redact token.
 	redacted := "**** (redacted)"
 	if strings.HasPrefix(token, "dapi-") {
@@ -449,4 +453,22 @@ func handlePrintEnv(profile, databricksHost, anthropicBaseURL, token, anthropicM
   Upstream binary:      %s
   OTEL enabled:         %v
 `, profile, databricksHost, anthropicBaseURL, redacted, anthropicModel, binaryPath, otelEnabled)
+
+	if otelEnabled {
+		fmt.Printf(`  OTEL metrics table:   %s
+  OTEL logs table:      %s
+  OTEL metric interval: 10000ms
+  OTEL logs interval:   5000ms
+`, otelMetricsTable, otelLogsTable)
+	}
+}
+
+// deriveLogsTable derives the OTEL logs table name from the metrics table name.
+// If the metrics table ends with "_otel_metrics", replace that suffix with "_otel_logs".
+// Otherwise, append "_otel_logs" as a sibling.
+func deriveLogsTable(metricsTable string) string {
+	if strings.HasSuffix(metricsTable, "_otel_metrics") {
+		return strings.TrimSuffix(metricsTable, "_otel_metrics") + "_otel_logs"
+	}
+	return metricsTable + "_otel_logs"
 }

--- a/main_test.go
+++ b/main_test.go
@@ -351,7 +351,7 @@ func captureStdout(fn func()) string {
 
 func TestHandlePrintEnv_DapiTokenRedacted(t *testing.T) {
 	out := captureStdout(func() {
-		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "dapi-abc123secret", "", "", false)
+		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "dapi-abc123secret", "", "", false, "", "")
 	})
 	if !strings.Contains(out, "dapi-***") {
 		t.Errorf("expected dapi token to appear as 'dapi-***', got:\n%s", out)
@@ -363,7 +363,7 @@ func TestHandlePrintEnv_DapiTokenRedacted(t *testing.T) {
 
 func TestHandlePrintEnv_NonDapiTokenRedacted(t *testing.T) {
 	out := captureStdout(func() {
-		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "eyJhbGciOiJSUzI1NiJ9", "", "", false)
+		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "eyJhbGciOiJSUzI1NiJ9", "", "", false, "", "")
 	})
 	if !strings.Contains(out, "**** (redacted)") {
 		t.Errorf("expected non-dapi token to appear as '**** (redacted)', got:\n%s", out)
@@ -376,7 +376,7 @@ func TestHandlePrintEnv_NonDapiTokenRedacted(t *testing.T) {
 func TestHandlePrintEnv_ContainsDatabricksHost(t *testing.T) {
 	host := "https://dbc-abc123.cloud.databricks.com"
 	out := captureStdout(func() {
-		handlePrintEnv("DEFAULT", host, "https://gw.example.com", "tok", "", "", false)
+		handlePrintEnv("DEFAULT", host, "https://gw.example.com", "tok", "", "", false, "", "")
 	})
 	if !strings.Contains(out, host) {
 		t.Errorf("expected output to contain DATABRICKS_HOST %q, got:\n%s", host, out)
@@ -386,7 +386,7 @@ func TestHandlePrintEnv_ContainsDatabricksHost(t *testing.T) {
 func TestHandlePrintEnv_ContainsAnthropicBaseURL(t *testing.T) {
 	baseURL := "https://gateway.example.com/anthropic"
 	out := captureStdout(func() {
-		handlePrintEnv("DEFAULT", "https://dbc.example.com", baseURL, "tok", "", "", false)
+		handlePrintEnv("DEFAULT", "https://dbc.example.com", baseURL, "tok", "", "", false, "", "")
 	})
 	if !strings.Contains(out, baseURL) {
 		t.Errorf("expected output to contain ANTHROPIC_BASE_URL %q, got:\n%s", baseURL, out)
@@ -395,7 +395,7 @@ func TestHandlePrintEnv_ContainsAnthropicBaseURL(t *testing.T) {
 
 func TestHandlePrintEnv_EmptyTokenRedacted(t *testing.T) {
 	out := captureStdout(func() {
-		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "", "", "", false)
+		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "", "", "", false, "", "")
 	})
 	// Empty string does not start with "dapi-" so it should show as **** (redacted)
 	if !strings.Contains(out, "**** (redacted)") {
@@ -463,5 +463,65 @@ func TestHandleHelp_ContainsVersion(t *testing.T) {
 	// Version variable is "dev" by default in tests.
 	if !strings.Contains(out, fmt.Sprintf("databricks-claude v%s", Version)) {
 		t.Errorf("expected help output to contain version string, got:\n%s", out)
+	}
+}
+
+// --- deriveLogsTable tests ---
+
+func TestOTELTableDerivation(t *testing.T) {
+	tests := []struct {
+		name    string
+		metrics string
+		want    string
+	}{
+		{
+			name:    "standard suffix replacement",
+			metrics: "main.claude_telemetry.claude_otel_metrics",
+			want:    "main.claude_telemetry.claude_otel_logs",
+		},
+		{
+			name:    "custom table without _otel_metrics suffix",
+			metrics: "mycatalog.myschema.custom",
+			want:    "mycatalog.myschema.custom_otel_logs",
+		},
+		{
+			name:    "only _otel_metrics",
+			metrics: "_otel_metrics",
+			want:    "_otel_logs",
+		},
+		{
+			name:    "empty string",
+			metrics: "",
+			want:    "_otel_logs",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveLogsTable(tc.metrics)
+			if got != tc.want {
+				t.Errorf("deriveLogsTable(%q) = %q, want %q", tc.metrics, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- handlePrintEnv OTEL fields test ---
+
+func TestHandlePrintEnv_OTELFields(t *testing.T) {
+	out := captureStdout(func() {
+		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "tok", "", "", true, "main.telemetry.claude_otel_metrics", "main.telemetry.claude_otel_logs")
+	})
+	checks := []string{
+		"OTEL enabled:         true",
+		"OTEL metrics table:   main.telemetry.claude_otel_metrics",
+		"OTEL logs table:      main.telemetry.claude_otel_logs",
+		"OTEL metric interval: 10000ms",
+		"OTEL logs interval:   5000ms",
+	}
+	for _, c := range checks {
+		if !strings.Contains(out, c) {
+			t.Errorf("expected output to contain %q, got:\n%s", c, out)
+		}
 	}
 }

--- a/process.go
+++ b/process.go
@@ -103,6 +103,12 @@ var inferenceKeys = []string{
 var otelKeys = []string{
 	"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
 	"OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+	"OTEL_METRIC_EXPORT_INTERVAL",
+	"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+	"OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+	"OTEL_LOGS_EXPORTER",
+	"OTEL_LOGS_EXPORT_INTERVAL",
 }
 
 // fullSetupInferenceKeys lists the env keys written by FullSetup (non-OTEL).
@@ -127,6 +133,13 @@ var fullSetupOTELKeys = []string{
 	"CLAUDE_CODE_ENABLE_TELEMETRY",
 	"OTEL_METRICS_EXPORTER",
 	"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+	"OTEL_METRIC_EXPORT_INTERVAL",
+	"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+	"OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+	"OTEL_LOGS_EXPORTER",
+	"OTEL_LOGS_EXPORT_INTERVAL",
+	"CLAUDE_OTEL_UC_TABLE",
 }
 
 // FullSetupConfig holds all parameters for FullSetup.
@@ -198,6 +211,13 @@ func (sm *SettingsManager) FullSetup(config FullSetupConfig) error {
 		env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
 		env["OTEL_METRICS_EXPORTER"] = "otlp"
 		env["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "http/protobuf"
+		env["OTEL_METRIC_EXPORT_INTERVAL"] = "10000"
+		env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = config.ProxyURL + "/otel/v1/logs"
+		env["OTEL_EXPORTER_OTLP_LOGS_HEADERS"] = "content-type=application/x-protobuf"
+		env["OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"] = "http/protobuf"
+		env["OTEL_LOGS_EXPORTER"] = "otlp"
+		env["OTEL_LOGS_EXPORT_INTERVAL"] = "5000"
+		env["CLAUDE_OTEL_UC_TABLE"] = config.OTELTable
 	}
 
 	return sm.writeSettings(doc)

--- a/process_test.go
+++ b/process_test.go
@@ -466,6 +466,53 @@ func TestFullSetup_CreatesSettingsIfMissing(t *testing.T) {
 	}
 }
 
+func TestFullSetup_OTELWritesAllTwelveKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	writeJSON(t, path, map[string]interface{}{"env": map[string]interface{}{}})
+
+	sm := NewSettingsManager(path)
+	cfg := FullSetupConfig{
+		ProxyURL:    "http://127.0.0.1:54321",
+		Token:       "tok",
+		Host:        "https://dbc.example.com",
+		Profile:     "p",
+		OTELEnabled: true,
+		OTELTable:   "main.claude_telemetry.claude_otel_metrics",
+	}
+	if err := sm.FullSetup(cfg); err != nil {
+		t.Fatalf("FullSetup: %v", err)
+	}
+
+	doc := readJSON(t, path)
+	env := doc["env"].(map[string]interface{})
+
+	otelChecks := map[string]string{
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": cfg.ProxyURL + "/otel/v1/metrics",
+		"OTEL_EXPORTER_OTLP_METRICS_HEADERS":  "content-type=application/x-protobuf",
+		"CLAUDE_CODE_ENABLE_TELEMETRY":         "1",
+		"OTEL_METRICS_EXPORTER":                "otlp",
+		"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL":  "http/protobuf",
+		"OTEL_METRIC_EXPORT_INTERVAL":           "10000",
+		"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT":     cfg.ProxyURL + "/otel/v1/logs",
+		"OTEL_EXPORTER_OTLP_LOGS_HEADERS":      "content-type=application/x-protobuf",
+		"OTEL_EXPORTER_OTLP_LOGS_PROTOCOL":     "http/protobuf",
+		"OTEL_LOGS_EXPORTER":                   "otlp",
+		"OTEL_LOGS_EXPORT_INTERVAL":            "5000",
+		"CLAUDE_OTEL_UC_TABLE":                 "main.claude_telemetry.claude_otel_metrics",
+	}
+	if len(otelChecks) != 12 {
+		t.Fatalf("expected 12 OTEL checks, got %d", len(otelChecks))
+	}
+	for k, want := range otelChecks {
+		if got, ok := env[k]; !ok {
+			t.Errorf("missing OTEL key %s", k)
+		} else if got != want {
+			t.Errorf("%s = %v, want %v", k, got, want)
+		}
+	}
+}
+
 func TestSignalForwarding(t *testing.T) {
 	// Start a child that sleeps; we'll kill it with SIGINT via ForwardSignals.
 	cmd := exec.Command("/bin/sleep", "60")

--- a/proxy.go
+++ b/proxy.go
@@ -15,7 +15,8 @@ import (
 type ProxyConfig struct {
 	InferenceUpstream string
 	OTELUpstream      string
-	UCTable           string
+	UCMetricsTable    string
+	UCLogsTable       string
 	TokenProvider     *TokenProvider
 	Verbose           bool
 }
@@ -101,7 +102,13 @@ func NewProxyServer(config *ProxyConfig) http.Handler {
 			}
 			req.Header.Set("Authorization", "Bearer "+token)
 			req.Header.Set("x-api-key", token)
-			req.Header.Set("X-Databricks-UC-Table-Name", config.UCTable)
+
+			// Pick the correct UC table based on whether this is a logs or metrics request.
+			ucTable := config.UCMetricsTable
+			if strings.Contains(req.URL.Path, "/v1/logs") {
+				ucTable = config.UCLogsTable
+			}
+			req.Header.Set("X-Databricks-UC-Table-Name", ucTable)
 
 			// Strip the /otel prefix and prepend the upstream base path.
 			stripped := strings.TrimPrefix(req.URL.Path, "/otel")

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -33,7 +33,8 @@ func TestProxy_InjectsAuthHeader(t *testing.T) {
 	cfg := &ProxyConfig{
 		InferenceUpstream: upstream.URL,
 		OTELUpstream:      upstream.URL,
-		UCTable:           "main.t.m",
+		UCMetricsTable:    "main.t.m",
+		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("test-token-123"),
 	}
 	handler := NewProxyServer(cfg)
@@ -59,7 +60,8 @@ func TestProxy_InjectsCustomHeaders(t *testing.T) {
 	cfg := &ProxyConfig{
 		InferenceUpstream: upstream.URL,
 		OTELUpstream:      upstream.URL,
-		UCTable:           "main.t.m",
+		UCMetricsTable:    "main.t.m",
+		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("tok"),
 	}
 	handler := NewProxyServer(cfg)
@@ -92,7 +94,8 @@ func TestProxy_RoutesDefaultToInference(t *testing.T) {
 	cfg := &ProxyConfig{
 		InferenceUpstream: inference.URL,
 		OTELUpstream:      otel.URL,
-		UCTable:           "main.t.m",
+		UCMetricsTable:    "main.t.m",
+		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("tok"),
 	}
 	handler := NewProxyServer(cfg)
@@ -124,7 +127,8 @@ func TestProxy_RoutesOTELPath(t *testing.T) {
 	cfg := &ProxyConfig{
 		InferenceUpstream: inference.URL,
 		OTELUpstream:      otel.URL,
-		UCTable:           "main.t.m",
+		UCMetricsTable:    "main.t.m",
+		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("tok"),
 	}
 	handler := NewProxyServer(cfg)
@@ -152,7 +156,8 @@ func TestProxy_PathAlgebra_Inference(t *testing.T) {
 	cfg := &ProxyConfig{
 		InferenceUpstream: upstream.URL + "/anthropic",
 		OTELUpstream:      upstream.URL,
-		UCTable:           "main.t.m",
+		UCMetricsTable:    "main.t.m",
+		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("tok"),
 	}
 	handler := NewProxyServer(cfg)
@@ -181,7 +186,8 @@ func TestProxy_PathAlgebra_OTEL(t *testing.T) {
 	cfg := &ProxyConfig{
 		InferenceUpstream: upstream.URL,
 		OTELUpstream:      upstream.URL + "/api/2.0/otel",
-		UCTable:           "main.t.m",
+		UCMetricsTable:    "main.t.m",
+		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("tok"),
 	}
 	handler := NewProxyServer(cfg)
@@ -210,7 +216,8 @@ func TestProxy_PreservesRequestBody(t *testing.T) {
 	cfg := &ProxyConfig{
 		InferenceUpstream: upstream.URL,
 		OTELUpstream:      upstream.URL,
-		UCTable:           "main.t.m",
+		UCMetricsTable:    "main.t.m",
+		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("tok"),
 	}
 	handler := NewProxyServer(cfg)
@@ -272,7 +279,8 @@ func TestProxy_SSEStreaming(t *testing.T) {
 	cfg := &ProxyConfig{
 		InferenceUpstream: upstream.URL,
 		OTELUpstream:      upstream.URL,
-		UCTable:           "main.t.m",
+		UCMetricsTable:    "main.t.m",
+		UCLogsTable:       "main.t.l",
 		TokenProvider:     warmToken("tok"),
 	}
 	handler := NewProxyServer(cfg)
@@ -298,5 +306,59 @@ func TestProxy_SSEStreaming(t *testing.T) {
 	want := "data: chunk\n\n"
 	if !strings.Contains(string(body), want) {
 		t.Errorf("response body %q does not contain %q", string(body), want)
+	}
+}
+
+// TestProxy_OTELTableName_Metrics verifies that /otel/v1/metrics gets the metrics table header.
+func TestProxy_OTELTableName_Metrics(t *testing.T) {
+	var gotTable string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTable = r.Header.Get("X-Databricks-UC-Table-Name")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &ProxyConfig{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCMetricsTable:    "main.telemetry.claude_otel_metrics",
+		UCLogsTable:       "main.telemetry.claude_otel_logs",
+		TokenProvider:     warmToken("tok"),
+	}
+	handler := NewProxyServer(cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/otel/v1/metrics", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if gotTable != "main.telemetry.claude_otel_metrics" {
+		t.Errorf("got table %q, want %q", gotTable, "main.telemetry.claude_otel_metrics")
+	}
+}
+
+// TestProxy_OTELTableName_Logs verifies that /otel/v1/logs gets the logs table header.
+func TestProxy_OTELTableName_Logs(t *testing.T) {
+	var gotTable string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTable = r.Header.Get("X-Databricks-UC-Table-Name")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &ProxyConfig{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCMetricsTable:    "main.telemetry.claude_otel_metrics",
+		UCLogsTable:       "main.telemetry.claude_otel_logs",
+		TokenProvider:     warmToken("tok"),
+	}
+	handler := NewProxyServer(cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/otel/v1/logs", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if gotTable != "main.telemetry.claude_otel_logs" {
+		t.Errorf("got table %q, want %q", gotTable, "main.telemetry.claude_otel_logs")
 	}
 }


### PR DESCRIPTION
## Summary

• Add 6 missing OTEL env vars: `OTEL_METRIC_EXPORT_INTERVAL`, `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`, `OTEL_EXPORTER_OTLP_LOGS_HEADERS`, `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`, `OTEL_LOGS_EXPORTER`, `OTEL_LOGS_EXPORT_INTERVAL`
• Split `UCTable` into `UCMetricsTable` + `UCLogsTable` with path-based selection in the OTEL proxy director (`/v1/logs` → logs table, everything else → metrics table)
• Derive logs table name from metrics table (replace `_otel_metrics` suffix with `_otel_logs`, or append `_otel_logs` for custom names)
• Persist `CLAUDE_OTEL_UC_TABLE` to settings.json so non-full-setup paths can recover the table name
• Expand `--print-env` to show OTEL metrics/logs table names and export intervals when OTEL is enabled

## Test plan

- [x] `TestProxy_OTELTableName_Metrics` — verifies `/otel/v1/metrics` gets the metrics table header
- [x] `TestProxy_OTELTableName_Logs` — verifies `/otel/v1/logs` gets the logs table header
- [x] `TestFullSetup_OTELWritesAllTwelveKeys` — verifies all 12 OTEL env vars are written
- [x] `TestOTELTableDerivation` — tests metrics→logs table name derivation (4 cases)
- [x] `TestHandlePrintEnv_OTELFields` — verifies OTEL fields in --print-env output
- [x] All existing tests pass, `go vet` clean

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)