### PR TITLE
feat(proxy): optional API key auth and TLS listener (closes #26, closes #27)

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	// Parse databricks-claude flags, passing everything else through to claude.
 	// Usage: databricks-claude [databricks-claude-flags] [--] [claude-args...]
 	// Unknown flags are forwarded to claude automatically.
-	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, otelMetricsTableSet, otelLogsTable, otelLogsTableSet, upstream, logFile, noOtel, claudeArgs := parseArgs(os.Args[1:])
+	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, otelMetricsTableSet, otelLogsTable, otelLogsTableSet, upstream, logFile, noOtel, proxyAPIKey, tlsCert, tlsKey, claudeArgs := parseArgs(os.Args[1:])
 
 	if showHelp {
 		handleHelp(upstream)
@@ -226,6 +226,11 @@ func main() {
 		os.Exit(0)
 	}
 
+	// --- Validate TLS config ---
+	if err := proxy.ValidateTLSConfig(tlsCert, tlsKey); err != nil {
+		log.Fatalf("databricks-claude: %v", err)
+	}
+
 	// --- Start proxy ---
 	proxyConfig := &ProxyConfig{
 		InferenceUpstream: inferenceUpstream,
@@ -234,13 +239,24 @@ func main() {
 		UCLogsTable:       ucLogsTable,
 		TokenProvider:     tp,
 		Verbose:           verbose,
+		APIKey:            proxyAPIKey,
+		TLSCertFile:       tlsCert,
+		TLSKeyFile:        tlsKey,
+	}
+	if proxyAPIKey != "" {
+		fmt.Fprintln(os.Stderr, "databricks-claude: proxy API key authentication enabled")
 	}
 	handler := NewProxyServer(proxyConfig)
-	listener, err := StartProxy(handler)
+	listener, err := StartProxy(proxyConfig, handler)
 	if err != nil {
 		log.Fatalf("databricks-claude: failed to start proxy: %v", err)
 	}
-	proxyURL := "http://" + listener.Addr().String()
+	scheme := "http"
+	if tlsCert != "" && tlsKey != "" {
+		scheme = "https"
+		fmt.Fprintln(os.Stderr, "databricks-claude: TLS enabled")
+	}
+	proxyURL := scheme + "://" + listener.Addr().String()
 
 	// --- Patch settings.json ---
 	sm := NewSettingsManager(settingsPath)
@@ -325,10 +341,10 @@ func envBlock(doc map[string]interface{}) map[string]interface{} {
 }
 
 // parseArgs separates databricks-claude flags from claude flags.
-// databricks-claude owns: --profile, --verbose/-v, --log-file, --version, --otel, --otel-metrics-table, --otel-logs-table, --no-otel.
+// databricks-claude owns: --profile, --verbose/-v, --log-file, --version, --otel, --otel-metrics-table, --otel-logs-table, --no-otel, --proxy-api-key, --tls-cert, --tls-key.
 // Everything else (including unknown flags like --debug) passes through to claude.
 // An explicit "--" separator is supported but not required.
-func parseArgs(args []string) (profile string, verbose bool, version bool, showHelp bool, printEnv bool, otel bool, otelMetricsTable string, otelMetricsTableSet bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, noOtel bool, claudeArgs []string) {
+func parseArgs(args []string) (profile string, verbose bool, version bool, showHelp bool, printEnv bool, otel bool, otelMetricsTable string, otelMetricsTableSet bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, noOtel bool, proxyAPIKey string, tlsCert string, tlsKey string, claudeArgs []string) {
 	otelMetricsTable = "main.claude_telemetry.claude_otel_metrics" // default
 
 	knownFlags := map[string]bool{
@@ -343,6 +359,9 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 		"--otel-logs-table":    true,
 		"--upstream":           true,
 		"--log-file":           true,
+		"--proxy-api-key":     true,
+		"--tls-cert":          true,
+		"--tls-key":           true,
 	}
 
 	i := 0
@@ -430,6 +449,27 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 					otel = true
 				case "--no-otel":
 					noOtel = true
+				case "--proxy-api-key":
+					if value != "" {
+						proxyAPIKey = value
+					} else if i+1 < len(args) {
+						i++
+						proxyAPIKey = args[i]
+					}
+				case "--tls-cert":
+					if value != "" {
+						tlsCert = value
+					} else if i+1 < len(args) {
+						i++
+						tlsCert = args[i]
+					}
+				case "--tls-key":
+					if value != "" {
+						tlsKey = value
+					} else if i+1 < len(args) {
+						i++
+						tlsKey = args[i]
+					}
 				}
 				i++
 				continue
@@ -463,6 +503,9 @@ Databricks-Claude Flags:
   --no-otel                    Clear persisted OTEL keys and disable OTEL for future sessions
   --otel-metrics-table string  Unity Catalog table for OTEL metrics
   --otel-logs-table string     Unity Catalog table for OTEL logs (derived from metrics table if omitted)
+  --proxy-api-key string       Require Bearer token auth on all proxy requests
+  --tls-cert string            Path to TLS certificate file (requires --tls-key)
+  --tls-key string             Path to TLS private key file (requires --tls-cert)
   --version                    Print version and exit
   --help, -h                   Show this help message
 

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,7 @@ import (
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, noOtel, claudeArgs := parseArgs([]string{"--help"})
+	profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, noOtel, _, _, _, claudeArgs := parseArgs([]string{"--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true for --help")
 	}
@@ -25,77 +25,77 @@ func TestParseArgs_HelpLong(t *testing.T) {
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, _, showHelp, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
+	_, _, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
 	if !showHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, _, printEnv, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
+	_, _, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
 	if !printEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, _, version, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
+	_, _, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
 	if !version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
+	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
 	if !verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
+	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
 	if !verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
+	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	profile, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "foo"})
+	profile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "foo"})
 	if profile != "foo" {
 		t.Errorf("expected profile=%q, got %q", "foo", profile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, upstream, _, _, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
+	_, _, _, _, _, _, _, _, _, _, upstream, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
 	if upstream != "/path/to/claude" {
 		t.Errorf("expected upstream=%q, got %q", "/path/to/claude", upstream)
 	}
 }
 
 func TestParseArgs_Otel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
 }
 
 func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
 	if !metricsTableSet {
 		t.Error("expected metricsTableSet=true when --otel-metrics-table is passed")
 	}
@@ -105,7 +105,7 @@ func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
 }
 
 func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if metricsTableSet {
 		t.Error("expected metricsTableSet=false when --otel-metrics-table is not passed")
 	}
@@ -115,7 +115,7 @@ func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
 	if !metricsTableSet {
 		t.Error("expected metricsTableSet=true for --otel-metrics-table=value")
 	}
@@ -125,7 +125,7 @@ func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
 	if !logsTableSet {
 		t.Error("expected logsTableSet=true when --otel-logs-table is passed")
 	}
@@ -135,7 +135,7 @@ func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if logsTableSet {
 		t.Error("expected logsTableSet=false when --otel-logs-table is not passed")
 	}
@@ -145,7 +145,7 @@ func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _ := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
 	if !logsTableSet {
 		t.Error("expected logsTableSet=true for --otel-logs-table=value")
 	}
@@ -155,7 +155,7 @@ func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
 }
 
 func TestParseArgs_BothOtelTables(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsSet, logsTable, logsSet, _, _, _, _ := parseArgs([]string{
+	_, _, _, _, _, _, metricsTable, metricsSet, logsTable, logsSet, _, _, _, _, _, _, _ := parseArgs([]string{
 		"--otel-metrics-table", "cat.schema.metrics",
 		"--otel-logs-table", "cat.schema.logs",
 	})
@@ -171,14 +171,14 @@ func TestParseArgs_BothOtelTables(t *testing.T) {
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--unknown"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--unknown"})
 	if len(claudeArgs) != 1 || claudeArgs[0] != "--unknown" {
 		t.Errorf("expected claudeArgs=[\"--unknown\"], got %v", claudeArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, _, _, _, upstream, logFile, noOtel, claudeArgs := parseArgs([]string{})
+	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, _, _, _, upstream, logFile, noOtel, _, _, _, claudeArgs := parseArgs([]string{})
 	if profile != "" {
 		t.Errorf("expected empty profile, got %q", profile)
 	}
@@ -201,7 +201,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	profile, verbose, _, showHelp, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
+	profile, verbose, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -214,7 +214,7 @@ func TestParseArgs_Mixed(t *testing.T) {
 }
 
 func TestParseArgs_NoOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, claudeArgs := parseArgs([]string{"--no-otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, claudeArgs := parseArgs([]string{"--no-otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true for --no-otel")
 	}
@@ -227,7 +227,7 @@ func TestParseArgs_NoOtel(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelAndOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _ := parseArgs([]string{"--no-otel", "--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _ := parseArgs([]string{"--no-otel", "--otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true")
 	}
@@ -237,7 +237,7 @@ func TestParseArgs_NoOtelAndOtel(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, noOtel, claudeArgs := parseArgs([]string{"--no-otel", "somearg"})
+	_, _, _, _, _, _, _, _, _, _, _, _, noOtel, _, _, _, claudeArgs := parseArgs([]string{"--no-otel", "somearg"})
 	if !noOtel {
 		t.Error("expected noOtel=true")
 	}
@@ -247,7 +247,7 @@ func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
 }
 
 func TestParseArgs_OtelUnaffectedByNoOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
@@ -354,7 +354,7 @@ func TestParseArgs_Table(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, _, claudeArgs := parseArgs(tc.args)
+			profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, _, _, _, _, claudeArgs := parseArgs(tc.args)
 
 			if profile != tc.want.profile {
 				t.Errorf("profile: got %q, want %q", profile, tc.want.profile)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -38,6 +39,12 @@ type Config struct {
 	UCLogsTable    string
 	TokenSource    TokenSource
 	Verbose        bool
+	// APIKey, when non-empty, requires all incoming requests to present
+	// Authorization: Bearer <APIKey>. Leave empty to disable auth.
+	APIKey string
+	// TLSCertFile and TLSKeyFile enable TLS on the listener when both are set.
+	TLSCertFile string
+	TLSKeyFile  string
 }
 
 // RecoveryHandler wraps h with panic recovery, returning 502 on panic.
@@ -226,6 +233,24 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, upstream *url.URL, 
 	}
 }
 
+// requireAPIKey returns middleware that validates Authorization: Bearer <key>
+// on every incoming request. If key is empty, authentication is disabled and
+// requests pass through unchanged.
+// APIKey check applies to all connections including WebSocket upgrades (used by databricks-codex)
+func requireAPIKey(next http.Handler, key string) http.Handler {
+	if key == "" {
+		return next // auth disabled
+	}
+	expected := "Bearer " + key
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != expected {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // NewServer returns an http.Handler that routes requests to the
 // inference upstream (default) and the OTEL upstream (/otel/).
 //
@@ -364,16 +389,48 @@ func NewServer(config *Config) http.Handler {
 	mux.Handle("/otel/", RecoveryHandler(otelProxy))
 	mux.Handle("/", RecoveryHandler(inferenceHandler))
 
-	return mux
+	// APIKey check applies to all connections including WebSocket upgrades (used by databricks-codex)
+	return requireAPIKey(mux, config.APIKey)
+}
+
+// ValidateTLSConfig returns an error if the TLS configuration is incomplete
+// (one of cert/key set but not the other). Both empty is valid (TLS disabled).
+func ValidateTLSConfig(certFile, keyFile string) error {
+	if (certFile == "") != (keyFile == "") {
+		return fmt.Errorf("both --tls-cert and --tls-key must be provided together")
+	}
+	return nil
 }
 
 // Start binds to 127.0.0.1:0, starts serving, and returns the listener.
 // Callers read l.Addr() to discover the assigned port.
-func Start(handler http.Handler) (net.Listener, error) {
+// When certFile and keyFile are both non-empty, the listener serves TLS.
+func Start(handler http.Handler, certFile, keyFile string) (net.Listener, error) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}
+
+	useTLS := certFile != "" && keyFile != ""
+
+	if useTLS {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			l.Close()
+			return nil, fmt.Errorf("failed to load TLS cert/key: %w", err)
+		}
+		tlsListener := tls.NewListener(l, &tls.Config{
+			Certificates: []tls.Certificate{cert},
+		})
+		go func() {
+			if err := http.Serve(tlsListener, handler); err != nil {
+				log.Printf("databricks-claude: proxy stopped: %v", err)
+			}
+		}()
+		log.Printf("databricks-claude: listening on https://%s", l.Addr().String())
+		return tlsListener, nil
+	}
+
 	go func() {
 		if err := http.Serve(l, handler); err != nil {
 			// http.Serve returns when the listener is closed; that is expected
@@ -381,5 +438,6 @@ func Start(handler http.Handler) (net.Listener, error) {
 			log.Printf("databricks-claude: proxy stopped: %v", err)
 		}
 	}()
+	log.Printf("databricks-claude: listening on http://%s", l.Addr().String())
 	return l, nil
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -283,7 +283,7 @@ func TestProxy_SSEStreaming(t *testing.T) {
 	}
 	handler := NewServer(cfg)
 
-	l, err := Start(handler)
+	l, err := Start(handler, "", "")
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -435,7 +435,7 @@ func TestProxy_WebSocket_UpgradeRejectedByUpstream(t *testing.T) {
 		TokenSource:       warmToken("tok"),
 	}
 
-	l, err := Start(NewServer(cfg))
+	l, err := Start(NewServer(cfg), "", "")
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -497,7 +497,7 @@ func TestProxy_Start(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	l, err := Start(handler)
+	l, err := Start(handler, "", "")
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -511,5 +511,123 @@ func TestProxy_Start(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("got status %d, want 200", resp.StatusCode)
+	}
+}
+
+// --- API Key auth tests ---
+
+// TestProxy_APIKey_CorrectKey verifies that a request with the correct API key
+// is forwarded to the upstream (200).
+func TestProxy_APIKey_CorrectKey(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCLogsTable:       "main.t.l",
+		TokenSource:       warmToken("tok"),
+		APIKey:            "my-secret-key",
+	}
+	handler := NewServer(cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set("Authorization", "Bearer my-secret-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("got status %d, want 200", rec.Code)
+	}
+}
+
+// TestProxy_APIKey_WrongKey verifies that a request with the wrong API key
+// is rejected with 401.
+func TestProxy_APIKey_WrongKey(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream should not be called with wrong key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCLogsTable:       "main.t.l",
+		TokenSource:       warmToken("tok"),
+		APIKey:            "my-secret-key",
+	}
+	handler := NewServer(cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set("Authorization", "Bearer wrong-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("got status %d, want 401", rec.Code)
+	}
+}
+
+// TestProxy_APIKey_NoKeyConfigured verifies that when no API key is configured,
+// requests pass through without auth (200).
+func TestProxy_APIKey_NoKeyConfigured(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCLogsTable:       "main.t.l",
+		TokenSource:       warmToken("tok"),
+		APIKey:            "", // no key — auth disabled
+	}
+	handler := NewServer(cfg)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	// No Authorization header at all.
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("got status %d, want 200", rec.Code)
+	}
+}
+
+// --- TLS config validation tests ---
+
+// TestValidateTLSConfig_CertWithoutKey returns error when only cert is provided.
+func TestValidateTLSConfig_CertWithoutKey(t *testing.T) {
+	err := ValidateTLSConfig("/path/to/cert.pem", "")
+	if err == nil {
+		t.Error("expected error when cert is set but key is empty")
+	}
+}
+
+// TestValidateTLSConfig_KeyWithoutCert returns error when only key is provided.
+func TestValidateTLSConfig_KeyWithoutCert(t *testing.T) {
+	err := ValidateTLSConfig("", "/path/to/key.pem")
+	if err == nil {
+		t.Error("expected error when key is set but cert is empty")
+	}
+}
+
+// TestValidateTLSConfig_BothSet returns no error when both cert and key are provided.
+func TestValidateTLSConfig_BothSet(t *testing.T) {
+	err := ValidateTLSConfig("/path/to/cert.pem", "/path/to/key.pem")
+	if err != nil {
+		t.Errorf("unexpected error when both cert and key are set: %v", err)
+	}
+}
+
+// TestValidateTLSConfig_NeitherSet returns no error when TLS is disabled.
+func TestValidateTLSConfig_NeitherSet(t *testing.T) {
+	err := ValidateTLSConfig("", "")
+	if err != nil {
+		t.Errorf("unexpected error when neither cert nor key is set: %v", err)
 	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -16,6 +16,9 @@ type ProxyConfig struct {
 	UCLogsTable       string
 	TokenProvider     *tokencache.TokenProvider
 	Verbose           bool
+	APIKey            string
+	TLSCertFile       string
+	TLSKeyFile        string
 }
 
 // recoveryHandler wraps h with panic recovery, returning 502 on panic.
@@ -33,11 +36,13 @@ func NewProxyServer(config *ProxyConfig) http.Handler {
 		UCLogsTable:       config.UCLogsTable,
 		TokenSource:       config.TokenProvider,
 		Verbose:           config.Verbose,
+		APIKey:            config.APIKey,
 	})
 }
 
 // StartProxy binds to 127.0.0.1:0, starts serving, and returns the listener.
 // Callers read l.Addr() to discover the assigned port.
-func StartProxy(handler http.Handler) (net.Listener, error) {
-	return proxy.Start(handler)
+// When config.TLSCertFile and config.TLSKeyFile are both set, the listener serves TLS.
+func StartProxy(config *ProxyConfig, handler http.Handler) (net.Listener, error) {
+	return proxy.Start(handler, config.TLSCertFile, config.TLSKeyFile)
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -285,7 +285,7 @@ func TestProxy_SSEStreaming(t *testing.T) {
 	handler := NewProxyServer(cfg)
 
 	// Use a real listener so we can test actual streaming behaviour.
-	l, err := StartProxy(handler)
+	l, err := StartProxy(cfg, handler)
 	if err != nil {
 		t.Fatalf("StartProxy: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Add `--proxy-api-key` flag for optional Bearer token authentication on all incoming proxy requests, including WebSocket upgrades used by databricks-codex
- Add `--tls-cert` and `--tls-key` flags for optional TLS on the proxy listener
- Both features are off by default, preserving existing behavior — zero breaking changes

## Details

*Issue #26 — API Key Auth*
• New `requireAPIKey` middleware wraps the entire mux handler so WebSocket upgrade requests also hit the key check before upgrade
• When `--proxy-api-key` is empty (default), middleware is a no-op passthrough
• When set, requires `Authorization: Bearer <key>` on every request; returns 401 otherwise

*Issue #27 — TLS Listener*
• When both `--tls-cert` and `--tls-key` are provided, `Start()` creates a TLS listener
• Validation rejects partial config (cert without key or vice versa)
• Startup log indicates `https://` vs `http://` scheme

## Test plan

• API key: correct key returns 200
• API key: wrong key returns 401
• API key: no key configured returns 200 (passthrough)
• TLS validation: cert without key returns error
• TLS validation: key without cert returns error
• TLS validation: both set returns no error
• TLS validation: neither set returns no error
• All existing tests pass unchanged (`go test ./...` clean, `go vet ./...` clean)