### PR TITLE
feat: add POST /shutdown endpoint and idle timeout for headless lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 databricks-claude
 dist/
 *.exe
+.omc/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ go test ./pkg/proxy/... -v       # test a single package
 
 Six `.go` files act as thin facades wiring together `pkg/` sub-packages:
 
-- **main.go** — CLI entry point: flag parsing, config resolution (`~/.claude/settings.json` + `~/.claude/.databricks-claude.json`), token seeding, AI Gateway auto-discovery, proxy startup, settings patching, child launch, and explicit settings restore before `os.Exit`.
+- **main.go** — CLI entry point: flag parsing, config resolution (`~/.claude/settings.json` + `~/.claude/.databricks-claude.json`), token seeding, AI Gateway auto-discovery, proxy startup, settings patching, child launch, headless lifecycle management (`wrapWithLifecycle` for `/shutdown` endpoint and idle timeout), and explicit settings restore before `os.Exit`.
 - **proxy.go** — Facade over `pkg/proxy`: defines `ProxyConfig`, wires `NewProxyServer` and `StartProxy`.
 - **token.go** — Facade over `pkg/tokencache`: implements `databricksFetcher` (shells out to `databricks auth token`), host discovery, workspace ID resolution via SCIM, AI Gateway URL construction.
 - **process.go** — `SettingsManager` wrapping `pkg/settings`: full-setup and save/restore of settings.json env keys, OTEL key management, `RunChild`, `ForwardSignals`.
@@ -47,9 +47,10 @@ Each package is independently importable with no cross-dependencies:
 
 ### Key data flow
 
-1. `main.go` seeds token cache → starts proxy on `127.0.0.1:0` → patches `settings.json` to point `ANTHROPIC_BASE_URL` at proxy → launches `claude` as child
-2. Proxy intercepts every request, injects fresh OAuth token via `pkg/tokencache` → forwards to AI Gateway (inference) or Databricks OTEL endpoint
-3. On exit, `SettingsManager.Restore()` is called **explicitly before `os.Exit`** (not via defer — `os.Exit` skips defers). Smart handoff points `ANTHROPIC_BASE_URL` to a surviving session if one exists.
+1. `main.go` seeds token cache → starts proxy on `127.0.0.1:0` → patches `settings.json` to point `ANTHROPIC_BASE_URL` at proxy → launches `claude` as child (or enters headless mode)
+2. In headless mode, the handler is wrapped with `wrapWithLifecycle` which adds `POST /shutdown` (refcount decrement + conditional exit) and idle timeout (default 30m, resets on each proxied request)
+3. Proxy intercepts every request, injects fresh OAuth token via `pkg/tokencache` → forwards to AI Gateway (inference) or Databricks OTEL endpoint
+4. On exit, `SettingsManager.Restore()` is called **explicitly before `os.Exit`** (not via defer — `os.Exit` skips defers). Smart handoff points `ANTHROPIC_BASE_URL` to a surviving session if one exists.
 
 ## Key Design Constraints
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ databricks-claude --tls-cert cert.pem --tls-key key.pem "explain this codebase"
 | `--port` | `49153` | Proxy listen port (saved for future sessions) |
 | `--tls-cert` | | Path to TLS certificate file (requires `--tls-key`) |
 | `--tls-key` | | Path to TLS private key file (requires `--tls-cert`) |
+| `--headless` | `false` | Start proxy without launching claude (for IDE extensions) |
+| `--idle-timeout` | `30m` | Idle timeout in headless mode (`0` disables) |
 | `--version` | | Print version and exit |
 | `--print-env` | | Print resolved configuration (token redacted) and exit |
 | `--help`, `-h` | | Print wrapper flags and the full `claude --help` output, then exit |
@@ -115,6 +117,21 @@ On first run (when `ANTHROPIC_BASE_URL` is not set), `databricks-claude` auto-di
 - Constructs the AI Gateway URL: `https://<workspace-id>.ai-gateway.cloud.databricks.com/anthropic`
 
 If workspace ID resolution fails, it falls back to `<host>/serving-endpoints/anthropic`.
