### PR TITLE
fix: remove env var from profile resolution — state file always wins

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,14 @@ If workspace ID resolution fails, it falls back to `<host>/serving-endpoints/ant
 
 ## Profile Resolution Order
 
-1. `--profile` CLI flag
-2. `DATABRICKS_CONFIG_PROFILE` environment variable
-3. `DATABRICKS_CONFIG_PROFILE` in `~/.claude/settings.json` env block
-4. `profile` from `~/.claude/.databricks-claude.json` (persistent config)
-5. `DEFAULT`
+1. `--profile` CLI flag (writes to state file for future runs)
+2. `profile` from `~/.claude/.databricks-claude.json` (state file)
+3. `DEFAULT`
+
+> **Note:** `DATABRICKS_CONFIG_PROFILE` is intentionally *not* consulted during
+> resolution. Claude's `settings.json` injects env vars into child processes,
+> which would override the user's explicit `--profile` choice persisted in the
+> state file.
 
 ## Persistent Config (`~/.claude/.databricks-claude.json`)
 

--- a/main.go
+++ b/main.go
@@ -89,11 +89,12 @@ func main() {
 
 	env := envBlock(settingsDoc)
 
-	// Resolve profile: CLI flag > env var > persistent config (state file) > DEFAULT
+	// Resolve profile: --profile flag (saved to state file) > state file > "DEFAULT"
+	// The env var DATABRICKS_CONFIG_PROFILE is NOT consulted here because
+	// Claude's settings.json injects env vars into child processes, which
+	// would override the user's explicit --profile choice persisted in the
+	// state file.
 	resolvedProfile := profile
-	if resolvedProfile == "" {
-		resolvedProfile = os.Getenv("DATABRICKS_CONFIG_PROFILE")
-	}
 	if resolvedProfile == "" {
 		pcPath := persistentConfigPath(homeDir)
 		if pc, err := readPersistentConfig(pcPath); err == nil {

--- a/main_test.go
+++ b/main_test.go
@@ -705,20 +705,29 @@ func TestPersistentConfigPath(t *testing.T) {
 	}
 }
 
-// TestProfileResolution_StateFileWinsOverSettingsEnv verifies that when the
-// state file has a profile set AND the settings.json env block has a different
-// DATABRICKS_CONFIG_PROFILE, the state file profile wins (because the
-// settings.json env block is no longer consulted in the resolution chain).
-func TestProfileResolution_StateFileWinsOverSettingsEnv(t *testing.T) {
-	// Simulate settings.json with env block containing a profile.
-	settingsDoc := map[string]interface{}{
-		"env": map[string]interface{}{
-			"DATABRICKS_CONFIG_PROFILE": "settings-profile",
-		},
+// TestProfileResolution_StateFileWins verifies that the state file profile
+// wins over both the settings.json env block AND the process environment
+// variable DATABRICKS_CONFIG_PROFILE. The resolution chain is:
+//
+//	--profile flag (saved to state file) > state file > "DEFAULT"
+func TestProfileResolution_StateFileWins(t *testing.T) {
+	// Helper: run the same resolution chain as main.go.
+	resolve := func(flagProfile string, pcPath string) string {
+		resolvedProfile := flagProfile
+		if resolvedProfile == "" {
+			if pc, err := readPersistentConfig(pcPath); err == nil {
+				if v, ok := pc["profile"].(string); ok && v != "" {
+					resolvedProfile = v
+				}
+			}
+		}
+		if resolvedProfile == "" {
+			resolvedProfile = "DEFAULT"
+		}
+		return resolvedProfile
 	}
-	env := envBlock(settingsDoc)
 
-	// Simulate state file with a different profile.
+	// Common setup: state file with "state-file-profile".
 	dir := t.TempDir()
 	pcPath := filepath.Join(dir, ".databricks-claude.json")
 	stateData := []byte(`{"profile":"state-file-profile"}`)
@@ -726,42 +735,48 @@ func TestProfileResolution_StateFileWinsOverSettingsEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Clear any real env var so it doesn't interfere.
-	t.Setenv("DATABRICKS_CONFIG_PROFILE", "")
-
-	// Run the same resolution chain as main.go (post-fix):
-	// 1. --profile flag (empty)
-	// 2. os.Getenv("DATABRICKS_CONFIG_PROFILE") (empty)
-	// 3. persistent config / state file
-	// 4. "DEFAULT"
-	resolvedProfile := "" // no --profile flag
-
-	if resolvedProfile == "" {
-		resolvedProfile = os.Getenv("DATABRICKS_CONFIG_PROFILE")
-	}
-	// NOTE: the old code had an env["DATABRICKS_CONFIG_PROFILE"] check here
-	// which would have resolved to "settings-profile". That block is removed.
-	if resolvedProfile == "" {
-		if pc, err := readPersistentConfig(pcPath); err == nil {
-			if v, ok := pc["profile"].(string); ok && v != "" {
-				resolvedProfile = v
-			}
+	t.Run("state file wins over settings.json env block", func(t *testing.T) {
+		// Simulate settings.json with env block containing a profile.
+		settingsDoc := map[string]interface{}{
+			"env": map[string]interface{}{
+				"DATABRICKS_CONFIG_PROFILE": "settings-profile",
+			},
 		}
-	}
-	if resolvedProfile == "" {
-		resolvedProfile = "DEFAULT"
-	}
+		env := envBlock(settingsDoc)
 
-	// The settings.json env block value must NOT have been used.
-	if resolvedProfile == "settings-profile" {
-		t.Fatalf("profile resolved to settings.json env value %q; state file should win", resolvedProfile)
-	}
-	if resolvedProfile != "state-file-profile" {
-		t.Fatalf("expected profile=%q, got %q", "state-file-profile", resolvedProfile)
-	}
+		got := resolve("", pcPath)
+		if got != "state-file-profile" {
+			t.Fatalf("expected profile=%q, got %q", "state-file-profile", got)
+		}
 
-	// Confirm the env block still contains the value (it exists, just isn't consulted).
-	if v, ok := env["DATABRICKS_CONFIG_PROFILE"].(string); !ok || v != "settings-profile" {
-		t.Errorf("env block should still contain settings-profile, got %v", env["DATABRICKS_CONFIG_PROFILE"])
-	}
+		// Confirm the env block still contains the value (it exists, just isn't consulted).
+		if v, ok := env["DATABRICKS_CONFIG_PROFILE"].(string); !ok || v != "settings-profile" {
+			t.Errorf("env block should still contain settings-profile, got %v", env["DATABRICKS_CONFIG_PROFILE"])
+		}
+	})
+
+	t.Run("state file wins over process env var", func(t *testing.T) {
+		// Set the process env var to a different profile.
+		t.Setenv("DATABRICKS_CONFIG_PROFILE", "env-var-profile")
+
+		got := resolve("", pcPath)
+		if got != "state-file-profile" {
+			t.Fatalf("expected profile=%q, got %q; process env var should not be consulted", "state-file-profile", got)
+		}
+	})
+
+	t.Run("flag still wins over state file", func(t *testing.T) {
+		got := resolve("flag-profile", pcPath)
+		if got != "flag-profile" {
+			t.Fatalf("expected profile=%q, got %q", "flag-profile", got)
+		}
+	})
+
+	t.Run("falls back to DEFAULT when no state file", func(t *testing.T) {
+		emptyPath := filepath.Join(dir, "nonexistent.json")
+		got := resolve("", emptyPath)
+		if got != "DEFAULT" {
+			t.Fatalf("expected profile=%q, got %q", "DEFAULT", got)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Removes \`DATABRICKS_CONFIG_PROFILE\` env var entirely from the proxy profile resolution chain.

*Before:* \`--profile\` flag → env var → state file → \`"DEFAULT"\`
*After:* \`--profile\` flag → state file → \`"DEFAULT"\`

The env var was a footgun: Claude's \`settings.json\` injects env vars into every child process, so whatever workspace profile Claude is configured for would silently override the proxy's state file — meaning inference requests could be routed to the wrong workspace (e.g. a CLI/data-eng workspace instead of a dedicated inference workspace).

Now the state file is the source of truth for proxy inference. Use \`--profile <name>\` once to write it; all future sessions pick it up from the state file regardless of what's in the environment.

Closes #34

## Test plan

• \`TestProfileResolution_StateFileWins\` covers four cases:
  - State file wins over settings.json env block
  - State file wins over process env var (new)
  - \`--profile\` flag still wins over state file
  - Falls back to \`"DEFAULT"\` when no state file
• All existing tests pass (\`go test ./...\`)