### PR TITLE
feat(pkg/proxy): add WebSocket support and make UCMetricsTable optional

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,8 +1,10 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"io"
 	"log"
 	"net"
@@ -18,13 +20,24 @@ type TokenSource interface {
 }
 
 // Config holds the configuration for the proxy server.
+//
+// WebSocket note: databricks-claude (Claude Code) uses HTTP with SSE for
+// streaming and never issues WebSocket upgrades. databricks-codex (Codex CLI)
+// uses WebSocket for its inference connection. The proxy handles both
+// transparently — WebSocket upgrades are detected per-request and routed
+// through handleWebSocket; plain HTTP falls through to httputil.ReverseProxy.
+// Centralising this here avoids maintaining a forked proxy in databricks-codex.
 type Config struct {
 	InferenceUpstream string
 	OTELUpstream      string
-	UCMetricsTable    string
-	UCLogsTable       string
-	TokenSource       TokenSource
-	Verbose           bool
+	// UCMetricsTable is the Unity Catalog table for OTEL metrics.
+	// Leave empty if the caller does not emit metrics (e.g. databricks-codex,
+	// which has no native metrics support). When empty the
+	// X-Databricks-UC-Table-Name header is omitted for metrics requests.
+	UCMetricsTable string
+	UCLogsTable    string
+	TokenSource    TokenSource
+	Verbose        bool
 }
 
 // RecoveryHandler wraps h with panic recovery, returning 502 on panic.
@@ -40,8 +53,191 @@ func RecoveryHandler(next http.Handler) http.Handler {
 	})
 }
 