+
+## Headless Mode
+
+`--headless` starts the proxy without launching a `claude` child process, for use by IDE extensions and external tooling.
+
+```bash
+databricks-claude --headless
+# prints: PROXY_URL=http://127.0.0.1:<port>
+```
+
+### Lifecycle Management
+
+- **`GET /health`** — liveness check, returns `{"tool":"databricks-claude","version":"...","pid":...}`
+- **`POST /shutdown`** — decrements the session refcount; when it reaches 0, the proxy exits. Returns `{"remaining": N, "exiting": true/false}`
+- **Idle timeout** — after 30 minutes with no proxied requests, the proxy shuts down automatically. Configure with `--idle-timeout <duration>` (e.g. `10m`, `1h`). Use `--idle-timeout 0` to disable.
 
 ## Profile Resolution Order
 

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -32,7 +33,7 @@ func main() {
 	// Parse databricks-claude flags, passing everything else through to claude.
 	// Usage: databricks-claude [databricks-claude-flags] [--] [claude-args...]
 	// Unknown flags are forwarded to claude automatically.
-	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, otelMetricsTableSet, otelLogsTable, otelLogsTableSet, upstream, logFile, noOtel, proxyAPIKey, tlsCert, tlsKey, portFlag, headless, claudeArgs := parseArgs(os.Args[1:])
+	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, otelMetricsTableSet, otelLogsTable, otelLogsTableSet, upstream, logFile, noOtel, proxyAPIKey, tlsCert, tlsKey, portFlag, headless, idleTimeout, claudeArgs := parseArgs(os.Args[1:])
 
 	if showHelp {
 		handleHelp(upstream)
@@ -285,6 +286,19 @@ func main() {
 	}
 	handler := NewProxyServer(proxyConfig)
 
+	// --- Reference counting (before server start so lifecycle wrapper can use refcountPath) ---
+	refcountPath := filepath.Join(os.TempDir(), fmt.Sprintf(".databricks-claude-sessions-%d", port))
+	if err := refcount.Acquire(refcountPath); err != nil {
+		log.Printf("databricks-claude: refcount acquire warning: %v", err)
+	}
+
+	// In headless mode, wrap handler with /shutdown endpoint and idle timeout.
+	var doneCh chan struct{}
+	if headless {
+		doneCh = make(chan struct{})
+		handler = wrapWithLifecycle(handler, refcountPath, isOwner, idleTimeout, proxyAPIKey, doneCh)
+	}
+
 	// --- Start proxy if we own the port; otherwise watch for owner death ---
 	if isOwner {
 		go func() {
@@ -302,12 +316,6 @@ func main() {
 	} else {
 		// Watch for owner death and take over the proxy if needed.
 		go watchProxy(port, handler, tlsCert, tlsKey)
-	}
-
-	// --- Reference counting ---
-	refcountPath := filepath.Join(os.TempDir(), fmt.Sprintf(".databricks-claude-sessions-%d", port))
-	if err := refcount.Acquire(refcountPath); err != nil {
-		log.Printf("databricks-claude: refcount acquire warning: %v", err)
 	}
 
 	// --- Write config once (idempotent) ---
@@ -352,7 +360,7 @@ func main() {
 		proxyURL, isOwner, resolvedProfile, inferenceUpstream)
 
 	if headless {
-		runHeadless(proxyURL, ln, isOwner, refcountPath)
+		runHeadless(proxyURL, ln, isOwner, refcountPath, doneCh)
 		return
 	}
 
@@ -376,18 +384,102 @@ func main() {
 	os.Exit(exitCode)
 }
 
+// shutdownResponse is the JSON body returned by POST /shutdown.
+type shutdownResponse struct {
+	Remaining int  `json:"remaining"`
+	Exiting   bool `json:"exiting"`
+}
+
+// wrapWithLifecycle wraps the proxy handler with:
+//   - POST /shutdown: decrements refcount and conditionally shuts down
+//   - Activity tracking: resets the idle timer on every proxied request
+//
+// It returns the wrapped handler. doneCh is closed when shutdown is triggered
+// (either via /shutdown or idle timeout). The caller selects on doneCh to
+// begin cleanup.
+func wrapWithLifecycle(
+	inner http.Handler,
+	refcountPath string,
+	isOwner bool,
+	idleTimeout time.Duration,
+	apiKey string,
+	doneCh chan struct{},
+) http.Handler {
+	var shutdownOnce sync.Once
+	triggerShutdown := func() {
+		shutdownOnce.Do(func() { close(doneCh) })
+	}
+
+	// Idle timer: fires once after idleTimeout of inactivity.
+	// Reset on every proxied request. time.AfterFunc is goroutine-safe.
+	var idleTimer *time.Timer
+	if idleTimeout > 0 {
+		idleTimer = time.AfterFunc(idleTimeout, func() {
+			log.Printf("databricks-claude: idle timeout (%s), shutting down", idleTimeout)
+			triggerShutdown()
+		})
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		// Enforce API key if configured (matches requireAPIKey in pkg/proxy).
+		if apiKey != "" {
+			if r.Header.Get("Authorization") != "Bearer "+apiKey {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+		remaining, err := refcount.Release(refcountPath)
+		if err != nil {
+			log.Printf("databricks-claude: shutdown refcount release error: %v", err)
+		}
+		exiting := remaining == 0 && isOwner
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(shutdownResponse{Remaining: remaining, Exiting: exiting})
+		if exiting {
+			// Stop idle timer to avoid double-shutdown.
+			if idleTimer != nil {
+				idleTimer.Stop()
+			}
+			triggerShutdown()
+		}
+	})
+
+	// All other routes: reset idle timer, then delegate to inner handler.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if idleTimer != nil {
+			idleTimer.Reset(idleTimeout)
+		}
+		inner.ServeHTTP(w, r)
+	})
+
+	return mux
+}
+
 // runHeadless runs the proxy without launching a claude child process.
-// It prints the proxy URL to stdout, then blocks until SIGINT/SIGTERM.
+// It prints the proxy URL to stdout, then blocks until SIGINT/SIGTERM
+// or until doneCh is closed (by /shutdown or idle timeout).
 // The watchProxy goroutine (for non-owner sessions) is already started
 // before this function is called.
-func runHeadless(proxyURL string, ln net.Listener, isOwner bool, refcountPath string) {
+func runHeadless(proxyURL string, ln net.Listener, isOwner bool, refcountPath string, doneCh chan struct{}) {
 	fmt.Printf("PROXY_URL=%s\n", proxyURL)
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	<-sigCh
-	signal.Stop(sigCh)
 
+	select {
+	case <-sigCh:
+		signal.Stop(sigCh)
+	case <-doneCh:
+		// Triggered by /shutdown or idle timeout.
+	}
+
+	// Release refcount. If /shutdown already released, Release floors at 0.
 	n, _ := refcount.Release(refcountPath)
 	if n == 0 && isOwner {
 		ln.Close()
@@ -433,8 +525,9 @@ func envBlock(doc map[string]interface{}) map[string]interface{} {
 // databricks-claude owns: --profile, --verbose/-v, --log-file, --version, --otel, --otel-metrics-table, --otel-logs-table, --no-otel, --proxy-api-key, --tls-cert, --tls-key.
 // Everything else (including unknown flags like --debug) passes through to claude.
 // An explicit "--" separator is supported but not required.
-func parseArgs(args []string) (profile string, verbose bool, version bool, showHelp bool, printEnv bool, otel bool, otelMetricsTable string, otelMetricsTableSet bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, noOtel bool, proxyAPIKey string, tlsCert string, tlsKey string, portFlag int, headless bool, claudeArgs []string) {
+func parseArgs(args []string) (profile string, verbose bool, version bool, showHelp bool, printEnv bool, otel bool, otelMetricsTable string, otelMetricsTableSet bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, noOtel bool, proxyAPIKey string, tlsCert string, tlsKey string, portFlag int, headless bool, idleTimeout time.Duration, claudeArgs []string) {
 	otelMetricsTable = "main.claude_telemetry.claude_otel_metrics" // default
+	idleTimeout = 30 * time.Minute                                 // default
 
 	knownFlags := map[string]bool{
 		"--profile":            true,
@@ -453,6 +546,7 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 		"--tls-key":           true,
 		"--port":              true,
 		"--headless":          true,
+		"--idle-timeout":      true,
 	}
 
 	i := 0
@@ -570,6 +664,20 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 					}
 				case "--headless":
 					headless = true
+				case "--idle-timeout":
+					raw := value
+					if raw == "" && i+1 < len(args) {
+						i++
+						raw = args[i]
+					}
+					if raw != "" {
+						if d, err := time.ParseDuration(raw); err == nil {
+							idleTimeout = d
+						} else if mins, err := strconv.Atoi(raw); err == nil {
+							// Bare number: treat as minutes for convenience.
+							idleTimeout = time.Duration(mins) * time.Minute
+						}
+					}
 				}
 				i++
 				continue
@@ -608,6 +716,7 @@ Databricks-Claude Flags:
   --tls-key string             Path to TLS private key file (requires --tls-cert)
   --port int                   Fixed proxy port (default: 49153, saved to state)
   --headless                   Start proxy without launching claude (for IDE extensions)
+  --idle-timeout duration      Idle timeout for headless mode (default 30m, 0 disables, bare number = minutes)
   --version                    Print version and exit
   --help, -h                   Show this help message
 

--- a/main_test.go
+++ b/main_test.go
@@ -6,16 +6,21 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/IceRhymers/databricks-claude/pkg/refcount"
 )
 
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, claudeArgs := parseArgs([]string{"--help"})
+	profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true for --help")
 	}
@@ -25,77 +30,77 @@ func TestParseArgs_HelpLong(t *testing.T) {
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
+	_, _, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
 	if !showHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
+	_, _, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
 	if !printEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, _, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
+	_, _, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
 	if !version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
+	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
 	if !verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
+	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
 	if !verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
+	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	profile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "foo"})
+	profile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "foo"})
 	if profile != "foo" {
 		t.Errorf("expected profile=%q, got %q", "foo", profile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
+	_, _, _, _, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
 	if upstream != "/path/to/claude" {
 		t.Errorf("expected upstream=%q, got %q", "/path/to/claude", upstream)
 	}
 }
 
 func TestParseArgs_Otel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
 }
 
 func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
 	if !metricsTableSet {
 		t.Error("expected metricsTableSet=true when --otel-metrics-table is passed")
 	}
@@ -105,7 +110,7 @@ func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
 }
 
 func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if metricsTableSet {
 		t.Error("expected metricsTableSet=false when --otel-metrics-table is not passed")
 	}
