### PR TITLE
feat: dispatch Homebrew formula update on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,17 @@ jobs:
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ needs.release-please.outputs.tag_name }} dist/*
-
+        run: gh release upload ${{ needs.release-please.outputs.tag_name }} dist/*update-homebrew:
+    needs: [release-please, build-and-upload]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch formula update to homebrew-tap
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          gh api repos/IceRhymers/homebrew-tap/dispatches \
+            -f event_type=formula-update \
+            -f "client_payload[tool]=databricks-claude" \
+            -f "client_payload[tag]=${{ needs.release-please.outputs.tag_name }}" \
+            -f "client_payload[version]=${{ needs.release-please.outputs.tag_name }}"


### PR DESCRIPTION
Closes #47

Adds update-homebrew job to release.yml that fires a repository_dispatch event to IceRhymers/homebrew-tap when a release is created.