### PR TITLE
feat: add update subcommand and startup update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,50 @@ func main() {
 }
 ```
 
+## Automatic Update Check
+
+`databricks-claude` checks for newer releases on startup (once every 24 hours) and prints a one-line notice to stderr when an update is available. The check is synchronous with a 2-second timeout — if GitHub is unreachable it silently skips.
+
+### Update notification
+
+When a newer version exists you'll see:
+
+```
+# Direct install
+databricks-claude: update available (v0.11.0). Run: databricks-claude update
+
+# Homebrew install
+databricks-claude: update available (v0.11.0). Run: brew upgrade databricks-claude
+```
+
+### `update` subcommand
+
+```bash
+databricks-claude update
+```
+
+Force-checks GitHub for the latest release (bypasses the 24-hour cache) and prints upgrade instructions:
+
+| Install method | Output |
+|---|---|
+| Already latest | `databricks-claude v0.10.1 is already the latest version` |
+| Direct install | `Update available: v0.11.0. Download from: https://github.com/...` |
+| Homebrew | `Update available: v0.11.0. Run: brew upgrade databricks-claude` |
+
+No binary is replaced — the command prints instructions only. In-place self-update is planned for a future release.
+
+### Opt out
+
+```bash
+# Per-invocation flag
+databricks-claude --no-update-check
+
+# Per-session or permanent (add to shell profile)
+export DATABRICKS_NO_UPDATE_CHECK=1
+```
+
+Both suppress the startup check and disable the `update` subcommand.
+
 ## License
 
 MIT

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -33,6 +33,7 @@ var flagDefs = []completion.FlagDef{
 	{Name: "uninstall-hooks", Description: "Remove databricks-claude hooks from ~/.claude/settings.json"},
 	{Name: "headless-ensure", Description: "Start proxy if not running — called by the SessionStart hook"},
 	{Name: "headless-release", Description: "Decrement proxy refcount — called by the Stop hook"},
+	{Name: "no-update-check", Description: "Skip the automatic update check on startup"},
 }
 
 // knownFlags is the set of flag names (with "--" prefix) that databricks-claude

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/IceRhymers/databricks-claude/pkg/portbind"
 	"github.com/IceRhymers/databricks-claude/pkg/proxy"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
+	"github.com/IceRhymers/databricks-claude/pkg/updater"
 )
 
 // Version is set at build time via -ldflags.
@@ -38,11 +39,38 @@ func main() {
 		os.Exit(0)
 	}
 
+	// update — force-check for a newer release and print instructions.
+	if len(os.Args) >= 2 && os.Args[1] == "update" {
+		if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
+			fmt.Fprintln(os.Stderr, "databricks-claude: update check disabled via DATABRICKS_NO_UPDATE_CHECK")
+			os.Exit(0)
+		}
+		cfg := buildUpdaterConfig()
+		cfg.CacheTTL = 0 // force fresh check
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		r, err := updater.Check(ctx, cfg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "databricks-claude: update check failed: %v\n", err)
+			os.Exit(1)
+		}
+		if !r.UpdateAvailable {
+			fmt.Fprintf(os.Stderr, "databricks-claude v%s is already the latest version\n", Version)
+			os.Exit(0)
+		}
+		if r.IsHomebrew {
+			fmt.Fprintf(os.Stderr, "Update available: v%s. Run: brew upgrade databricks-claude\n", r.LatestVersion)
+		} else {
+			fmt.Fprintf(os.Stderr, "Update available: v%s. Download from: %s\n", r.LatestVersion, r.ReleaseURL)
+		}
+		os.Exit(0)
+	}
+
 	// Parse databricks-claude flags, passing everything else through to claude.
 	// Usage: databricks-claude [databricks-claude-flags] [--] [claude-args...]
 	// Unknown flags are forwarded to claude automatically.
 	// Tip: use "databricks-claude -- completion" to pass "completion" to claude.
