### PR TITLE
feat: persist Databricks CLI profile across sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Transparent proxy wrapper for Claude Code that auto-refreshes Databricks OAuth t
 
 Four source files plus tests, all in `package main`:
 
-- **main.go** — CLI entry point: parses flags, resolves config from `~/.claude/settings.json`, seeds the token cache, discovers the AI Gateway URL, starts the proxy, patches settings, launches `claude`, and restores settings on exit.
+- **main.go** — CLI entry point: parses flags, resolves config from `~/.claude/settings.json` and `~/.claude/.databricks-claude.json` (persistent config), seeds the token cache, discovers the AI Gateway URL, starts the proxy, patches settings, launches `claude`, and restores settings on exit.
 - **proxy.go** — HTTP reverse proxy with two routes: `/` forwards to the inference upstream (AI Gateway), `/otel/` forwards to the OTEL upstream. Both routes inject fresh OAuth tokens per-request.
 - **token.go** — `TokenProvider` fetches and caches Databricks access tokens by shelling out to `databricks auth token`. Also contains `DiscoverHost`, `ResolveWorkspaceID`, and `ConstructGatewayURL` for auto-discovery.
 - **process.go** — `SettingsManager` for atomic read/patch/restore of `~/.claude/settings.json`. `RunChild` launches `claude` as a subprocess. `ForwardSignals` relays SIGINT/SIGTERM to the child.
@@ -19,6 +19,7 @@ Four source files plus tests, all in `package main`:
 - **Child process signals** — SIGINT/SIGTERM are forwarded to `claude`; its exit code is propagated as our exit code.
 - **Two proxy routes** — `/` routes to inference upstream, `/otel/` routes to OTEL upstream. Path algebra prepends the upstream base path.
 - **Panic recovery** — both proxy routes are wrapped in `recoveryHandler` that catches panics and returns HTTP 502.
+- **Persistent config** — `~/.claude/.databricks-claude.json` stores the Databricks CLI profile across sessions, independent of the settings.json restore cycle. Written on first setup when profile is not DEFAULT.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,22 @@ If workspace ID resolution fails, it falls back to `<host>/serving-endpoints/ant
 1. `--profile` CLI flag
 2. `DATABRICKS_CONFIG_PROFILE` environment variable
 3. `DATABRICKS_CONFIG_PROFILE` in `~/.claude/settings.json` env block
-4. `DEFAULT`
+4. `profile` from `~/.claude/.databricks-claude.json` (persistent config)
+5. `DEFAULT`
+
+## Persistent Config (`~/.claude/.databricks-claude.json`)
+
+On first setup (when `ANTHROPIC_BASE_URL` is not yet configured), `databricks-claude` saves your resolved profile to `~/.claude/.databricks-claude.json`. This file is **never** modified by the settings.json restore cycle, so your profile persists across sessions.
+
+```json
+{
+  "profile": "my-workspace"
+}
+```
+
+This means you only need to pass `--profile` once — subsequent runs will automatically use the saved profile. To switch profiles, pass `--profile <new-profile>` and the persistent config is updated.
+
+The file is only written when the profile is not `DEFAULT` (the implicit default doesn't need saving).
 
 ## Debugging
 

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 
 	env := envBlock(settingsDoc)
 
-	// Resolve profile: CLI flag > env var > settings.json > DEFAULT
+	// Resolve profile: CLI flag > env var > settings.json > persistent config > DEFAULT
 	resolvedProfile := profile
 	if resolvedProfile == "" {
 		resolvedProfile = os.Getenv("DATABRICKS_CONFIG_PROFILE")
@@ -89,6 +89,15 @@ func main() {
 	if resolvedProfile == "" {
 		if v, ok := env["DATABRICKS_CONFIG_PROFILE"].(string); ok && v != "" {
 			resolvedProfile = v
+		}
+	}
+	if resolvedProfile == "" {
+		pcPath := persistentConfigPath(homeDir)
+		if pc, err := readPersistentConfig(pcPath); err == nil {
+			if v, ok := pc["profile"].(string); ok && v != "" {
+				resolvedProfile = v
+				log.Printf("databricks-claude: using profile %q from persistent config", v)
+			}
 		}
 	}
 	if resolvedProfile == "" {
@@ -241,6 +250,18 @@ func main() {
 		}
 		log.Printf("databricks-claude: self-setup complete — profile=%s, host=%s, gateway=%s",
 			resolvedProfile, databricksHost, inferenceUpstream)
+
+		// Persist profile so future runs don't need --profile.
+		if resolvedProfile != "DEFAULT" {
+			pcPath := persistentConfigPath(homeDir)
+			pc, _ := readPersistentConfig(pcPath)
+			pc["profile"] = resolvedProfile
+			if err := writePersistentConfig(pcPath, pc); err != nil {
+				log.Printf("databricks-claude: warning: failed to persist profile: %v", err)
+			} else {
+				log.Printf("databricks-claude: persisted profile %q to %s", resolvedProfile, pcPath)
+			}
+		}
 	} else {
 		if err := sm.SaveAndOverwrite(proxyURL); err != nil {
 			log.Fatalf("databricks-claude: failed to patch settings.json: %v", err)
@@ -420,7 +441,7 @@ Usage:
   databricks-claude [databricks-claude flags] [claude flags] [claude args]
 
 Databricks-Claude Flags:
-  --profile string      Databricks config profile (default "DEFAULT")
+  --profile string      Databricks config profile (saved to ~/.claude/.databricks-claude.json)
   --upstream string     Override the AI Gateway URL (default: auto-discovered)
   --print-env           Print resolved configuration and exit (token redacted)
   --verbose, -v         Enable debug logging to stderr
@@ -502,6 +523,48 @@ func handlePrintEnv(profile, databricksHost, anthropicBaseURL, token, anthropicM
   OTEL logs interval:   5000ms
 `, otelMetricsTable, otelLogsTable)
 	}
