### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ You use it exactly like `claude`. Every flag and argument is forwarded.
 
 ## Installation
 
+Via Homebrew (recommended):
+
+```
+brew tap IceRhymers/tap
+brew install databricks-claude
+```
+
+Via Go:
+
 ### From source
 
 ```bash


### PR DESCRIPTION
Adds `brew tap IceRhymers/tap && brew install databricks-claude` to the README. Also triggers the first real test of the homebrew-tap dispatch pipeline.