-	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, otelMetricsTableSet, otelLogsTable, otelLogsTableSet, upstream, logFile, noOtel, proxyAPIKey, tlsCert, tlsKey, portFlag, headless, idleTimeout, installHooksFlag, uninstallHooksFlag, headlessEnsureFlag, headlessReleaseFlag, claudeArgs := parseArgs(os.Args[1:])
+	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, otelMetricsTableSet, otelLogsTable, otelLogsTableSet, upstream, logFile, noOtel, proxyAPIKey, tlsCert, tlsKey, portFlag, headless, idleTimeout, installHooksFlag, uninstallHooksFlag, headlessEnsureFlag, headlessReleaseFlag, noUpdateCheck, claudeArgs := parseArgs(os.Args[1:])
 
 	if showHelp {
 		handleHelp(upstream)
@@ -407,6 +435,11 @@ func main() {
 		return
 	}
 
+	// --- Synchronous update check (before child to avoid stderr interleaving) ---
+	if !noUpdateCheck && os.Getenv("DATABRICKS_NO_UPDATE_CHECK") != "1" {
+		printUpdateNotice(buildUpdaterConfig())
+	}
+
 	// --- Run child ---
 	exitCode, err := RunChild(context.Background(), claudeArgs)
 	if err != nil {
@@ -573,7 +606,7 @@ func envBlock(doc map[string]interface{}) map[string]interface{} {
 // databricks-claude owns: --profile, --verbose/-v, --log-file, --version, --otel, --otel-metrics-table, --otel-logs-table, --no-otel, --proxy-api-key, --tls-cert, --tls-key.
 // Everything else (including unknown flags like --debug) passes through to claude.
 // An explicit "--" separator is supported but not required.
-func parseArgs(args []string) (profile string, verbose bool, version bool, showHelp bool, printEnv bool, otel bool, otelMetricsTable string, otelMetricsTableSet bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, noOtel bool, proxyAPIKey string, tlsCert string, tlsKey string, portFlag int, headless bool, idleTimeout time.Duration, installHooksFlag bool, uninstallHooksFlag bool, headlessEnsureFlag bool, headlessReleaseFlag bool, claudeArgs []string) {
+func parseArgs(args []string) (profile string, verbose bool, version bool, showHelp bool, printEnv bool, otel bool, otelMetricsTable string, otelMetricsTableSet bool, otelLogsTable string, otelLogsTableSet bool, upstream string, logFile string, noOtel bool, proxyAPIKey string, tlsCert string, tlsKey string, portFlag int, headless bool, idleTimeout time.Duration, installHooksFlag bool, uninstallHooksFlag bool, headlessEnsureFlag bool, headlessReleaseFlag bool, noUpdateCheck bool, claudeArgs []string) {
 	otelMetricsTable = "main.claude_telemetry.claude_otel_metrics" // default
 	idleTimeout = 30 * time.Minute                                 // default
 
@@ -703,6 +736,8 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 					headlessEnsureFlag = true
 				case "--headless-release":
 					headlessReleaseFlag = true
+				case "--no-update-check":
+					noUpdateCheck = true
 				case "--idle-timeout":
 					raw := value
 					if raw == "" && i+1 < len(args) {
@@ -760,8 +795,13 @@ Databricks-Claude Flags:
   --idle-timeout duration      Idle timeout for headless mode (default 30m, 0 disables, bare number = minutes)
   --install-hooks              Install SessionStart/Stop hooks into ~/.claude/settings.json
   --uninstall-hooks            Remove databricks-claude hooks from ~/.claude/settings.json
+  --no-update-check            Skip the automatic update check on startup
   --version                    Print version and exit
   --help, -h                   Show this help message
+
+Subcommands:
+  completion <shell>           Generate shell completions (bash, zsh, fish)
+  update                       Check for a newer release and print upgrade instructions
 
 Example Unity Catalog table setup (run in a Databricks SQL warehouse):
 
@@ -796,6 +836,38 @@ Claude CLI Options:
 	cmd.Stderr = &buf
 	_ = cmd.Run()
 	fmt.Print(buf.String())
+}
+
+// buildUpdaterConfig returns the standard updater.Config for databricks-claude.
+func buildUpdaterConfig() updater.Config {
+	home, _ := os.UserHomeDir()
+	return updater.Config{
+		RepoSlug:       "IceRhymers/databricks-claude",
+		CurrentVersion: Version,
+		BinaryName:     "databricks-claude",
+		CacheFile:      filepath.Join(home, ".claude", ".update-check.json"),
+		CacheTTL:       24 * time.Hour,
+	}
+}
+
+// printUpdateNotice checks for a newer release and prints a one-line notice
+// to stderr. The 2-second timeout ensures cold misses don't delay startup.
+func printUpdateNotice(cfg updater.Config) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	r, err := updater.Check(ctx, cfg)
+	if err != nil {
+		log.Printf("databricks-claude: update check: %v", err)
+		return
+	}
+	if !r.UpdateAvailable {
+		return
+	}
+	if r.IsHomebrew {
+		fmt.Fprintf(os.Stderr, "databricks-claude: update available (v%s). Run: brew upgrade databricks-claude\n", r.LatestVersion)
+	} else {
+		fmt.Fprintf(os.Stderr, "databricks-claude: update available (v%s). Run: databricks-claude update\n", r.LatestVersion)
+	}
 }
 
 // handlePrintEnv prints resolved configuration with the token redacted.

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ import (
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--help"})
+	profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true for --help")
 	}
@@ -30,77 +30,77 @@ func TestParseArgs_HelpLong(t *testing.T) {
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
+	_, _, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
 	if !showHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
+	_, _, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
 	if !printEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, _, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
+	_, _, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
 	if !version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
+	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
 	if !verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
+	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
 	if !verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
+	_, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	profile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "foo"})
+	profile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "foo"})
 	if profile != "foo" {
 		t.Errorf("expected profile=%q, got %q", "foo", profile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
+	_, _, _, _, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
 	if upstream != "/path/to/claude" {
 		t.Errorf("expected upstream=%q, got %q", "/path/to/claude", upstream)
 	}
 }
 
 func TestParseArgs_Otel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
 }
 
 func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
 	if !metricsTableSet {
 		t.Error("expected metricsTableSet=true when --otel-metrics-table is passed")
 	}
@@ -110,7 +110,7 @@ func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
 }
 
 func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if metricsTableSet {
 		t.Error("expected metricsTableSet=false when --otel-metrics-table is not passed")
 	}