+// isWebSocketUpgrade returns true if the request is a WebSocket upgrade.
+//
+// Claude Code never sends WebSocket upgrades (it uses SSE over HTTP). This
+// check exists to support databricks-codex, whose upstream uses WebSocket for
+// inference. The check is passive — non-upgrade requests fall through to the
+// normal httputil.ReverseProxy path with zero overhead.
+func isWebSocketUpgrade(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
+}
+
+// handleWebSocket proxies a WebSocket upgrade request to the upstream,
+// injecting a fresh Bearer token. After a successful 101 response it pipes
+// data bidirectionally between client and upstream until either side closes.
+//
+// Why this exists here: Codex (databricks-codex) connects to its inference
+// endpoint over WebSocket rather than HTTP/SSE. The token injection and
+// bidirectional piping logic is centralised in this shared package so
+// databricks-codex can import it rather than maintaining its own copy.
+func handleWebSocket(w http.ResponseWriter, r *http.Request, upstream *url.URL, config *Config) {
+	token, err := config.TokenSource.Token(r.Context())
+	if err != nil {
+		log.Printf("databricks-claude: ws token fetch error: %v", err)
+		http.Error(w, "token fetch failed", http.StatusBadGateway)
+		return
+	}
+
+	// Build upstream path: prepend upstream base path to request path.
+	basePath := strings.TrimRight(upstream.Path, "/")
+	upstreamPath := basePath + r.URL.Path
+
+	// Determine host:port for dialing.
+	dialHost := upstream.Host
+	useTLS := upstream.Scheme == "https" || upstream.Scheme == "wss"
+	if !strings.Contains(dialHost, ":") {
+		if useTLS {
+			dialHost += ":443"
+		} else {
+			dialHost += ":80"
+		}
+	}
+
+	if config.Verbose {
+		log.Printf("databricks-claude: ws upgrade → %s%s (tls=%v)", upstream.Host, upstreamPath, useTLS)
+	}
+
+	// Dial upstream.
+	var upstreamConn net.Conn
+	if useTLS {
+		upstreamConn, err = tls.Dial("tcp", dialHost, &tls.Config{
+			ServerName: upstream.Hostname(),
+		})
+	} else {
+		upstreamConn, err = net.Dial("tcp", dialHost)
+	}
+	if err != nil {
+		log.Printf("databricks-claude: ws dial failed: %v", err)
+		http.Error(w, "upstream dial failed", http.StatusBadGateway)
+		return
+	}
+	defer upstreamConn.Close()
+
+	// Build the HTTP upgrade request for the upstream.
+	upgradeReq, err := http.NewRequest(r.Method, (&url.URL{
+		Path:     upstreamPath,
+		RawQuery: r.URL.RawQuery,
+	}).RequestURI(), nil)
+	if err != nil {
+		log.Printf("databricks-claude: ws build request failed: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy original headers, then override auth + host.
+	for k, vv := range r.Header {
+		for _, v := range vv {
+			upgradeReq.Header.Add(k, v)
+		}
+	}
+	upgradeReq.Header.Set("Authorization", "Bearer "+token)
+	upgradeReq.Header.Set("x-api-key", token)
+	upgradeReq.Header.Set("x-databricks-use-coding-agent-mode", "true")
+	upgradeReq.Host = upstream.Host
+	upgradeReq.Header.Set("Host", upstream.Host)
+
+	// Send the upgrade request to the upstream.
+	if err := upgradeReq.Write(upstreamConn); err != nil {
+		log.Printf("databricks-claude: ws write upgrade failed: %v", err)
+		http.Error(w, "upstream write failed", http.StatusBadGateway)
+		return
+	}
+
+	// Read the upstream response.
+	br := bufio.NewReader(upstreamConn)
+	upstreamResp, err := http.ReadResponse(br, upgradeReq)
+	if err != nil {
+		log.Printf("databricks-claude: ws read response failed: %v", err)
+		http.Error(w, "upstream response failed", http.StatusBadGateway)
+		return
+	}
+
+	// If the upstream did not switch protocols, forward the error to the client.
+	if upstreamResp.StatusCode != http.StatusSwitchingProtocols {
+		body, _ := io.ReadAll(upstreamResp.Body)
+		upstreamResp.Body.Close()
+		log.Printf("databricks-claude: ws upgrade rejected: %d %s", upstreamResp.StatusCode, string(body))
+		w.WriteHeader(upstreamResp.StatusCode)
+		w.Write(body) //nolint:errcheck
+		return
+	}
+
+	// Hijack the client connection.
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		log.Printf("databricks-claude: ResponseWriter does not support hijacking")
+		http.Error(w, "hijack not supported", http.StatusInternalServerError)
+		return
+	}
+	clientConn, clientBuf, err := hijacker.Hijack()
+	if err != nil {
+		log.Printf("databricks-claude: ws hijack failed: %v", err)
+		return
+	}
+	defer clientConn.Close()
+
+	// Forward the 101 Switching Protocols response to the client.
+	if err := upstreamResp.Write(clientConn); err != nil {
+		log.Printf("databricks-claude: ws write 101 to client failed: %v", err)
+		return
+	}
+
+	if config.Verbose {
+		log.Printf("databricks-claude: ws connected, piping data")
+	}
+
+	// Bidirectional pipe. When either direction finishes, close both.
+	done := make(chan struct{}, 2)
+
+	// Client → Upstream
+	go func() {
+		defer func() { done <- struct{}{} }()
+		// Flush any buffered data from the client's bufio reader first.
+		if clientBuf != nil && clientBuf.Reader.Buffered() > 0 {
+			buffered := make([]byte, clientBuf.Reader.Buffered())
+			n, _ := clientBuf.Read(buffered)
+			if n > 0 {
+				upstreamConn.Write(buffered[:n]) //nolint:errcheck
+			}
+		}
+		io.Copy(upstreamConn, clientConn) //nolint:errcheck
+	}()
+
+	// Upstream → Client
+	go func() {
+		defer func() { done <- struct{}{} }()
+		// Flush any buffered data from the upstream's bufio reader first.
+		if br.Buffered() > 0 {
+			buffered := make([]byte, br.Buffered())
+			n, _ := br.Read(buffered)
+			if n > 0 {
+				clientConn.Write(buffered[:n]) //nolint:errcheck
+			}
+		}
+		io.Copy(clientConn, upstreamConn) //nolint:errcheck
+	}()
+
+	// Wait for one direction to finish, then close both.
+	<-done
+
+	if config.Verbose {
+		log.Printf("databricks-claude: ws connection closed")
+	}
+}
+
 // NewServer returns an http.Handler that routes requests to the
 // inference upstream (default) and the OTEL upstream (/otel/).
+//
+// Inference route behaviour:
+//   - WebSocket upgrade requests (used by databricks-codex / Codex CLI) are
+//     handled via handleWebSocket with bidirectional piping and fresh token injection.
+//   - All other requests (used by databricks-claude / Claude Code, which speaks
+//     HTTP + SSE) are handled by httputil.ReverseProxy.
+//
+// OTEL route (/otel/):
+//   - /v1/logs paths → UCLogsTable header
+//   - all other paths → UCMetricsTable header (omitted if UCMetricsTable is empty)
 func NewServer(config *Config) http.Handler {
 	mux := http.NewServeMux()
 
@@ -99,6 +295,17 @@ func NewServer(config *Config) http.Handler {
 		FlushInterval: -1,
 	}
 
+	// Wrap inference proxy with WebSocket upgrade detection.
+	// Claude Code never sends WebSocket upgrades; this branch exists for
+	// databricks-codex (Codex CLI), which uses WebSocket for inference.
+	inferenceHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isWebSocketUpgrade(r) {
+			handleWebSocket(w, r, inferenceUpstream, config)
+			return
+		}
+		inferenceProxy.ServeHTTP(w, r)
+	})
+
 	// OTEL proxy — /otel/ route
 	otelProxy := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