+}
+
+// persistentConfigPath returns the path to the persistent config file.
+func persistentConfigPath(homeDir string) string {
+	return filepath.Join(homeDir, ".claude", ".databricks-claude.json")
+}
+
+// readPersistentConfig reads the persistent config file. Returns an empty map
+// if the file does not exist.
+func readPersistentConfig(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]interface{}{}, nil
+		}
+		return nil, err
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// writePersistentConfig atomically writes the persistent config file.
+func writePersistentConfig(path string, cfg map[string]interface{}) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }
 
 // deriveLogsTable derives the OTEL logs table name from the metrics table name.

--- a/main_test.go
+++ b/main_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -599,5 +601,106 @@ func TestHandlePrintEnv_OTELFields(t *testing.T) {
 		if !strings.Contains(out, c) {
 			t.Errorf("expected output to contain %q, got:\n%s", c, out)
 		}
+	}
+}
+
+// --- Persistent config tests ---
+
+func TestReadPersistentConfig_MissingFile(t *testing.T) {
+	cfg, err := readPersistentConfig(filepath.Join(t.TempDir(), "nonexistent.json"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg) != 0 {
+		t.Errorf("expected empty map, got %v", cfg)
+	}
+}
+
+func TestReadPersistentConfig_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".databricks-claude.json")
+	data := []byte(`{"profile":"my-workspace"}`)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := readPersistentConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg["profile"] != "my-workspace" {
+		t.Errorf("expected profile=%q, got %v", "my-workspace", cfg["profile"])
+	}
+}
+
+func TestReadPersistentConfig_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".databricks-claude.json")
+	if err := os.WriteFile(path, []byte(`{bad json`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := readPersistentConfig(path)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestWritePersistentConfig_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", ".databricks-claude.json")
+
+	cfg := map[string]interface{}{"profile": "test-profile"}
+	if err := writePersistentConfig(path, cfg); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	got, err := readPersistentConfig(path)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if got["profile"] != "test-profile" {
+		t.Errorf("expected profile=%q, got %v", "test-profile", got["profile"])
+	}
+
+	// Verify the file is valid JSON with indentation.
+	raw, _ := os.ReadFile(path)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("file is not valid JSON: %v", err)
+	}
+	if !strings.Contains(string(raw), "\n") {
+		t.Error("expected indented JSON output")
+	}
+}
+
+func TestWritePersistentConfig_UpdatesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".databricks-claude.json")
+
+	// Write initial config.
+	initial := map[string]interface{}{"profile": "first"}
+	if err := writePersistentConfig(path, initial); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read, update, write.
+	cfg, _ := readPersistentConfig(path)
+	cfg["profile"] = "second"
+	if err := writePersistentConfig(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := readPersistentConfig(path)
+	if got["profile"] != "second" {
+		t.Errorf("expected profile=%q, got %v", "second", got["profile"])
+	}
+}
+
+func TestPersistentConfigPath(t *testing.T) {
+	got := persistentConfigPath("/home/user")
+	want := filepath.Join("/home/user", ".claude", ".databricks-claude.json")
+	if got != want {
+		t.Errorf("persistentConfigPath=%q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `~/.claude/.databricks-claude.json` as a persistent config file that survives the `settings.json` restore cycle
- On first setup with `--profile foo`, the profile is saved; subsequent runs without `--profile` automatically use it
- Updated resolution chain: CLI flag > env var > settings.json > persistent config > DEFAULT

## Changes

- **main.go**: `readPersistentConfig`/`writePersistentConfig` functions, updated profile resolution chain, profile persistence after `FullSetup`
- **main_test.go**: 6 new tests covering read/write/roundtrip/update/path/missing-file/invalid-JSON
- **README.md**: Documented persistent config file and updated resolution order
- **CLAUDE.md**: Added persistent config to architecture and design decisions

## Test plan

- [x] `readPersistentConfig` returns empty map for missing file
- [x] `readPersistentConfig` parses valid JSON
- [x] `readPersistentConfig` errors on invalid JSON
- [x] `writePersistentConfig` roundtrips through read
- [x] `writePersistentConfig` updates existing file
- [x] `persistentConfigPath` returns correct path
- [x] All existing tests still pass

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)