@@ -120,7 +120,7 @@ func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
+	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
 	if !metricsTableSet {
 		t.Error("expected metricsTableSet=true for --otel-metrics-table=value")
 	}
@@ -130,7 +130,7 @@ func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
 	if !logsTableSet {
 		t.Error("expected logsTableSet=true when --otel-logs-table is passed")
 	}
@@ -140,7 +140,7 @@ func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if logsTableSet {
 		t.Error("expected logsTableSet=false when --otel-logs-table is not passed")
 	}
@@ -150,7 +150,7 @@ func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
+	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
 	if !logsTableSet {
 		t.Error("expected logsTableSet=true for --otel-logs-table=value")
 	}
@@ -160,7 +160,7 @@ func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
 }
 
 func TestParseArgs_BothOtelTables(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsSet, logsTable, logsSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{
+	_, _, _, _, _, _, metricsTable, metricsSet, logsTable, logsSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{
 		"--otel-metrics-table", "cat.schema.metrics",
 		"--otel-logs-table", "cat.schema.logs",
 	})
@@ -176,14 +176,14 @@ func TestParseArgs_BothOtelTables(t *testing.T) {
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--unknown"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--unknown"})
 	if len(claudeArgs) != 1 || claudeArgs[0] != "--unknown" {
 		t.Errorf("expected claudeArgs=[\"--unknown\"], got %v", claudeArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{})
+	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{})
 	if profile != "" {
 		t.Errorf("expected empty profile, got %q", profile)
 	}
