### PR TITLE
Add --model flag and make state path overridable

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 	// Parse databricks-claude flags, passing everything else through to claude.
 	// Usage: databricks-claude [databricks-claude-flags] [--] [claude-args...]
 	// Unknown flags are forwarded to claude automatically.
-	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, otelMetricsTableSet, otelLogsTable, otelLogsTableSet, upstream, logFile, noOtel, proxyAPIKey, tlsCert, tlsKey, model, modelSet, portFlag, claudeArgs := parseArgs(os.Args[1:])
+	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, otelMetricsTableSet, otelLogsTable, otelLogsTableSet, upstream, logFile, noOtel, proxyAPIKey, tlsCert, tlsKey, portFlag, claudeArgs := parseArgs(os.Args[1:])
 
 	if showHelp {
 		handleHelp(upstream)
@@ -217,7 +217,7 @@ func main() {
 		ucLogsTable = deriveLogsTable(ucMetricsTable)
 	}
 
-	// --- Load persistent state and resolve port + model ---
+	// --- Load persistent state and resolve port ---
 	state := loadState()
 
 	port := resolvePort(portFlag, state)
@@ -226,20 +226,6 @@ func main() {
 		if err := saveState(state); err != nil {
 			log.Printf("databricks-claude: warning: failed to save port: %v", err)
 		}
-	}
-
-	// --- Resolve model ---
-	resolvedModel := resolveModel(model, state)
-	if modelSet {
-		state.Model = resolvedModel
-		if err := saveState(state); err != nil {
-			log.Printf("databricks-claude: warning: failed to save model: %v", err)
-		} else {
-			log.Printf("databricks-claude: saved model %q for future sessions", resolvedModel)
-		}
-	}
-	if resolvedModel != "" {
-		log.Printf("databricks-claude: using model: %s", resolvedModel)
 	}
 
 	// Persist profile so future runs don't need --profile.
@@ -254,7 +240,7 @@ func main() {
 
 	// --- Print env and exit if requested ---
 	if printEnv {
-		handlePrintEnv(resolvedProfile, databricksHost, inferenceUpstream, initialToken, resolvedModel, upstream, otel || otelConfigured, ucMetricsTable, ucLogsTable)
+		handlePrintEnv(resolvedProfile, databricksHost, inferenceUpstream, initialToken, upstream, otel || otelConfigured, ucMetricsTable, ucLogsTable)
 		os.Exit(0)
 	}
 
@@ -404,7 +390,7 @@ func envBlock(doc map[string]interface{}) map[string]interface{} {
 // databricks-claude owns: --profile, --verbose/-v, --log-file, --version, --otel, --otel-metrics-table, --otel-logs-table, --no-otel, --proxy-api-key, --tls-cert, --tls-key.
 // Everything else (including unknown flags like --debug) passes through to claude.
 // An explicit "--" separator is supported but not required.
-func parseArgs(args []string) (profile string, verbose bool, version bool, showHelp bool, printEnv bool, otel bool, otelMetricsTable string, otelMetricsTableSet bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, noOtel bool, proxyAPIKey string, tlsCert string, tlsKey string, model string, modelSet bool, portFlag int, claudeArgs []string) {
+func parseArgs(args []string) (profile string, verbose bool, version bool, showHelp bool, printEnv bool, otel bool, otelMetricsTable string, otelMetricsTableSet bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, noOtel bool, proxyAPIKey string, tlsCert string, tlsKey string, portFlag int, claudeArgs []string) {
 	otelMetricsTable = "main.claude_telemetry.claude_otel_metrics" // default
 
 	knownFlags := map[string]bool{
@@ -422,7 +408,6 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 		"--proxy-api-key":     true,
 		"--tls-cert":          true,
 		"--tls-key":           true,
-		"--model":             true,
 		"--port":              true,
 	}
 
@@ -532,15 +517,6 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 						i++
 						tlsKey = args[i]
 					}
-				case "--model":
-					if value != "" {
-						model = value
-						modelSet = true
-					} else if i+1 < len(args) {
-						i++
-						model = args[i]
-						modelSet = true
-					}
 				case "--port":
 					if value != "" {
 						portFlag, _ = strconv.Atoi(value)
@@ -573,7 +549,6 @@ Usage:
 
 Databricks-Claude Flags:
   --profile string      Databricks config profile (saved to ~/.claude/.databricks-claude.json)
-  --model string        Model name (saved for future sessions)
   --upstream string     Override the AI Gateway URL (default: auto-discovered)
   --print-env           Print resolved configuration and exit (token redacted)
   --verbose, -v         Enable debug logging to stderr
@@ -625,7 +600,7 @@ Claude CLI Options:
 }
 
 // handlePrintEnv prints resolved configuration with the token redacted.
-func handlePrintEnv(profile, databricksHost, anthropicBaseURL, token, model, upstreamBinary string, otelEnabled bool, otelMetricsTable, otelLogsTable string) {
+func handlePrintEnv(profile, databricksHost, anthropicBaseURL, token, upstreamBinary string, otelEnabled bool, otelMetricsTable, otelLogsTable string) {
 	// Redact token.
 	redacted := "**** (redacted)"
 	if strings.HasPrefix(token, "dapi-") {
@@ -642,20 +617,14 @@ func handlePrintEnv(profile, databricksHost, anthropicBaseURL, token, model, ups
 		}
 	}
 
-	modelDisplay := model
-	if modelDisplay == "" {
-		modelDisplay = "(default)"
-	}
-
 	fmt.Printf(`databricks-claude configuration:
   Profile:              %s
-  Model:                %s
   DATABRICKS_HOST:      %s
   ANTHROPIC_BASE_URL:   %s
   ANTHROPIC_AUTH_TOKEN: %s
   Upstream binary:      %s
   OTEL enabled:         %v
-`, profile, modelDisplay, databricksHost, anthropicBaseURL, redacted, binaryPath, otelEnabled)
+`, profile, databricksHost, anthropicBaseURL, redacted, binaryPath, otelEnabled)
 
 	if otelEnabled {
 		fmt.Printf(`  OTEL metrics table:   %s

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,7 @@ import (
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--help"})
+	profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, noOtel, _, _, _, _, claudeArgs := parseArgs([]string{"--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true for --help")
 	}
@@ -25,77 +25,77 @@ func TestParseArgs_HelpLong(t *testing.T) {
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
+	_, _, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
 	if !showHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
+	_, _, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
 	if !printEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, _, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
+	_, _, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
 	if !version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
+	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
 	if !verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
+	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
 	if !verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
+	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	profile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "foo"})
+	profile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "foo"})
 	if profile != "foo" {
 		t.Errorf("expected profile=%q, got %q", "foo", profile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
+	_, _, _, _, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
 	if upstream != "/path/to/claude" {
 		t.Errorf("expected upstream=%q, got %q", "/path/to/claude", upstream)
 	}
 }
 
 func TestParseArgs_Otel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
 }
 
 func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
 	if !metricsTableSet {
 		t.Error("expected metricsTableSet=true when --otel-metrics-table is passed")
 	}
@@ -105,7 +105,7 @@ func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
 }
 
 func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if metricsTableSet {
 		t.Error("expected metricsTableSet=false when --otel-metrics-table is not passed")
 	}
@@ -115,7 +115,7 @@ func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
 	if !metricsTableSet {
 		t.Error("expected metricsTableSet=true for --otel-metrics-table=value")
 	}
@@ -125,7 +125,7 @@ func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
 	if !logsTableSet {
 		t.Error("expected logsTableSet=true when --otel-logs-table is passed")
 	}
@@ -135,7 +135,7 @@ func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if logsTableSet {
 		t.Error("expected logsTableSet=false when --otel-logs-table is not passed")
 	}
@@ -145,7 +145,7 @@ func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
 	if !logsTableSet {
 		t.Error("expected logsTableSet=true for --otel-logs-table=value")
 	}
@@ -155,7 +155,7 @@ func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
 }
 
 func TestParseArgs_BothOtelTables(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsSet, logsTable, logsSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{
+	_, _, _, _, _, _, metricsTable, metricsSet, logsTable, logsSet, _, _, _, _, _, _, _, _ := parseArgs([]string{
 		"--otel-metrics-table", "cat.schema.metrics",
 		"--otel-logs-table", "cat.schema.logs",
 	})
@@ -171,14 +171,14 @@ func TestParseArgs_BothOtelTables(t *testing.T) {
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--unknown"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--unknown"})
 	if len(claudeArgs) != 1 || claudeArgs[0] != "--unknown" {
 		t.Errorf("expected claudeArgs=[\"--unknown\"], got %v", claudeArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, _, claudeArgs := parseArgs([]string{})
+	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, _, _, _, upstream, logFile, noOtel, _, _, _, _, claudeArgs := parseArgs([]string{})
 	if profile != "" {
 		t.Errorf("expected empty profile, got %q", profile)
 	}
@@ -201,7 +201,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	profile, verbose, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
+	profile, verbose, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -214,7 +214,7 @@ func TestParseArgs_Mixed(t *testing.T) {
 }
 
 func TestParseArgs_NoOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true for --no-otel")
 	}
@@ -227,7 +227,7 @@ func TestParseArgs_NoOtel(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelAndOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _ := parseArgs([]string{"--no-otel", "--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _ := parseArgs([]string{"--no-otel", "--otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true")
 	}
@@ -237,7 +237,7 @@ func TestParseArgs_NoOtelAndOtel(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel", "somearg"})
+	_, _, _, _, _, _, _, _, _, _, _, _, noOtel, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel", "somearg"})
 	if !noOtel {
 		t.Error("expected noOtel=true")
 	}
@@ -247,57 +247,12 @@ func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
 }
 
 func TestParseArgs_OtelUnaffectedByNoOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
 	if noOtel {
 		t.Error("expected noOtel=false when only --otel given")
-	}
-}
-
-// --- Model flag parseArgs tests ---
-
-func TestParseArgs_Model(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _ := parseArgs([]string{"--model", "databricks-claude-sonnet-4-6"})
-	if !modelSet {
-		t.Error("expected modelSet=true when --model is passed")
-	}
-	if model != "databricks-claude-sonnet-4-6" {
-		t.Errorf("expected model=%q, got %q", "databricks-claude-sonnet-4-6", model)
-	}
-}
-
-func TestParseArgs_ModelEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _ := parseArgs([]string{"--model=custom-model"})
-	if !modelSet {
-		t.Error("expected modelSet=true when --model=value is passed")
-	}
-	if model != "custom-model" {
-		t.Errorf("expected model=%q, got %q", "custom-model", model)
-	}
-}
-
-func TestParseArgs_ModelDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, _ := parseArgs([]string{})
-	if modelSet {
-		t.Error("expected modelSet=false when --model is not passed")
-	}
-	if model != "" {
-		t.Errorf("expected empty model from parseArgs, got %q", model)
-	}
-}
-
-func TestParseArgs_ModelNotPassedThrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, model, modelSet, _, claudeArgs := parseArgs([]string{"--model", "my-model", "prompt"})
-	if !modelSet {
-		t.Error("expected modelSet=true")
-	}
-	if model != "my-model" {
-		t.Errorf("expected model=%q, got %q", "my-model", model)
-	}
-	if len(claudeArgs) != 1 || claudeArgs[0] != "prompt" {
-		t.Errorf("expected claudeArgs=[\"prompt\"], got %v", claudeArgs)
 	}
 }
 
@@ -399,7 +354,7 @@ func TestParseArgs_Table(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, _, _, _, _, _, _, _, claudeArgs := parseArgs(tc.args)
+			profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, _, _, _, _, _, claudeArgs := parseArgs(tc.args)
 
 			if profile != tc.want.profile {
 				t.Errorf("profile: got %q, want %q", profile, tc.want.profile)
@@ -474,7 +429,7 @@ func captureStdout(fn func()) string {
 
 func TestHandlePrintEnv_DapiTokenRedacted(t *testing.T) {
 	out := captureStdout(func() {
-		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "dapi-abc123secret", "", "", false, "", "")
+		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "dapi-abc123secret", "", false, "", "")
 	})
 	if !strings.Contains(out, "dapi-***") {
 		t.Errorf("expected dapi token to appear as 'dapi-***', got:\n%s", out)
@@ -486,7 +441,7 @@ func TestHandlePrintEnv_DapiTokenRedacted(t *testing.T) {
 
 func TestHandlePrintEnv_NonDapiTokenRedacted(t *testing.T) {
 	out := captureStdout(func() {
-		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "eyJhbGciOiJSUzI1NiJ9", "", "", false, "", "")
+		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "eyJhbGciOiJSUzI1NiJ9", "", false, "", "")
 	})
 	if !strings.Contains(out, "**** (redacted)") {
 		t.Errorf("expected non-dapi token to appear as '**** (redacted)', got:\n%s", out)
@@ -499,7 +454,7 @@ func TestHandlePrintEnv_NonDapiTokenRedacted(t *testing.T) {
 func TestHandlePrintEnv_ContainsDatabricksHost(t *testing.T) {
 	host := "https://dbc-abc123.cloud.databricks.com"
 	out := captureStdout(func() {
-		handlePrintEnv("DEFAULT", host, "https://gw.example.com", "tok", "", "", false, "", "")
+		handlePrintEnv("DEFAULT", host, "https://gw.example.com", "tok", "", false, "", "")
 	})
 	if !strings.Contains(out, host) {
 		t.Errorf("expected output to contain DATABRICKS_HOST %q, got:\n%s", host, out)
@@ -509,7 +464,7 @@ func TestHandlePrintEnv_ContainsDatabricksHost(t *testing.T) {
 func TestHandlePrintEnv_ContainsAnthropicBaseURL(t *testing.T) {
 	baseURL := "https://gateway.example.com/anthropic"
 	out := captureStdout(func() {
-		handlePrintEnv("DEFAULT", "https://dbc.example.com", baseURL, "tok", "", "", false, "", "")
+		handlePrintEnv("DEFAULT", "https://dbc.example.com", baseURL, "tok", "", false, "", "")
 	})
 	if !strings.Contains(out, baseURL) {
 		t.Errorf("expected output to contain ANTHROPIC_BASE_URL %q, got:\n%s", baseURL, out)
@@ -518,7 +473,7 @@ func TestHandlePrintEnv_ContainsAnthropicBaseURL(t *testing.T) {
 
 func TestHandlePrintEnv_EmptyTokenRedacted(t *testing.T) {
 	out := captureStdout(func() {
-		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "", "", "", false, "", "")
+		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "", "", false, "", "")
 	})
 	// Empty string does not start with "dapi-" so it should show as **** (redacted)
 	if !strings.Contains(out, "**** (redacted)") {
@@ -633,7 +588,7 @@ func TestOTELTableDerivation(t *testing.T) {
 
 func TestHandlePrintEnv_OTELFields(t *testing.T) {
 	out := captureStdout(func() {
-		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "tok", "", "", true, "main.telemetry.claude_otel_metrics", "main.telemetry.claude_otel_logs")
+		handlePrintEnv("DEFAULT", "https://dbc.example.com", "https://gw.example.com", "tok", "", true, "main.telemetry.claude_otel_metrics", "main.telemetry.claude_otel_logs")
 	})
 	checks := []string{
 		"OTEL enabled:         true",

--- a/state.go
+++ b/state.go
@@ -11,7 +11,6 @@ import (
 // This file survives config restores and persists across sessions.
 type persistentState struct {
 	Profile string `json:"profile,omitempty"`
-	Model   string `json:"model,omitempty"`
 	Port    int    `json:"port,omitempty"`
 }
 
@@ -29,20 +28,6 @@ func resolvePort(portFlag int, state persistentState) int {
 		return state.Port
 	}
 	return defaultPort
-}
-
-// resolveModel returns the model to use, following the resolution chain:
-// 1. --model flag (non-empty)
-// 2. Saved state value (non-empty)
-// 3. Default "" (no override)
-func resolveModel(flagVal string, state persistentState) string {
-	if flagVal != "" {
-		return flagVal
-	}
-	if state.Model != "" {
-		return state.Model
-	}
-	return ""
 }
 
 // statePath returns the path to the persistent state file.

--- a/state_test.go
+++ b/state_test.go
@@ -64,46 +64,6 @@ func TestSaveState_OverwritesPrevious(t *testing.T) {
 	}
 }
 
-func TestSaveAndLoadState_Model(t *testing.T) {
-	dir := t.TempDir()
-	orig := statePath
-	statePath = func() string { return filepath.Join(dir, "state.json") }
-	defer func() { statePath = orig }()
-
-	if err := saveState(persistentState{Model: "databricks-claude-sonnet-4-6"}); err != nil {
-		t.Fatalf("saveState: %v", err)
-	}
-
-	s := loadState()
-	if s.Model != "databricks-claude-sonnet-4-6" {
-		t.Errorf("got Model %q, want %q", s.Model, "databricks-claude-sonnet-4-6")
-	}
-}
-
-func TestSaveState_ModelPreservesOtherFields(t *testing.T) {
-	dir := t.TempDir()
-	orig := statePath
-	statePath = func() string { return filepath.Join(dir, "state.json") }
-	defer func() { statePath = orig }()
-
-	saveState(persistentState{Profile: "aidev", Port: 9999})
-
-	s := loadState()
-	s.Model = "custom-model"
-	saveState(s)
-
-	s = loadState()
-	if s.Profile != "aidev" {
-		t.Errorf("got Profile %q, want %q", s.Profile, "aidev")
-	}
-	if s.Port != 9999 {
-		t.Errorf("got Port %d, want %d", s.Port, 9999)
-	}
-	if s.Model != "custom-model" {
-		t.Errorf("got Model %q, want %q", s.Model, "custom-model")
-	}
-}
-
 func TestSaveAndLoadState_Port(t *testing.T) {
 	dir := t.TempDir()
 	orig := statePath
@@ -137,28 +97,6 @@ func TestResolvePort(t *testing.T) {
 			got := resolvePort(tc.portFlag, tc.state)
 			if got != tc.want {
 				t.Errorf("resolvePort(%d, %+v) = %d, want %d", tc.portFlag, tc.state, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestResolveModel(t *testing.T) {
-	tests := []struct {
-		name    string
-		flagVal string
-		state   persistentState
-		want    string
-	}{
-		{"flag wins over state", "flag-model", persistentState{Model: "state-model"}, "flag-model"},
-		{"state wins over default", "", persistentState{Model: "state-model"}, "state-model"},
-		{"empty when no flag and no state", "", persistentState{}, ""},
-		{"flag wins over empty state", "flag-model", persistentState{}, "flag-model"},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := resolveModel(tc.flagVal, tc.state)
-			if got != tc.want {
-				t.Errorf("resolveModel(%q, %+v) = %q, want %q", tc.flagVal, tc.state, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Add `--model` flag with state persistence matching the `databricks-codex` pattern (flag > saved state > default)
- Refactor `statePath` from a function to an overridable package-level variable so tests use temp dirs instead of touching `~/.claude/`
- Align `loadState`/`saveState` signatures with `databricks-codex` (value types, no error return from load)

Closes #37, Closes #38

## Changes
- `state.go`: `var statePath = func() string { ... }`, `Model` field on `persistentState`, `resolveModel()`, atomic writes via `os.CreateTemp`
- `main.go`: `--model` in `parseArgs`, model resolution + save in lifecycle, `--print-env` shows model, `--help` lists `--model`
- `state_test.go`: new file with temp-dir tests for save/load, resolvePort, resolveModel, statePath override
- `main_test.go`: updated all `parseArgs` calls for new signature, added model flag test cases

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] New `state_test.go` covers model persistence, port, profile, and statePath override
- [x] New `TestParseArgs_Model*` tests cover `--model`, `--model=value`, default, and passthrough