### PR TITLE
security: sanitize sensitive values from proxy log output

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -157,7 +157,7 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, upstream *url.URL, 
 	if upstreamResp.StatusCode != http.StatusSwitchingProtocols {
 		body, _ := io.ReadAll(upstreamResp.Body)
 		upstreamResp.Body.Close()
-		log.Printf("databricks-claude: ws upgrade rejected: %d %s", upstreamResp.StatusCode, string(body))
+		log.Printf("databricks-claude: ws upgrade rejected: %d %s", upstreamResp.StatusCode, sanitizeLogOutput(string(body)))
 		w.WriteHeader(upstreamResp.StatusCode)
 		w.Write(body) //nolint:errcheck
 		return
@@ -285,7 +285,7 @@ func NewServer(config *Config) http.Handler {
 					if len(snippet) > 500 {
 						snippet = snippet[:500] + "..."
 					}
-					log.Printf("databricks-claude: upstream error %d: %s", resp.StatusCode, snippet)
+					log.Printf("databricks-claude: upstream error %d: %s", resp.StatusCode, sanitizeLogOutput(snippet))
 					// Put the body back so the caller still gets it
 					resp.Body = io.NopCloser(bytes.NewReader(body))
 				}
@@ -349,7 +349,7 @@ func NewServer(config *Config) http.Handler {
 						snippet = snippet[:500] + "..."
 					}
 					if resp.StatusCode >= 400 {
-						log.Printf("databricks-claude: otel upstream error %d: %s", resp.StatusCode, snippet)
+						log.Printf("databricks-claude: otel upstream error %d: %s", resp.StatusCode, sanitizeLogOutput(snippet))
 					} else {
 						log.Printf("databricks-claude: otel ← %d (%d bytes)", resp.StatusCode, len(body))
 					}

--- a/pkg/proxy/sanitize.go
+++ b/pkg/proxy/sanitize.go
@@ -1,0 +1,18 @@
+package proxy
+
+import "regexp"
+
+var sensitivePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`Bearer [^\s"]+`),
+	regexp.MustCompile(`dapi-[a-zA-Z0-9]+`),
+	regexp.MustCompile(`(?i)x-api-key:\s*[^\s"]+`),
+}
+
+// sanitizeLogOutput redacts sensitive values (Bearer tokens, PATs, API keys)
+// from strings before they are written to logs.
+func sanitizeLogOutput(s string) string {
+	for _, re := range sensitivePatterns {
+		s = re.ReplaceAllString(s, "[REDACTED]")
+	}
+	return s
+}

--- a/pkg/proxy/sanitize_test.go
+++ b/pkg/proxy/sanitize_test.go
@@ -1,0 +1,51 @@
+package proxy
+
+import "testing"
+
+func TestSanitizeLogOutput(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "bearer token in body",
+			input: `{"Authorization": "Bearer dapi1234567890abcdef"}`,
+			want:  `{"Authorization": "[REDACTED]"}`,
+		},
+		{
+			name:  "dapi PAT token",
+			input: `token was dapi-abc123XYZ in the request`,
+			want:  `token was [REDACTED] in the request`,
+		},
+		{
+			name:  "x-api-key header case insensitive",
+			input: `X-Api-Key: secret-key-value`,
+			want:  `[REDACTED]`,
+		},
+		{
+			name:  "x-api-key lowercase",
+			input: `x-api-key: another-secret`,
+			want:  `[REDACTED]`,
+		},
+		{
+			name:  "safe string unchanged",
+			input: `{"status": "ok", "code": 200}`,
+			want:  `{"status": "ok", "code": 200}`,
+		},
+		{
+			name:  "multiple sensitive values",
+			input: `Bearer tok123 and dapi-xyz456`,
+			want:  `[REDACTED] and [REDACTED]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeLogOutput(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeLogOutput(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements #23. Adds sanitizeLogOutput() to pkg/proxy and applies it to all body/error log calls.

Closes #23