@@ -206,7 +206,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	profile, verbose, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
+	profile, verbose, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -219,14 +219,21 @@ func TestParseArgs_Mixed(t *testing.T) {
 }
 
 func TestParseArgs_Headless(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _, _ := parseArgs([]string{"--headless"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _, _, _ := parseArgs([]string{"--headless"})
 	if !headless {
 		t.Error("expected headless=true for --headless")
 	}
 }
 
+func TestParseArgs_NoUpdateCheck(t *testing.T) {
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, noUpdateCheck, _ := parseArgs([]string{"--no-update-check"})
+	if !noUpdateCheck {
+		t.Error("expected noUpdateCheck=true for --no-update-check")
+	}
+}
+
 func TestParseArgs_HeadlessWithOtherFlags(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _, _ := parseArgs([]string{"--headless", "--verbose"})
+	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _, _, _ := parseArgs([]string{"--headless", "--verbose"})
 	if !headless {
 		t.Error("expected headless=true")
 	}
@@ -236,7 +243,7 @@ func TestParseArgs_HeadlessWithOtherFlags(t *testing.T) {
 }
 
 func TestParseArgs_NoOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true for --no-otel")
 	}
@@ -249,7 +256,7 @@ func TestParseArgs_NoOtel(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelAndOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--no-otel", "--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--no-otel", "--otel"})
 	if !noOtel {
 		t.Error("expected noOtel=true")
 	}
@@ -259,7 +266,7 @@ func TestParseArgs_NoOtelAndOtel(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel", "somearg"})
+	_, _, _, _, _, _, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel", "somearg"})
 	if !noOtel {
 		t.Error("expected noOtel=true")
 	}
@@ -269,7 +276,7 @@ func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
 }
 
 func TestParseArgs_OtelUnaffectedByNoOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
+	_, _, _, _, _, otel, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
 	if !otel {
 		t.Error("expected otel=true for --otel")
 	}
@@ -376,7 +383,7 @@ func TestParseArgs_Table(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs(tc.args)
+			profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, upstream, logFile, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs(tc.args)
 
 			if profile != tc.want.profile {
 				t.Errorf("profile: got %q, want %q", profile, tc.want.profile)
@@ -806,35 +813,35 @@ func TestProfileResolution_StateFileWins(t *testing.T) {
 // --- idle-timeout flag tests ---
 
 func TestParseArgs_IdleTimeoutDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _ := parseArgs([]string{})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _, _ := parseArgs([]string{})
 	if idleTimeout != 30*time.Minute {
 		t.Errorf("expected default idleTimeout=30m, got %v", idleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutCustom(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _ := parseArgs([]string{"--idle-timeout", "10m"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _, _ := parseArgs([]string{"--idle-timeout", "10m"})
 	if idleTimeout != 10*time.Minute {
 		t.Errorf("expected idleTimeout=10m, got %v", idleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutZero(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _ := parseArgs([]string{"--idle-timeout", "0"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _, _ := parseArgs([]string{"--idle-timeout", "0"})
 	if idleTimeout != 0 {
 		t.Errorf("expected idleTimeout=0, got %v", idleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _ := parseArgs([]string{"--idle-timeout=5m"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _, _ := parseArgs([]string{"--idle-timeout=5m"})
 	if idleTimeout != 5*time.Minute {
 		t.Errorf("expected idleTimeout=5m, got %v", idleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutBareNumber(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _ := parseArgs([]string{"--idle-timeout", "1"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _, _ := parseArgs([]string{"--idle-timeout", "1"})
 	if idleTimeout != 1*time.Minute {
 		t.Errorf("expected idleTimeout=1m for bare number '1', got %v", idleTimeout)
 	}


### PR DESCRIPTION
## Summary

Wires `pkg/updater` (from #75) into `main.go` to provide:

• *`databricks-claude update`* subcommand — early-exit command that force-checks GitHub for a newer release (CacheTTL=0, 10s timeout) and prints upgrade instructions (Homebrew or direct download)
• *Synchronous startup check* — runs before the child process launches with a 2s timeout. Cache hits are sub-ms; cold misses that exceed 2s are silently skipped. No goroutine, no stderr interleaving.
• *`buildUpdaterConfig` / `printUpdateNotice`* helpers with cache file at `~/.claude/.update-check.json`
• *Opt-out* via `--no-update-check` flag or `DATABRICKS_NO_UPDATE_CHECK=1` env var (suppresses both the subcommand and startup check)
• *Help text* updated with a Subcommands section listing `completion` and `update`

## Test plan

• All existing tests updated for new `noUpdateCheck` return value from `parseArgs`
• New `TestParseArgs_NoUpdateCheck` test added
• `go build ./...`, `go test ./...`, `go vet ./...` all pass

Closes #74