@@ -109,12 +316,16 @@ func NewServer(config *Config) http.Handler {
 			req.Header.Set("Authorization", "Bearer "+token)
 			req.Header.Set("x-api-key", token)
 
-			// Pick the correct UC table based on whether this is a logs or metrics request.
-			ucTable := config.UCMetricsTable
-			if strings.Contains(req.URL.Path, "/v1/logs") {
-				ucTable = config.UCLogsTable
+			// Pick the correct UC table based on whether this is a logs or metrics
+			// request. UCMetricsTable may be empty (e.g. databricks-codex has no
+			// native metrics); in that case the header is omitted for metrics paths.
+			ucTable := config.UCLogsTable
+			if !strings.Contains(req.URL.Path, "/v1/logs") {
+				ucTable = config.UCMetricsTable
 			}
-			req.Header.Set("X-Databricks-UC-Table-Name", ucTable)
+			if ucTable != "" {
+				req.Header.Set("X-Databricks-UC-Table-Name", ucTable)
+			}
 
 			// Strip the /otel prefix and prepend the upstream base path.
 			stripped := strings.TrimPrefix(req.URL.Path, "/otel")
@@ -151,7 +362,7 @@ func NewServer(config *Config) http.Handler {
 	}
 
 	mux.Handle("/otel/", RecoveryHandler(otelProxy))
-	mux.Handle("/", RecoveryHandler(inferenceProxy))
+	mux.Handle("/", RecoveryHandler(inferenceHandler))
 
 	return mux
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -360,6 +360,138 @@ func TestProxy_OTELTableName_Logs(t *testing.T) {
 	}
 }
 
+// TestProxy_OTELTableName_MetricsEmpty verifies that when UCMetricsTable is
+// empty (e.g. databricks-codex which has no native metrics), the
+// X-Databricks-UC-Table-Name header is omitted for metrics requests.
+func TestProxy_OTELTableName_MetricsEmpty(t *testing.T) {
+	var gotTable string
+	var tableHeaderPresent bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, tableHeaderPresent = r.Header["X-Databricks-Uc-Table-Name"]
+		gotTable = r.Header.Get("X-Databricks-UC-Table-Name")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCMetricsTable:    "", // empty — caller does not emit metrics
+		UCLogsTable:       "main.telemetry.codex_otel_logs",
+		TokenSource:       warmToken("tok"),
+	}
+	handler := NewServer(cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/otel/v1/metrics", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if tableHeaderPresent || gotTable != "" {
+		t.Errorf("expected X-Databricks-UC-Table-Name to be absent when UCMetricsTable is empty, got %q", gotTable)
+	}
+}
+
+// TestProxy_WebSocket_IsUpgradeDetected verifies that isWebSocketUpgrade
+// correctly identifies WebSocket upgrade requests.
+func TestProxy_WebSocket_IsUpgradeDetected(t *testing.T) {
+	tests := []struct {
+		name    string
+		upgrade string
+		want    bool
+	}{
+		{"websocket lowercase", "websocket", true},
+		{"WebSocket mixed case", "WebSocket", true},
+		{"WEBSOCKET uppercase", "WEBSOCKET", true},
+		{"empty", "", false},
+		{"http2", "h2c", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.upgrade != "" {
+				r.Header.Set("Upgrade", tc.upgrade)
+			}
+			if got := isWebSocketUpgrade(r); got != tc.want {
+				t.Errorf("isWebSocketUpgrade(%q) = %v, want %v", tc.upgrade, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProxy_WebSocket_UpgradeRejectedByUpstream verifies that when the upstream
+// rejects the WebSocket upgrade (non-101), the status is forwarded to the client.
+// This covers the codex inference path — Codex uses WebSocket; Claude uses HTTP/SSE.
+func TestProxy_WebSocket_UpgradeRejectedByUpstream(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate upstream rejecting the upgrade (e.g. auth failure).
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCLogsTable:       "main.t.l",
+		TokenSource:       warmToken("tok"),
+	}
+
+	l, err := Start(NewServer(cfg))
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer l.Close()
+
+	// Send a WebSocket upgrade request through the running proxy.
+	req, _ := http.NewRequest(http.MethodGet, "http://"+l.Addr().String()+"/v1/ws", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	req.Header.Set("Sec-WebSocket-Version", "13")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("got status %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+// TestProxy_WebSocket_PlainHTTPNotAffected verifies that plain HTTP requests
+// (no Upgrade header) are still routed through the normal httputil.ReverseProxy
+// path after the WebSocket detection wrapper was added. This is the
+// databricks-claude (Claude Code) path — it never sends WebSocket upgrades.
+func TestProxy_WebSocket_PlainHTTPNotAffected(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCLogsTable:       "main.t.l",
+		TokenSource:       warmToken("plain-http-token"),
+	}
+	handler := NewServer(cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	// No Upgrade header — this is a plain HTTP request (Claude Code path).
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if gotAuth != "Bearer plain-http-token" {
+		t.Errorf("got Authorization %q, want %q", gotAuth, "Bearer plain-http-token")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("got status %d, want 200", rec.Code)
+	}
+}
+
 // Ensure Start works correctly and listeners can be used.
 func TestProxy_Start(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Closes #19.

Centralises the WebSocket inference proxy from `databricks-codex` into `pkg/proxy` so codex can import the shared package rather than maintaining a forked copy.

• *Claude Code path (HTTP + SSE)* — `isWebSocketUpgrade` check is passive, fires on the `Upgrade` header, falls through to `httputil.ReverseProxy` with zero overhead. Behaviour unchanged.
• *Codex path (WebSocket)* — `handleWebSocket` injects a fresh Bearer token, dials upstream over raw TCP/TLS, performs the HTTP upgrade handshake, then bidirectionally pipes frames until either side closes.
• `UCMetricsTable` is now optional — leave empty (e.g. in databricks-codex, which has no native metrics) and `X-Databricks-UC-Table-Name` is omitted for metrics-path OTEL requests.
• All code documented explaining *why* WebSocket lives here and *why* Claude never hits that branch.

## New tests

• `TestProxy_OTELTableName_MetricsEmpty` — header absent when UCMetricsTable is empty
• `TestProxy_WebSocket_IsUpgradeDetected` — case-insensitive Upgrade header detection (5 subtests)
• `TestProxy_WebSocket_UpgradeRejectedByUpstream` — non-101 upstream response forwarded to client
• `TestProxy_WebSocket_PlainHTTPNotAffected` — plain HTTP still routes through ReverseProxy (Claude Code path)

## Test plan

- [x] All 16 tests pass (`go test ./pkg/proxy/... -v`)
- [x] `go vet ./...` clean
- [ ] After merge: tag v0.2.0, then open databricks-codex#5 to drop local pkg/ copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)