@@ -115,7 +120,7 @@ func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
 	if !metricsTableSet {
 		t.Error("expected metricsTableSet=true for --otel-metrics-table=value")
 	}
@@ -125,7 +130,7 @@ func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
 	if !logsTableSet {
 		t.Error("expected logsTableSet=true when --otel-logs-table is passed")
 	}
@@ -135,7 +140,7 @@ func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if logsTableSet {
 		t.Error("expected logsTableSet=false when --otel-logs-table is not passed")
 	}
@@ -145,7 +150,7 @@ func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
 	if !logsTableSet {
 		t.Error("expected logsTableSet=true for --otel-logs-table=value")
 	}
@@ -155,7 +160,7 @@ func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
 }
 
 func TestParseArgs_BothOtelTables(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsSet, logsTable, logsSet, _, _, _, _, _, _, _, _, _ := parseArgs([]string{
+	_, _, _, _, _, _, metricsTable, metricsSet, logsTable, logsSet, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{
 		"--otel-metrics-table", "cat.schema.metrics",
 		"--otel-logs-table", "cat.schema.logs",
 	})
@@ -171,14 +176,14 @@ func TestParseArgs_BothOtelTables(t *testing.T) {
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--unknown"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--unknown"})
 	if len(claudeArgs) != 1 || claudeArgs[0] != "--unknown" {
 		t.Errorf("expected claudeArgs=[\"--unknown\"], got %v", claudeArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, claudeArgs := parseArgs([]string{})
+	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, _, claudeArgs := parseArgs([]string{})
 	if profile != "" {
 		t.Errorf("expected empty profile, got %q", profile)
 	}
@@ -201,7 +206,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	profile, verbose, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
+	profile, verbose, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -214,14 +219,14 @@ func TestParseArgs_Mixed(t *testing.T) {
 }
 
 func TestParseArgs_Headless(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _ := parseArgs([]string{"--headless"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _, _ := parseArgs([]string{"--headless"})
 	if !headless {
 		t.Error("expected headless=true for --headless")
 	}
 }
 
 func TestParseArgs_HeadlessWithOtherFlags(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _ := parseArgs([]string{"--headless", "--verbose"})
+	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _, _ := parseArgs([]string{"--headless", "--verbose"})
 	if !headless {
 		t.Error("expected headless=true")
 	}
@@ -231,7 +236,7 @@ func TestParseArgs_HeadlessWithOtherFlags(t *testing.T) {
 }
 
 func TestParseArgs_NoOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true for --no-otel")
 	}
@@ -244,7 +249,7 @@ func TestParseArgs_NoOtel(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelAndOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _ := parseArgs([]string{"--no-otel", "--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _ := parseArgs([]string{"--no-otel", "--otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true")
 	}
@@ -254,7 +259,7 @@ func TestParseArgs_NoOtelAndOtel(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, noOtel, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel", "somearg"})
+	_, _, _, _, _, _, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel", "somearg"})
 	if !noOtel {
 		t.Error("expected noOtel=true")
 	}
@@ -264,7 +269,7 @@ func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
 }
 
 func TestParseArgs_OtelUnaffectedByNoOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
@@ -371,7 +376,7 @@ func TestParseArgs_Table(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, _, _, _, _, _, _, claudeArgs := parseArgs(tc.args)
+			profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, _, _, _, _, _, _, _, claudeArgs := parseArgs(tc.args)
 
 			if profile != tc.want.profile {
 				t.Errorf("profile: got %q, want %q", profile, tc.want.profile)
@@ -542,7 +547,7 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--otel-metrics-table", "--otel-logs-table", "--headless", "--version", "--help"}
+	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--otel-metrics-table", "--otel-logs-table", "--headless", "--idle-timeout", "--version", "--help"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)
@@ -796,4 +801,239 @@ func TestProfileResolution_StateFileWins(t *testing.T) {
 			t.Fatalf("expected profile=%q, got %q", "DEFAULT", got)
 		}
 	})
+}
+
+// --- idle-timeout flag tests ---
+
+func TestParseArgs_IdleTimeoutDefault(t *testing.T) {
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _ := parseArgs([]string{})
+	if idleTimeout != 30*time.Minute {
+		t.Errorf("expected default idleTimeout=30m, got %v", idleTimeout)
+	}
+}
+
+func TestParseArgs_IdleTimeoutCustom(t *testing.T) {
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _ := parseArgs([]string{"--idle-timeout", "10m"})
+	if idleTimeout != 10*time.Minute {
+		t.Errorf("expected idleTimeout=10m, got %v", idleTimeout)
+	}
+}
+
+func TestParseArgs_IdleTimeoutZero(t *testing.T) {
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _ := parseArgs([]string{"--idle-timeout", "0"})
+	if idleTimeout != 0 {
+		t.Errorf("expected idleTimeout=0, got %v", idleTimeout)
+	}
+}
+
+func TestParseArgs_IdleTimeoutEquals(t *testing.T) {
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _ := parseArgs([]string{"--idle-timeout=5m"})
+	if idleTimeout != 5*time.Minute {
+		t.Errorf("expected idleTimeout=5m, got %v", idleTimeout)
+	}
+}
+
+func TestParseArgs_IdleTimeoutBareNumber(t *testing.T) {
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _ := parseArgs([]string{"--idle-timeout", "1"})
+	if idleTimeout != 1*time.Minute {
+		t.Errorf("expected idleTimeout=1m for bare number '1', got %v", idleTimeout)
+	}
+}
+
+// --- /shutdown endpoint tests ---
+
+func TestShutdown_DecrementsRefcount(t *testing.T) {
+	refcountPath := filepath.Join(t.TempDir(), "refcount")
+
+	// Acquire twice to simulate two sessions.
+	if err := refcount.Acquire(refcountPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := refcount.Acquire(refcountPath); err != nil {
+		t.Fatal(err)
+	}
+
+	doneCh := make(chan struct{})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := wrapWithLifecycle(inner, refcountPath, true, 0, "", doneCh)
+
+	// First shutdown: refcount goes from 2 to 1.
+	req := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp shutdownResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Remaining != 1 || resp.Exiting {
+		t.Errorf("expected remaining=1, exiting=false; got remaining=%d, exiting=%v", resp.Remaining, resp.Exiting)
+	}
+
+	// doneCh should still be open.
+	select {
+	case <-doneCh:
+		t.Fatal("doneCh should not be closed yet")
+	default:
+	}
+
+	// Second shutdown: refcount goes from 1 to 0, owner exits.
+	req2 := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	var resp2 shutdownResponse
+	if err := json.NewDecoder(rec2.Body).Decode(&resp2); err != nil {
+		t.Fatal(err)
+	}
+	if resp2.Remaining != 0 || !resp2.Exiting {
+		t.Errorf("expected remaining=0, exiting=true; got remaining=%d, exiting=%v", resp2.Remaining, resp2.Exiting)
+	}
+
+	// doneCh should be closed now.
+	select {
+	case <-doneCh:
+		// OK
+	case <-time.After(time.Second):
+		t.Fatal("doneCh should be closed after last shutdown")
+	}
+}
+
+func TestShutdown_MethodNotAllowed(t *testing.T) {
+	doneCh := make(chan struct{})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	refcountPath := filepath.Join(t.TempDir(), "refcount")
+	handler := wrapWithLifecycle(inner, refcountPath, true, 0, "", doneCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/shutdown", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestShutdown_RequiresAPIKey(t *testing.T) {
+	doneCh := make(chan struct{})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	refcountPath := filepath.Join(t.TempDir(), "refcount")
+	handler := wrapWithLifecycle(inner, refcountPath, true, 0, "my-secret-key", doneCh)
+
+	// No auth header → 401.
+	req := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without auth, got %d", rec.Code)
+	}
+
+	// Wrong key → 401.
+	req2 := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	req2.Header.Set("Authorization", "Bearer wrong-key")
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 with wrong key, got %d", rec2.Code)
+	}
+
+	// Correct key → 200.
+	if err := refcount.Acquire(refcountPath); err != nil {
+		t.Fatal(err)
+	}
+	req3 := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	req3.Header.Set("Authorization", "Bearer my-secret-key")
+	rec3 := httptest.NewRecorder()
+	handler.ServeHTTP(rec3, req3)
+	if rec3.Code != http.StatusOK {
+		t.Errorf("expected 200 with correct key, got %d", rec3.Code)
+	}
+}
+
+func TestShutdown_PassesThrough(t *testing.T) {
+	var gotPath string
+	doneCh := make(chan struct{})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+	refcountPath := filepath.Join(t.TempDir(), "refcount")
+	handler := wrapWithLifecycle(inner, refcountPath, true, 0, "", doneCh)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/messages", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if gotPath != "/v1/messages" {
+		t.Errorf("expected inner handler to receive /v1/messages, got %q", gotPath)
+	}
+}
+
+// --- idle timeout tests ---
+
+func TestIdleTimeout_TriggersShutdown(t *testing.T) {
+	doneCh := make(chan struct{})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	refcountPath := filepath.Join(t.TempDir(), "refcount")
+	_ = wrapWithLifecycle(inner, refcountPath, true, 50*time.Millisecond, "", doneCh)
+
+	select {
+	case <-doneCh:
+		// OK — idle timeout fired.
+	case <-time.After(2 * time.Second):
+		t.Fatal("doneCh should have been closed by idle timeout")
+	}
+}
+
+func TestIdleTimeout_ResetByRequest(t *testing.T) {
+	doneCh := make(chan struct{})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	refcountPath := filepath.Join(t.TempDir(), "refcount")
+	handler := wrapWithLifecycle(inner, refcountPath, true, 100*time.Millisecond, "", doneCh)
+
+	// Send a request at 60ms to reset the timer.
+	time.Sleep(60 * time.Millisecond)
+	req := httptest.NewRequest(http.MethodGet, "/v1/messages", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// At 120ms from start (60ms after request), timer should NOT have fired
+	// because it was reset to 100ms from the request time.
+	time.Sleep(60 * time.Millisecond)
+	select {
+	case <-doneCh:
+		t.Fatal("doneCh should not be closed yet — timer was reset by request")
+	default:
+		// OK
+	}
+
+	// Wait for the timer to actually fire (100ms from the request at 60ms = 160ms total).
+	select {
+	case <-doneCh:
+		// OK
+	case <-time.After(2 * time.Second):
+		t.Fatal("doneCh should have been closed by idle timeout after activity stopped")
+	}
+}
+
+func TestIdleTimeout_ZeroDisables(t *testing.T) {
+	doneCh := make(chan struct{})
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	refcountPath := filepath.Join(t.TempDir(), "refcount")
+	_ = wrapWithLifecycle(inner, refcountPath, true, 0, "", doneCh)
+
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-doneCh:
+		t.Fatal("doneCh should not be closed when idle timeout is 0")
+	default:
+		// OK — no timeout.
+	}
 }


### PR DESCRIPTION
## Summary

- `POST /shutdown` endpoint decrements the session refcount; closes the listener and exits when the last session calls it
- Idle watcher (`time.AfterFunc`) shuts down the proxy after 30 minutes of no inference/OTEL traffic — covers unclean exits (force-quit, OOM) without requiring a Stop hook to fire
- `runHeadless` now unblocks on either SIGINT/SIGTERM or the internal `doneCh` close
- Lifecycle logic centralised in `wrapWithLifecycle` in `main.go`; `pkg/proxy` unchanged

## Closes

Closes #59

## Test plan

- [x] `databricks-claude --headless` starts, `curl -X POST localhost:49153/shutdown` exits cleanly
- [x] Idle timeout: proxy exits ~30m after last request with no sessions active
- [ ] SIGINT/SIGTERM still shuts down correctly
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)