### PR TITLE
feat: add pkg/updater — GitHub release checker with cache

### DIFF
--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -1,0 +1,264 @@
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Config holds the parameters for an update check.
+type Config struct {
+	RepoSlug       string        // e.g. "IceRhymers/databricks-claude"
+	CurrentVersion string        // e.g. "0.10.1" (no "v" prefix)
+	BinaryName     string        // e.g. "databricks-claude"
+	CacheFile      string        // caller-provided full path
+	CacheTTL       time.Duration // default 24h
+}
+
+// Result holds the outcome of an update check.
+type Result struct {
+	UpdateAvailable bool
+	LatestVersion   string
+	IsHomebrew      bool
+	ReleaseURL      string
+	AssetURL        string
+}
+
+// cacheEntry is the on-disk JSON schema for the cache file.
+type cacheEntry struct {
+	CheckedAt     string `json:"checked_at"`
+	LatestVersion string `json:"latest_version"`
+	ReleaseURL    string `json:"release_url"`
+	AssetURL      string `json:"asset_url"`
+}
+
+// githubRelease is a subset of the GitHub release API response.
+type githubRelease struct {
+	TagName    string        `json:"tag_name"`
+	HTMLURL    string        `json:"html_url"`
+	Prerelease bool          `json:"prerelease"`
+	Assets     []githubAsset `json:"assets"`
+}
+
+// githubAsset is a subset of a GitHub release asset.
+type githubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// Overridable for testing.
+var timeNow = time.Now
+
+// Check queries GitHub for the latest release and returns whether an update
+// is available. Results are cached to CacheFile with CacheTTL freshness.
+func Check(ctx context.Context, cfg Config) (Result, error) {
+	if cfg.CacheTTL == 0 {
+		cfg.CacheTTL = 24 * time.Hour
+	}
+
+	// Try reading cache first.
+	if entry, err := readCache(cfg.CacheFile); err == nil {
+		checkedAt, parseErr := time.Parse(time.RFC3339, entry.CheckedAt)
+		if parseErr == nil && timeNow().Before(checkedAt.Add(cfg.CacheTTL)) {
+			return buildResult(cfg.CurrentVersion, entry.LatestVersion, entry.ReleaseURL, entry.AssetURL), nil
+		}
+	}
+
+	// Cache miss or expired — fetch from GitHub.
+	rel, err := fetchLatestRelease(ctx, cfg.RepoSlug)
+	if err != nil {
+		return Result{}, fmt.Errorf("fetching latest release: %w", err)
+	}
+
+	if rel.Prerelease {
+		return Result{}, nil
+	}
+
+	latestVersion := strings.TrimPrefix(rel.TagName, "v")
+	assetURL := matchAsset(rel.Assets, cfg.BinaryName)
+
+	// Write cache (best-effort; errors returned to caller).
+	if err := writeCache(cfg.CacheFile, cacheEntry{
+		CheckedAt:     timeNow().UTC().Format(time.RFC3339),
+		LatestVersion: latestVersion,
+		ReleaseURL:    rel.HTMLURL,
+		AssetURL:      assetURL,
+	}); err != nil {
+		return Result{}, fmt.Errorf("writing update cache: %w", err)
+	}
+
+	return buildResult(cfg.CurrentVersion, latestVersion, rel.HTMLURL, assetURL), nil
+}
+
+// buildResult constructs a Result, setting UpdateAvailable based on version comparison.
+func buildResult(currentVersion, latestVersion, releaseURL, assetURL string) Result {
+	return Result{
+		UpdateAvailable: CompareVersions(currentVersion, latestVersion) == -1,
+		LatestVersion:   latestVersion,
+		IsHomebrew:      IsHomebrew(),
+		ReleaseURL:      releaseURL,
+		AssetURL:        assetURL,
+	}
+}
+
+// IsHomebrew returns true if the running binary is managed by Homebrew.
+func IsHomebrew() bool {
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return false
+	}
+	lower := strings.ToLower(resolved)
+	return strings.Contains(lower, "/cellar/") || strings.Contains(lower, "/homebrew/")
+}
+
+// CompareVersions compares two semver-like version strings numerically.
+// Returns -1 if a < b, 0 if a == b, +1 if a > b.
+// Pre-release suffixes (anything after "-") make a version sort before
+// the same version without a suffix.
+func CompareVersions(a, b string) int {
+	aParts, aPre := splitVersion(a)
+	bParts, bPre := splitVersion(b)
+
+	// Pad to equal length.
+	for len(aParts) < len(bParts) {
+		aParts = append(aParts, 0)
+	}
+	for len(bParts) < len(aParts) {
+		bParts = append(bParts, 0)
+	}
+
+	for i := range aParts {
+		if aParts[i] < bParts[i] {
+			return -1
+		}
+		if aParts[i] > bParts[i] {
+			return 1
+		}
+	}
+
+	// Equal numeric parts — pre-release < release.
+	if aPre && !bPre {
+		return -1
+	}
+	if !aPre && bPre {
+		return 1
+	}
+	return 0
+}
+
+// splitVersion parses "1.2.3-rc1" into ([1,2,3], true).
+func splitVersion(v string) ([]int, bool) {
+	v = strings.TrimPrefix(v, "v")
+	pre := false
+	if idx := strings.IndexByte(v, '-'); idx >= 0 {
+		v = v[:idx]
+		pre = true
+	}
+	parts := strings.Split(v, ".")
+	nums := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			n = 0
+		}
+		nums = append(nums, n)
+	}
+	return nums, pre
+}
+
+// fetchLatestRelease calls the GitHub API for the latest release.
+func fetchLatestRelease(ctx context.Context, slug string) (githubRelease, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", slug)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return githubRelease{}, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var rel githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return githubRelease{}, fmt.Errorf("decoding response: %w", err)
+	}
+	return rel, nil
+}
+
+// matchAsset finds the asset URL matching the current OS/arch.
+func matchAsset(assets []githubAsset, binaryName string) string {
+	target := fmt.Sprintf("%s-%s-%s", binaryName, runtime.GOOS, runtime.GOARCH)
+	for _, a := range assets {
+		if a.Name == target {
+			return a.BrowserDownloadURL
+		}
+	}
+	return ""
+}
+
+// readCache reads and parses the cache file.
+func readCache(path string) (cacheEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cacheEntry{}, err
+	}
+	var entry cacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return cacheEntry{}, fmt.Errorf("parsing cache: %w", err)
+	}
+	return entry, nil
+}
+
+// writeCache writes the cache file atomically (temp + rename).
+func writeCache(path string, entry cacheEntry) error {
+	data, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(dir, ".update-cache-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/pkg/updater/updater_test.go
+++ b/pkg/updater/updater_test.go
@@ -1,0 +1,343 @@
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// CompareVersions
+// ---------------------------------------------------------------------------
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"0.9.0", "0.10.0", -1},
+		{"0.10.0", "0.9.0", 1},
+		{"1.0", "1.0.0", 0},
+		{"1.0.0", "1.0", 0},
+		{"1.0.0-rc1", "1.0.0", -1},
+		{"1.0.0", "1.0.0-rc1", 1},
+		{"1.0.0-rc1", "1.0.0-rc2", 0}, // same numeric parts, both pre-release
+		{"1.2.3", "1.2.3", 0},
+		{"2.0.0", "1.99.99", 1},
+		{"0.0.1", "0.0.2", -1},
+		{"v1.0.0", "1.0.0", 0},
+		{"1", "1.0.0", 0},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s_vs_%s", tc.a, tc.b), func(t *testing.T) {
+			got := CompareVersions(tc.a, tc.b)
+			if got != tc.want {
+				t.Errorf("CompareVersions(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Check — cache miss → HTTP call + cache written
+// ---------------------------------------------------------------------------
+
+func TestCheck_CacheMiss(t *testing.T) {
+	assetName := fmt.Sprintf("mybin-%s-%s", runtime.GOOS, runtime.GOARCH)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(githubRelease{
+			TagName:    "v0.11.0",
+			HTMLURL:    "https://github.com/test/repo/releases/tag/v0.11.0",
+			Prerelease: false,
+			Assets: []githubAsset{
+				{Name: assetName, BrowserDownloadURL: "https://dl.example.com/mybin"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	// Patch fetchLatestRelease to use our test server by overriding the HTTP
+	// call via a custom transport that rewrites the URL.
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	cacheDir := t.TempDir()
+	cacheFile := filepath.Join(cacheDir, "cache.json")
+
+	res, err := Check(context.Background(), Config{
+		RepoSlug:       "test/repo",
+		CurrentVersion: "0.10.0",
+		BinaryName:     "mybin",
+		CacheFile:      cacheFile,
+		CacheTTL:       24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !res.UpdateAvailable {
+		t.Error("expected UpdateAvailable=true")
+	}
+	if res.LatestVersion != "0.11.0" {
+		t.Errorf("LatestVersion = %q, want %q", res.LatestVersion, "0.11.0")
+	}
+	if res.AssetURL != "https://dl.example.com/mybin" {
+		t.Errorf("AssetURL = %q, want download URL", res.AssetURL)
+	}
+
+	// Verify cache was written.
+	if _, err := os.Stat(cacheFile); err != nil {
+		t.Fatalf("cache file not created: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Check — cache hit (fresh) → no HTTP call
+// ---------------------------------------------------------------------------
+
+func TestCheck_CacheHit(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	cacheDir := t.TempDir()
+	cacheFile := filepath.Join(cacheDir, "cache.json")
+
+	// Seed fresh cache.
+	entry := cacheEntry{
+		CheckedAt:     timeNow().UTC().Format(time.RFC3339),
+		LatestVersion: "0.12.0",
+		ReleaseURL:    "https://github.com/test/repo/releases/tag/v0.12.0",
+		AssetURL:      "https://dl.example.com/cached",
+	}
+	data, _ := json.Marshal(entry)
+	os.WriteFile(cacheFile, data, 0o600)
+
+	res, err := Check(context.Background(), Config{
+		RepoSlug:       "test/repo",
+		CurrentVersion: "0.10.0",
+		BinaryName:     "mybin",
+		CacheFile:      cacheFile,
+		CacheTTL:       24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if called {
+		t.Error("HTTP call was made despite fresh cache")
+	}
+	if !res.UpdateAvailable {
+		t.Error("expected UpdateAvailable=true from cache")
+	}
+	if res.LatestVersion != "0.12.0" {
+		t.Errorf("LatestVersion = %q, want %q", res.LatestVersion, "0.12.0")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Check — cache expired → HTTP call made
+// ---------------------------------------------------------------------------
+
+func TestCheck_CacheExpired(t *testing.T) {
+	called := false
+	assetName := fmt.Sprintf("mybin-%s-%s", runtime.GOOS, runtime.GOARCH)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		json.NewEncoder(w).Encode(githubRelease{
+			TagName:    "v0.13.0",
+			HTMLURL:    "https://github.com/test/repo/releases/tag/v0.13.0",
+			Prerelease: false,
+			Assets: []githubAsset{
+				{Name: assetName, BrowserDownloadURL: "https://dl.example.com/new"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	cacheDir := t.TempDir()
+	cacheFile := filepath.Join(cacheDir, "cache.json")
+
+	// Seed stale cache (25 hours old).
+	entry := cacheEntry{
+		CheckedAt:     timeNow().Add(-25 * time.Hour).UTC().Format(time.RFC3339),
+		LatestVersion: "0.11.0",
+		ReleaseURL:    "https://github.com/test/repo/releases/tag/v0.11.0",
+		AssetURL:      "https://dl.example.com/old",
+	}
+	data, _ := json.Marshal(entry)
+	os.WriteFile(cacheFile, data, 0o600)
+
+	res, err := Check(context.Background(), Config{
+		RepoSlug:       "test/repo",
+		CurrentVersion: "0.10.0",
+		BinaryName:     "mybin",
+		CacheFile:      cacheFile,
+		CacheTTL:       24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if !called {
+		t.Error("HTTP call was NOT made despite expired cache")
+	}
+	if res.LatestVersion != "0.13.0" {
+		t.Errorf("LatestVersion = %q, want %q", res.LatestVersion, "0.13.0")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Check — HTTP timeout → error returned
+// ---------------------------------------------------------------------------
+
+func TestCheck_HTTPTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Block until context is cancelled.
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	cacheDir := t.TempDir()
+	_, err := Check(ctx, Config{
+		RepoSlug:       "test/repo",
+		CurrentVersion: "0.10.0",
+		BinaryName:     "mybin",
+		CacheFile:      filepath.Join(cacheDir, "cache.json"),
+		CacheTTL:       24 * time.Hour,
+	})
+	if err == nil {
+		t.Fatal("expected error on timeout, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Check — malformed response → error returned gracefully
+// ---------------------------------------------------------------------------
+
+func TestCheck_MalformedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("this is not json"))
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	cacheDir := t.TempDir()
+	_, err := Check(context.Background(), Config{
+		RepoSlug:       "test/repo",
+		CurrentVersion: "0.10.0",
+		BinaryName:     "mybin",
+		CacheFile:      filepath.Join(cacheDir, "cache.json"),
+		CacheTTL:       24 * time.Hour,
+	})
+	if err == nil {
+		t.Fatal("expected error on malformed response, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Check — no update available (current == latest)
+// ---------------------------------------------------------------------------
+
+func TestCheck_NoUpdate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(githubRelease{
+			TagName:    "v0.10.0",
+			HTMLURL:    "https://github.com/test/repo/releases/tag/v0.10.0",
+			Prerelease: false,
+		})
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	cacheDir := t.TempDir()
+	res, err := Check(context.Background(), Config{
+		RepoSlug:       "test/repo",
+		CurrentVersion: "0.10.0",
+		BinaryName:     "mybin",
+		CacheFile:      filepath.Join(cacheDir, "cache.json"),
+		CacheTTL:       24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if res.UpdateAvailable {
+		t.Error("expected UpdateAvailable=false when versions are equal")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsHomebrew — path-based detection
+// ---------------------------------------------------------------------------
+
+func TestIsHomebrew_Paths(t *testing.T) {
+	// IsHomebrew relies on os.Executable which we can't easily override,
+	// so we test the path-matching logic directly via the underlying check.
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/usr/local/Cellar/mybin/1.0/bin/mybin", true},
+		{"/opt/homebrew/bin/mybin", true},
+		{"/home/user/.local/bin/mybin", false},
+		{"/usr/bin/mybin", false},
+		{"/opt/Homebrew/Cellar/something/bin/x", true},
+	}
+	for _, tc := range tests {
+		lower := strings.ToLower(tc.path)
+		got := strings.Contains(lower, "/cellar/") || strings.Contains(lower, "/homebrew/")
+		if got != tc.want {
+			t.Errorf("path %q: got %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// rewriteTransport redirects all requests to the test server.
+// ---------------------------------------------------------------------------
+
+type rewriteTransport struct {
+	target string
+}
+
+func (rt rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = strings.TrimPrefix(rt.target, "http://")
+	return http.DefaultTransport.RoundTrip(req)
+}


### PR DESCRIPTION
## Summary

Implements #73 — adds `pkg/updater` as a shared library for all three proxy CLIs (databricks-claude, databricks-codex, databricks-opencode).

• `Check(ctx, Config) (Result, error)` — queries GitHub releases API with JSON file cache + TTL (default 24h), atomic write
• `CompareVersions(a, b string) int` — numeric per-segment semver comparison (0.9.0 < 0.10.0)
• `IsHomebrew() bool` — detects Homebrew-managed binaries via symlink resolution
• No `Apply()` in v1 — deferred to v2 with SHA256 verification

## Test plan

• CompareVersions: 12 table-driven cases including "0.9.0" vs "0.10.0", missing segments, pre-release suffixes, v-prefix
• Check: httptest.Server mocks covering cache miss, cache hit (fresh), cache expired, HTTP timeout, malformed response, no-update
• IsHomebrew: path pattern matching for /cellar/ and /homebrew/
• All tests pass, go vet clean

Closes #73