### PR TITLE
feat(pkg/authcheck): add shared auth detection, adopt in claude main

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
 )
 
 // Version is set at build time via -ldflags.
@@ -102,6 +104,11 @@ func main() {
 	}
 	if resolvedProfile == "" {
 		resolvedProfile = "DEFAULT"
+	}
+
+	// --- Ensure the user is authenticated before proceeding ---
+	if err := authcheck.EnsureAuthenticated(resolvedProfile); err != nil {
+		log.Fatalf("databricks-claude: auth failed: %v", err)
 	}
 
 	// Extract upstream values from settings.json.

--- a/pkg/authcheck/authcheck.go
+++ b/pkg/authcheck/authcheck.go
@@ -1,0 +1,48 @@
+package authcheck
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Overridable for testing.
+var execCommand = exec.Command
+var execCommandContext = exec.CommandContext
+
+// IsAuthenticated returns true if a valid token can be fetched for the given
+// Databricks profile without triggering an interactive login.
+func IsAuthenticated(profile string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := execCommandContext(ctx, "databricks", "auth", "token", "--profile", profile).Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), "access_token")
+}
+
+// EnsureAuthenticated verifies the user has a valid token for the profile.
+// If not authenticated, it runs "databricks auth login --profile <profile>"
+// interactively (attaches stdin/stdout/stderr so the browser OAuth flow works).
+// Returns nil if authentication succeeds, error if it fails even after login.
+func EnsureAuthenticated(profile string) error {
+	if IsAuthenticated(profile) {
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "databricks: not authenticated for profile %q, opening browser login...\n", profile)
+	cmd := execCommand("databricks", "auth", "login", "--profile", profile)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("databricks auth login failed: %w", err)
+	}
+	if !IsAuthenticated(profile) {
+		return fmt.Errorf("still not authenticated for profile %q after login attempt", profile)
+	}
+	return nil
+}

--- a/pkg/authcheck/authcheck_test.go
+++ b/pkg/authcheck/authcheck_test.go
@@ -1,0 +1,116 @@
+package authcheck
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+)
+
+// fakeCommandContext returns a *exec.Cmd that does nothing successfully
+// and whose Output() returns the given data.
+func fakeCommandContext(output string, fail bool) func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if fail {
+			return exec.CommandContext(ctx, "false")
+		}
+		return exec.CommandContext(ctx, "echo", output)
+	}
+}
+
+func fakeCommand(output string, fail bool) func(name string, args ...string) *exec.Cmd {
+	return func(name string, args ...string) *exec.Cmd {
+		if fail {
+			return exec.Command("false")
+		}
+		return exec.Command("echo", output)
+	}
+}
+
+func TestIsAuthenticated_Success(t *testing.T) {
+	origCtx := execCommandContext
+	defer func() { execCommandContext = origCtx }()
+
+	execCommandContext = fakeCommandContext(`{"access_token":"dapi-xxx","token_type":"Bearer"}`, false)
+
+	if !IsAuthenticated("DEFAULT") {
+		t.Error("expected IsAuthenticated to return true when access_token is present")
+	}
+}
+
+func TestIsAuthenticated_NoToken(t *testing.T) {
+	origCtx := execCommandContext
+	defer func() { execCommandContext = origCtx }()
+
+	execCommandContext = fakeCommandContext(`{"error":"no token"}`, false)
+
+	if IsAuthenticated("DEFAULT") {
+		t.Error("expected IsAuthenticated to return false when access_token is absent")
+	}
+}
+
+func TestIsAuthenticated_CommandFails(t *testing.T) {
+	origCtx := execCommandContext
+	defer func() { execCommandContext = origCtx }()
+
+	execCommandContext = fakeCommandContext("", true)
+
+	if IsAuthenticated("DEFAULT") {
+		t.Error("expected IsAuthenticated to return false when command fails")
+	}
+}
+
+func TestEnsureAuthenticated_AlreadyAuthed(t *testing.T) {
+	origCtx := execCommandContext
+	defer func() { execCommandContext = origCtx }()
+
+	execCommandContext = fakeCommandContext(`{"access_token":"dapi-xxx"}`, false)
+
+	if err := EnsureAuthenticated("DEFAULT"); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestEnsureAuthenticated_LoginFails(t *testing.T) {
+	origCtx := execCommandContext
+	origCmd := execCommand
+	defer func() {
+		execCommandContext = origCtx
+		execCommand = origCmd
+	}()
+
+	// IsAuthenticated returns false
+	execCommandContext = fakeCommandContext("", true)
+	// login command fails
+	execCommand = fakeCommand("", true)
+
+	err := EnsureAuthenticated("DEFAULT")
+	if err == nil {
+		t.Error("expected error when login fails")
+	}
+}
+
+func TestEnsureAuthenticated_LoginSucceeds(t *testing.T) {
+	origCtx := execCommandContext
+	origCmd := execCommand
+	defer func() {
+		execCommandContext = origCtx
+		execCommand = origCmd
+	}()
+
+	callCount := 0
+	// First call: not authenticated. Second call (after login): authenticated.
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		callCount++
+		if callCount == 1 {
+			return exec.CommandContext(ctx, "false")
+		}
+		return exec.CommandContext(ctx, "echo", fmt.Sprintf(`{"access_token":"dapi-xxx"}`))
+	}
+	// login succeeds
+	execCommand = fakeCommand("login ok", false)
+
+	if err := EnsureAuthenticated("DEFAULT"); err != nil {
+		t.Errorf("expected no error after successful login, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #21. Adds pkg/authcheck with IsAuthenticated/EnsureAuthenticated. Updates main.go to call EnsureAuthenticated at startup. pkg/authcheck will be importable by databricks-codex and databricks-cursor via v0.3.0.