### PR TITLE
security: add startup security checks for root and permissive umask

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
+	"github.com/IceRhymers/databricks-claude/pkg/proxy"
 )
 
 // Version is set at build time via -ldflags.
@@ -109,6 +110,11 @@ func main() {
 	// --- Ensure the user is authenticated before proceeding ---
 	if err := authcheck.EnsureAuthenticated(resolvedProfile); err != nil {
 		log.Fatalf("databricks-claude: auth failed: %v", err)
+	}
+
+	// --- Startup security checks ---
+	for _, w := range proxy.SecurityChecks() {
+		fmt.Fprintln(os.Stderr, w)
 	}
 
 	// Extract upstream values from settings.json.

--- a/pkg/proxy/checks.go
+++ b/pkg/proxy/checks.go
@@ -1,0 +1,29 @@
+package proxy
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// getuid is overridable in tests.
+var getuid = os.Getuid
+
+// SecurityChecks returns a list of human-readable warnings for risky startup
+// conditions. Returns nil when no issues are detected.
+func SecurityChecks() []string {
+	var warnings []string
+
+	if getuid() == 0 {
+		warnings = append(warnings, "WARNING: running as root is not recommended for proxy operation")
+	}
+
+	// Check if umask allows group or other write
+	old := syscall.Umask(0)
+	syscall.Umask(old)
+	if old&0o022 != 0o022 {
+		warnings = append(warnings, fmt.Sprintf("WARNING: umask %04o allows group/other write — config files may be world-writable", old))
+	}
+
+	return warnings
+}

--- a/pkg/proxy/checks_test.go
+++ b/pkg/proxy/checks_test.go
@@ -1,0 +1,38 @@
+package proxy
+
+import "testing"
+
+func TestSecurityChecks_Root(t *testing.T) {
+	orig := getuid
+	t.Cleanup(func() { getuid = orig })
+
+	getuid = func() int { return 0 }
+
+	warnings := SecurityChecks()
+
+	found := false
+	for _, w := range warnings {
+		if w == "WARNING: running as root is not recommended for proxy operation" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected root warning, got %v", warnings)
+	}
+}
+
+func TestSecurityChecks_NonRoot(t *testing.T) {
+	orig := getuid
+	t.Cleanup(func() { getuid = orig })
+
+	getuid = func() int { return 1000 }
+
+	warnings := SecurityChecks()
+
+	for _, w := range warnings {
+		if w == "WARNING: running as root is not recommended for proxy operation" {
+			t.Errorf("unexpected root warning for uid 1000, got %v", warnings)
+		}
+	}
+}


### PR DESCRIPTION
Implements #25.

Adds `SecurityChecks()` to `pkg/proxy` that warns on stderr when:
• Running as root
• Umask allows group/other write (config files may be world-writable)

Integrated into `main.go` after auth verification. Includes unit tests.