### PR TITLE
refactor: extract shared proxy utilities into pkg/ (issue #78)

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
 
+	"github.com/IceRhymers/databricks-claude/pkg/headless"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
 )
 
@@ -17,47 +17,12 @@ import (
 // If not, it starts a detached headless proxy and polls until ready (max 10s).
 // Called by the SessionStart hook via: databricks-claude --headless-ensure
 func headlessEnsure(port int) {
-	if os.Getenv("DATABRICKS_CLAUDE_MANAGED") == "1" {
-		log.Printf("databricks-claude: --headless-ensure: skipped (managed session)")
-		return
-	}
-
-	// Acquire refcount FIRST so every ensure/release pair is symmetric.
-	refcountPath := refcountPathForPort(port)
-	if err := refcount.Acquire(refcountPath); err != nil {
-		log.Printf("databricks-claude: --headless-ensure: refcount acquire warning: %v", err)
-	}
-
-	if isProxyHealthy(port) {
-		return // already running, refcount incremented
-	}
-
-	self, err := os.Executable()
-	if err != nil {
-		refcount.Release(refcountPath) // undo acquire on failure
-		log.Fatalf("databricks-claude: --headless-ensure: cannot find self: %v", err)
-	}
-
-	cmd := exec.Command(self, "--headless", fmt.Sprintf("--port=%d", port))
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	if err := cmd.Start(); err != nil {
-		refcount.Release(refcountPath) // undo acquire on failure
-		log.Fatalf("databricks-claude: --headless-ensure: failed to start proxy: %v", err)
-	}
-	if err := cmd.Process.Release(); err != nil {
-		log.Printf("databricks-claude: --headless-ensure: release warning: %v", err)
-	}
-
-	// Poll until healthy or timeout.
-	for i := 0; i < 20; i++ {
-		time.Sleep(500 * time.Millisecond)
-		if isProxyHealthy(port) {
-			return
-		}
-	}
-	refcount.Release(refcountPath) // undo acquire on failure
-	log.Fatalf("databricks-claude: --headless-ensure: proxy did not become healthy within 10s")
+	headless.Ensure(headless.Config{
+		Port:          port,
+		ManagedEnvVar: "DATABRICKS_CLAUDE_MANAGED",
+		LogPrefix:     "databricks-claude",
+		RefcountPath:  refcount.PathForPort(".databricks-claude-sessions", port),
+	})
 }
 
 // headlessRelease calls POST /shutdown on the proxy to decrement the refcount.
@@ -76,17 +41,6 @@ func headlessRelease(port int) {
 		return
 	}
 	resp.Body.Close()
-}
-
-// isProxyHealthy returns true if the proxy on port responds to GET /health.
-func isProxyHealthy(port int) bool {
-	client := &http.Client{Timeout: 500 * time.Millisecond}
-	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
-	if err != nil {
-		return false
-	}
-	resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
 }
 
 // installHooks merges the databricks-claude SessionStart and Stop hooks into

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/IceRhymers/databricks-claude/pkg/refcount"
 )
 
 // TestHeadlessEnsure_ManagedSessionSkips verifies that headlessEnsure returns
@@ -58,7 +60,7 @@ func TestHeadlessEnsure_AcquiresRefcount(t *testing.T) {
 	}
 
 	// Ensure the refcount file doesn't exist before the call.
-	rcPath := refcountPathForPort(port)
+	rcPath := refcount.PathForPort(".databricks-claude-sessions", port)
 	os.Remove(rcPath)
 	t.Cleanup(func() { os.Remove(rcPath) })
 
@@ -82,11 +84,11 @@ func TestHeadlessEnsure_AcquiresRefcount(t *testing.T) {
 }
 
 // TestRefcountPathForPort verifies that the refcount file path is constructed
-// correctly from the port number.
+// correctly from the port number via the shared pkg/refcount function.
 func TestRefcountPathForPort(t *testing.T) {
 	want := filepath.Join(os.TempDir(), ".databricks-claude-sessions-12345")
-	got := refcountPathForPort(12345)
+	got := refcount.PathForPort(".databricks-claude-sessions", 12345)
 	if got != want {
-		t.Errorf("refcountPathForPort(12345) = %q, want %q", got, want)
+		t.Errorf("PathForPort(..., 12345) = %q, want %q", got, want)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,12 +15,13 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
 	"github.com/IceRhymers/databricks-claude/pkg/completion"
+	"github.com/IceRhymers/databricks-claude/pkg/health"
+	"github.com/IceRhymers/databricks-claude/pkg/lifecycle"
 	"github.com/IceRhymers/databricks-claude/pkg/portbind"
 	"github.com/IceRhymers/databricks-claude/pkg/proxy"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
@@ -332,7 +332,7 @@ func main() {
 		scheme = "https"
 		fmt.Fprintln(os.Stderr, "databricks-claude: TLS enabled")
 	}
-	proxyURL := fmt.Sprintf("%s://127.0.0.1:%d", scheme, listenerPort(ln, port))
+	proxyURL := fmt.Sprintf("%s://127.0.0.1:%d", scheme, portbind.ListenerPort(ln, port))
 
 	// --- Build proxy handler (needed by both owner and watchProxy) ---
 	proxyConfig := &ProxyConfig{
@@ -358,7 +358,7 @@ func main() {
 	// acquires, --headless-release releases). The proxy itself does NOT self-acquire
 	// so the last session's release brings the count to 0 and triggers shutdown.
 	// In wrapper mode, the parent process acquires here and releases on exit.
-	refcountPath := refcountPathForPort(port)
+	refcountPath := refcount.PathForPort(".databricks-claude-sessions", port)
 	if !headless {
 		if err := refcount.Acquire(refcountPath); err != nil {
 			log.Printf("databricks-claude: refcount acquire warning: %v", err)
@@ -369,7 +369,15 @@ func main() {
 	var doneCh chan struct{}
 	if headless {
 		doneCh = make(chan struct{})
-		handler = wrapWithLifecycle(handler, refcountPath, isOwner, idleTimeout, proxyAPIKey, doneCh)
+		handler = lifecycle.WrapWithLifecycle(lifecycle.Config{
+			Inner:        handler,
+			RefcountPath: refcountPath,
+			IsOwner:      isOwner,
+			IdleTimeout:  idleTimeout,
+			APIKey:       proxyAPIKey,
+			DoneCh:       doneCh,
+			LogPrefix:    "databricks-claude",
+		})
 	}
 
 	// --- Start proxy if we own the port; otherwise watch for owner death ---
@@ -388,7 +396,7 @@ func main() {
 		}()
 	} else {
 		// Watch for owner death and take over the proxy if needed.
-		go watchProxy(port, handler, tlsCert, tlsKey)
+		go health.WatchProxy(port, handler, tlsCert, tlsKey, "databricks-claude")
 	}
 
 	// --- Write config once (idempotent) ---
@@ -437,7 +445,7 @@ func main() {
 
 	// --- Synchronous update check (before child to avoid stderr interleaving) ---
 	if !noUpdateCheck && os.Getenv("DATABRICKS_NO_UPDATE_CHECK") != "1" {
-		printUpdateNotice(buildUpdaterConfig())
+		updater.PrintUpdateNotice(buildUpdaterConfig())
 	}
 
 	// --- Run child ---
@@ -460,82 +468,6 @@ func main() {
 	os.Exit(exitCode)
 }
 
-// shutdownResponse is the JSON body returned by POST /shutdown.
-type shutdownResponse struct {
-	Remaining int  `json:"remaining"`
-	Exiting   bool `json:"exiting"`
-}
-
-// wrapWithLifecycle wraps the proxy handler with:
-//   - POST /shutdown: decrements refcount and conditionally shuts down
-//   - Activity tracking: resets the idle timer on every proxied request
-//
-// It returns the wrapped handler. doneCh is closed when shutdown is triggered
-// (either via /shutdown or idle timeout). The caller selects on doneCh to
-// begin cleanup.
-func wrapWithLifecycle(
-	inner http.Handler,
-	refcountPath string,
-	isOwner bool,
-	idleTimeout time.Duration,
-	apiKey string,
-	doneCh chan struct{},
-) http.Handler {
-	var shutdownOnce sync.Once
-	triggerShutdown := func() {
-		shutdownOnce.Do(func() { close(doneCh) })
-	}
-
-	// Idle timer: fires once after idleTimeout of inactivity.
-	// Reset on every proxied request. time.AfterFunc is goroutine-safe.
-	var idleTimer *time.Timer
-	if idleTimeout > 0 {
-		idleTimer = time.AfterFunc(idleTimeout, func() {
-			log.Printf("databricks-claude: idle timeout (%s), shutting down", idleTimeout)
-			triggerShutdown()
-		})
-	}
-
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		// Enforce API key if configured (matches requireAPIKey in pkg/proxy).
-		if apiKey != "" {
-			if r.Header.Get("Authorization") != "Bearer "+apiKey {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
-		}
-		remaining, err := refcount.Release(refcountPath)
-		if err != nil {
-			log.Printf("databricks-claude: shutdown refcount release error: %v", err)
-		}
-		exiting := remaining == 0 && isOwner
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(shutdownResponse{Remaining: remaining, Exiting: exiting})
-		if exiting {
-			// Stop idle timer to avoid double-shutdown.
-			if idleTimer != nil {
-				idleTimer.Stop()
-			}
-			triggerShutdown()
-		}
-	})
-
-	// All other routes: reset idle timer, then delegate to inner handler.
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if idleTimer != nil {
-			idleTimer.Reset(idleTimeout)
-		}
-		inner.ServeHTTP(w, r)
-	})
-
-	return mux
-}
 
 // runHeadless runs the proxy without launching a claude child process.
 // It prints the proxy URL to stdout, then blocks until SIGINT/SIGTERM
@@ -562,22 +494,6 @@ func runHeadless(proxyURL string, ln net.Listener, isOwner bool, refcountPath st
 	}
 }
 
-// refcountPathForPort returns the file path used for cross-process session counting.
-func refcountPathForPort(port int) string {
-	return filepath.Join(os.TempDir(), fmt.Sprintf(".databricks-claude-sessions-%d", port))
-}
-
-// listenerPort extracts the port from a net.Listener, falling back to the
-// configured port if the listener is nil (e.g., non-owner case).
-func listenerPort(ln net.Listener, fallback int) int {
-	if ln == nil {
-		return fallback
-	}
-	if addr, ok := ln.Addr().(*net.TCPAddr); ok {
-		return addr.Port
-	}
-	return fallback
-}
 
 // readSettingsDoc reads and parses settings.json, returning the full document.
 // If the file does not exist, an empty document is returned.
@@ -854,25 +770,6 @@ func buildUpdaterConfig() updater.Config {
 	}
 }
 
-// printUpdateNotice checks for a newer release and prints a one-line notice
-// to stderr. The 2-second timeout ensures cold misses don't delay startup.
-func printUpdateNotice(cfg updater.Config) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	r, err := updater.Check(ctx, cfg)
-	if err != nil {
-		log.Printf("databricks-claude: update check: %v", err)
-		return
-	}
-	if !r.UpdateAvailable {
-		return
-	}
-	if r.IsHomebrew {
-		fmt.Fprintf(os.Stderr, "databricks-claude: update available (v%s). Run: brew upgrade databricks-claude\n", r.LatestVersion)
-	} else {
-		fmt.Fprintf(os.Stderr, "databricks-claude: update available (v%s). Run: databricks-claude update\n", r.LatestVersion)
-	}
-}
 
 // handlePrintEnv prints resolved configuration with the token redacted.
 func handlePrintEnv(profile, databricksHost, anthropicBaseURL, token, upstreamBinary string, otelEnabled bool, otelMetricsTable, otelLogsTable string) {
@@ -952,51 +849,6 @@ func writePersistentConfig(path string, cfg map[string]interface{}) error {
 	return os.Rename(tmp, path)
 }
 
-// proxyHealthy checks whether the proxy on the given port is responding.
-func proxyHealthy(port int, scheme string) bool {
-	client := &http.Client{Timeout: 500 * time.Millisecond}
-	if scheme == "https" {
-		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-	}
-	resp, err := client.Get(fmt.Sprintf("%s://127.0.0.1:%d/health", scheme, port))
-	if err != nil {
-		return false
-	}
-	resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
-}
-
-// watchProxy polls the proxy health endpoint and takes over the port if the
-// owner process dies. Runs as a goroutine for non-owner sessions.
-func watchProxy(port int, handler http.Handler, tlsCert, tlsKey string) {
-	scheme := "http"
-	if tlsCert != "" && tlsKey != "" {
-		scheme = "https"
-	}
-
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-
-	for range ticker.C {
-		if proxyHealthy(port, scheme) {
-			continue
-		}
-
-		// Proxy is unreachable — try to bind the port and take over.
-		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-		if err != nil {
-			continue // another session grabbed it first
-		}
-		if _, err := proxy.Serve(ln, handler, tlsCert, tlsKey); err != nil {
-			ln.Close()
-			continue
-		}
-		log.Printf("databricks-claude: proxy owner died, took over on :%d", port)
-		return
-	}
-}
 
 // deriveLogsTable derives the OTEL logs table name from the metrics table name.
 // If the metrics table ends with "_otel_metrics", replace that suffix with "_otel_logs".

--- a/main_test.go
+++ b/main_test.go
@@ -14,8 +14,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/IceRhymers/databricks-claude/pkg/lifecycle"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
 )
+
+// shutdownResp mirrors the JSON body returned by POST /shutdown for test decoding.
+type shutdownResp struct {
+	Remaining int  `json:"remaining"`
+	Exiting   bool `json:"exiting"`
+}
 
 // --- parseArgs tests ---
 
@@ -864,7 +871,7 @@ func TestShutdown_DecrementsRefcount(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	handler := wrapWithLifecycle(inner, refcountPath, true, 0, "", doneCh)
+	handler := lifecycle.WrapWithLifecycle(lifecycle.Config{Inner: inner, RefcountPath: refcountPath, IsOwner: true, DoneCh: doneCh, LogPrefix: "test"})
 
 	// First shutdown: refcount goes from 2 to 1.
 	req := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
@@ -874,7 +881,7 @@ func TestShutdown_DecrementsRefcount(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
-	var resp shutdownResponse
+	var resp shutdownResp
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
 	}
@@ -894,7 +901,7 @@ func TestShutdown_DecrementsRefcount(t *testing.T) {
 	rec2 := httptest.NewRecorder()
 	handler.ServeHTTP(rec2, req2)
 
-	var resp2 shutdownResponse
+	var resp2 shutdownResp
 	if err := json.NewDecoder(rec2.Body).Decode(&resp2); err != nil {
 		t.Fatal(err)
 	}
@@ -915,7 +922,7 @@ func TestShutdown_MethodNotAllowed(t *testing.T) {
 	doneCh := make(chan struct{})
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	refcountPath := filepath.Join(t.TempDir(), "refcount")
-	handler := wrapWithLifecycle(inner, refcountPath, true, 0, "", doneCh)
+	handler := lifecycle.WrapWithLifecycle(lifecycle.Config{Inner: inner, RefcountPath: refcountPath, IsOwner: true, DoneCh: doneCh, LogPrefix: "test"})
 
 	req := httptest.NewRequest(http.MethodGet, "/shutdown", nil)
 	rec := httptest.NewRecorder()
@@ -930,7 +937,7 @@ func TestShutdown_RequiresAPIKey(t *testing.T) {
 	doneCh := make(chan struct{})
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	refcountPath := filepath.Join(t.TempDir(), "refcount")
-	handler := wrapWithLifecycle(inner, refcountPath, true, 0, "my-secret-key", doneCh)
+	handler := lifecycle.WrapWithLifecycle(lifecycle.Config{Inner: inner, RefcountPath: refcountPath, IsOwner: true, APIKey: "my-secret-key", DoneCh: doneCh, LogPrefix: "test"})
 
 	// No auth header → 401.
 	req := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
@@ -970,7 +977,7 @@ func TestShutdown_PassesThrough(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	refcountPath := filepath.Join(t.TempDir(), "refcount")
-	handler := wrapWithLifecycle(inner, refcountPath, true, 0, "", doneCh)
+	handler := lifecycle.WrapWithLifecycle(lifecycle.Config{Inner: inner, RefcountPath: refcountPath, IsOwner: true, DoneCh: doneCh, LogPrefix: "test"})
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/messages", nil)
 	rec := httptest.NewRecorder()
@@ -987,7 +994,7 @@ func TestIdleTimeout_TriggersShutdown(t *testing.T) {
 	doneCh := make(chan struct{})
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	refcountPath := filepath.Join(t.TempDir(), "refcount")
-	_ = wrapWithLifecycle(inner, refcountPath, true, 50*time.Millisecond, "", doneCh)
+	_ = lifecycle.WrapWithLifecycle(lifecycle.Config{Inner: inner, RefcountPath: refcountPath, IsOwner: true, IdleTimeout: 50 * time.Millisecond, DoneCh: doneCh, LogPrefix: "test"})
 
 	select {
 	case <-doneCh:
@@ -1003,7 +1010,7 @@ func TestIdleTimeout_ResetByRequest(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	refcountPath := filepath.Join(t.TempDir(), "refcount")
-	handler := wrapWithLifecycle(inner, refcountPath, true, 100*time.Millisecond, "", doneCh)
+	handler := lifecycle.WrapWithLifecycle(lifecycle.Config{Inner: inner, RefcountPath: refcountPath, IsOwner: true, IdleTimeout: 100 * time.Millisecond, DoneCh: doneCh, LogPrefix: "test"})
 
 	// Send a request at 60ms to reset the timer.
 	time.Sleep(60 * time.Millisecond)
@@ -1034,7 +1041,7 @@ func TestIdleTimeout_ZeroDisables(t *testing.T) {
 	doneCh := make(chan struct{})
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	refcountPath := filepath.Join(t.TempDir(), "refcount")
-	_ = wrapWithLifecycle(inner, refcountPath, true, 0, "", doneCh)
+	_ = lifecycle.WrapWithLifecycle(lifecycle.Config{Inner: inner, RefcountPath: refcountPath, IsOwner: true, DoneCh: doneCh, LogPrefix: "test"})
 
 	time.Sleep(100 * time.Millisecond)
 	select {

--- a/pkg/headless/headless.go
+++ b/pkg/headless/headless.go
@@ -1,0 +1,97 @@
+// Package headless provides the headless-ensure logic shared across
+// databricks-claude, databricks-codex, and databricks-opencode.
+package headless
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/IceRhymers/databricks-claude/pkg/health"
+	"github.com/IceRhymers/databricks-claude/pkg/refcount"
+)
+
+// Config holds the parameters for Ensure.
+type Config struct {
+	// Port is the proxy port to check/start.
+	Port int
+
+	// Scheme is "http" or "https" for health checks. Typically "http" for
+	// the headless-ensure path since TLS is not yet negotiated.
+	Scheme string
+
+	// ManagedEnvVar is the environment variable that, when set to "1",
+	// causes Ensure to skip (e.g. "DATABRICKS_CLAUDE_MANAGED").
+	ManagedEnvVar string
+
+	// BinaryPath is the path to the binary to launch in headless mode.
+	// If empty, os.Executable() is used.
+	BinaryPath string
+
+	// LogPrefix is the string used in log messages (e.g. "databricks-claude").
+	LogPrefix string
+
+	// RefcountPath, when non-empty, causes Ensure to acquire/release the
+	// refcount around the operation (claude behavior). When empty, refcount
+	// is skipped (codex/opencode behavior).
+	RefcountPath string
+}
+
+// Ensure checks whether the proxy is healthy on the given port.
+// If not, it starts a detached headless proxy and polls until ready (max 10s).
+func Ensure(cfg Config) {
+	if cfg.ManagedEnvVar != "" && os.Getenv(cfg.ManagedEnvVar) == "1" {
+		log.Printf("%s: --headless-ensure: skipped (managed session)", cfg.LogPrefix)
+		return
+	}
+
+	// Acquire refcount FIRST so every ensure/release pair is symmetric.
+	if cfg.RefcountPath != "" {
+		if err := refcount.Acquire(cfg.RefcountPath); err != nil {
+			log.Printf("%s: --headless-ensure: refcount acquire warning: %v", cfg.LogPrefix, err)
+		}
+	}
+
+	if health.IsProxyHealthy(cfg.Port) {
+		return // already running, refcount incremented
+	}
+
+	self := cfg.BinaryPath
+	if self == "" {
+		var err error
+		self, err = os.Executable()
+		if err != nil {
+			if cfg.RefcountPath != "" {
+				refcount.Release(cfg.RefcountPath) // undo acquire on failure
+			}
+			log.Fatalf("%s: --headless-ensure: cannot find self: %v", cfg.LogPrefix, err)
+		}
+	}
+
+	cmd := exec.Command(self, "--headless", fmt.Sprintf("--port=%d", cfg.Port))
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		if cfg.RefcountPath != "" {
+			refcount.Release(cfg.RefcountPath) // undo acquire on failure
+		}
+		log.Fatalf("%s: --headless-ensure: failed to start proxy: %v", cfg.LogPrefix, err)
+	}
+	if err := cmd.Process.Release(); err != nil {
+		log.Printf("%s: --headless-ensure: release warning: %v", cfg.LogPrefix, err)
+	}
+
+	// Poll until healthy or timeout.
+	for i := 0; i < 20; i++ {
+		time.Sleep(500 * time.Millisecond)
+		if health.IsProxyHealthy(cfg.Port) {
+			return
+		}
+	}
+	if cfg.RefcountPath != "" {
+		refcount.Release(cfg.RefcountPath) // undo acquire on failure
+	}
+	log.Fatalf("%s: --headless-ensure: proxy did not become healthy within 10s", cfg.LogPrefix)
+}

--- a/pkg/headless/headless_test.go
+++ b/pkg/headless/headless_test.go
@@ -1,0 +1,37 @@
+package headless
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEnsure_ManagedSessionSkips(t *testing.T) {
+	t.Setenv("DATABRICKS_CLAUDE_MANAGED", "1")
+	// Port 99999 has nothing listening. Without the guard this would fatalf.
+	Ensure(Config{
+		Port:          99999,
+		ManagedEnvVar: "DATABRICKS_CLAUDE_MANAGED",
+		LogPrefix:     "test",
+	})
+}
+
+func TestEnsure_AlreadyHealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+
+	// Should return immediately without trying to start a new proxy.
+	Ensure(Config{
+		Port:      port,
+		LogPrefix: "test",
+	})
+}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,0 +1,40 @@
+// Package health provides proxy health-check utilities shared across
+// databricks-claude, databricks-codex, and databricks-opencode.
+package health
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// ProxyHealthy checks whether the proxy on the given port is responding.
+// scheme should be "http" or "https". For https, TLS certificate verification
+// is skipped (the proxy uses a self-signed cert on localhost).
+func ProxyHealthy(port int, scheme string) bool {
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	if scheme == "https" {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+	resp, err := client.Get(fmt.Sprintf("%s://127.0.0.1:%d/health", scheme, port))
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// IsProxyHealthy returns true if the proxy on port responds to GET /health
+// over plain HTTP.
+func IsProxyHealthy(port int) bool {
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -1,0 +1,79 @@
+package health
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProxyHealthy_Healthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	if !ProxyHealthy(port, "http") {
+		t.Error("expected ProxyHealthy to return true for healthy server")
+	}
+}
+
+func TestProxyHealthy_Unhealthy(t *testing.T) {
+	// Use a port with nothing listening.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	if ProxyHealthy(port, "http") {
+		t.Error("expected ProxyHealthy to return false for closed port")
+	}
+}
+
+func TestProxyHealthy_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	if ProxyHealthy(port, "http") {
+		t.Error("expected ProxyHealthy to return false for 503 response")
+	}
+}
+
+func TestIsProxyHealthy_Healthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	if !IsProxyHealthy(port) {
+		t.Error("expected IsProxyHealthy to return true for healthy server")
+	}
+}
+
+func TestIsProxyHealthy_Unhealthy(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	if IsProxyHealthy(port) {
+		t.Error("expected IsProxyHealthy to return false for closed port")
+	}
+}

--- a/pkg/health/watch.go
+++ b/pkg/health/watch.go
@@ -1,0 +1,42 @@
+package health
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/IceRhymers/databricks-claude/pkg/proxy"
+)
+
+// WatchProxy polls the proxy health endpoint and takes over the port if the
+// owner process dies. Runs as a goroutine for non-owner sessions.
+// logPrefix is used for log messages (e.g. "databricks-claude").
+func WatchProxy(port int, handler http.Handler, tlsCert, tlsKey, logPrefix string) {
+	scheme := "http"
+	if tlsCert != "" && tlsKey != "" {
+		scheme = "https"
+	}
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		if ProxyHealthy(port, scheme) {
+			continue
+		}
+
+		// Proxy is unreachable — try to bind the port and take over.
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			continue // another session grabbed it first
+		}
+		if _, err := proxy.Serve(ln, handler, tlsCert, tlsKey); err != nil {
+			ln.Close()
+			continue
+		}
+		log.Printf("%s: proxy owner died, took over on :%d", logPrefix, port)
+		return
+	}
+}

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -1,0 +1,124 @@
+// Package lifecycle provides an HTTP handler wrapper that adds /shutdown and
+// /health endpoints with idle-timeout support. Shared across databricks-claude,
+// databricks-codex, and databricks-opencode.
+package lifecycle
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/IceRhymers/databricks-claude/pkg/refcount"
+)
+
+// Config holds the parameters for WrapWithLifecycle.
+type Config struct {
+	// Inner is the upstream handler to delegate non-lifecycle requests to.
+	Inner http.Handler
+
+	// RefcountPath is the path to the refcount file. When empty, /shutdown
+	// always closes DoneCh (opencode behavior). When set, /shutdown
+	// decrements the refcount and only closes DoneCh when the count reaches
+	// zero and IsOwner is true (claude/codex behavior).
+	RefcountPath string
+
+	// IsOwner indicates whether this process owns the listener.
+	IsOwner bool
+
+	// IdleTimeout is the duration after which the proxy shuts down if no
+	// requests are received. Zero disables the idle timer.
+	IdleTimeout time.Duration
+
+	// APIKey, when non-empty, requires Bearer token auth on /shutdown.
+	APIKey string
+
+	// DoneCh is closed when shutdown is triggered (by /shutdown or idle timeout).
+	DoneCh chan struct{}
+
+	// LogPrefix is the string used in log messages (e.g. "databricks-claude").
+	LogPrefix string
+}
+
+// shutdownResponse is the JSON body returned by POST /shutdown.
+type shutdownResponse struct {
+	Remaining int  `json:"remaining"`
+	Exiting   bool `json:"exiting"`
+}
+
+// WrapWithLifecycle wraps the inner handler with:
+//   - POST /shutdown: decrements refcount (if configured) and conditionally shuts down
+//   - Activity tracking: resets the idle timer on every proxied request
+//
+// It returns the wrapped handler. DoneCh is closed when shutdown is triggered
+// (either via /shutdown or idle timeout). The caller selects on DoneCh to
+// begin cleanup.
+func WrapWithLifecycle(cfg Config) http.Handler {
+	var shutdownOnce sync.Once
+	triggerShutdown := func() {
+		shutdownOnce.Do(func() { close(cfg.DoneCh) })
+	}
+
+	// Idle timer: fires once after IdleTimeout of inactivity.
+	// Reset on every proxied request. time.AfterFunc is goroutine-safe.
+	var idleTimer *time.Timer
+	if cfg.IdleTimeout > 0 {
+		idleTimer = time.AfterFunc(cfg.IdleTimeout, func() {
+			log.Printf("%s: idle timeout (%s), shutting down", cfg.LogPrefix, cfg.IdleTimeout)
+			triggerShutdown()
+		})
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		// Enforce API key if configured (matches requireAPIKey in pkg/proxy).
+		if cfg.APIKey != "" {
+			if r.Header.Get("Authorization") != "Bearer "+cfg.APIKey {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+
+		if cfg.RefcountPath == "" {
+			// No refcount — always shut down (opencode behavior).
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(shutdownResponse{Remaining: 0, Exiting: true})
+			if idleTimer != nil {
+				idleTimer.Stop()
+			}
+			triggerShutdown()
+			return
+		}
+
+		remaining, err := refcount.Release(cfg.RefcountPath)
+		if err != nil {
+			log.Printf("%s: shutdown refcount release error: %v", cfg.LogPrefix, err)
+		}
+		exiting := remaining == 0 && cfg.IsOwner
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(shutdownResponse{Remaining: remaining, Exiting: exiting})
+		if exiting {
+			// Stop idle timer to avoid double-shutdown.
+			if idleTimer != nil {
+				idleTimer.Stop()
+			}
+			triggerShutdown()
+		}
+	})
+
+	// All other routes: reset idle timer, then delegate to inner handler.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if idleTimer != nil {
+			idleTimer.Reset(cfg.IdleTimeout)
+		}
+		cfg.Inner.ServeHTTP(w, r)
+	})
+
+	return mux
+}

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -1,0 +1,117 @@
+package lifecycle
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestWrapWithLifecycle_HealthDelegates(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	doneCh := make(chan struct{})
+	handler := WrapWithLifecycle(Config{
+		Inner:     inner,
+		DoneCh:    doneCh,
+		LogPrefix: "test",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET /health returned %d, want 200", rec.Code)
+	}
+}
+
+func TestWrapWithLifecycle_ShutdownClosesDoneCh_NoRefcount(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	doneCh := make(chan struct{})
+	handler := WrapWithLifecycle(Config{
+		Inner:     inner,
+		DoneCh:    doneCh,
+		LogPrefix: "test",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("POST /shutdown returned %d, want 200", rec.Code)
+	}
+
+	var resp shutdownResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode shutdown response: %v", err)
+	}
+	if !resp.Exiting {
+		t.Error("expected Exiting=true when no refcount path")
+	}
+
+	select {
+	case <-doneCh:
+		// expected
+	case <-time.After(time.Second):
+		t.Error("doneCh was not closed after /shutdown")
+	}
+}
+
+func TestWrapWithLifecycle_ShutdownMethodNotAllowed(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	doneCh := make(chan struct{})
+	handler := WrapWithLifecycle(Config{
+		Inner:     inner,
+		DoneCh:    doneCh,
+		LogPrefix: "test",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/shutdown", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET /shutdown returned %d, want 405", rec.Code)
+	}
+}
+
+func TestWrapWithLifecycle_APIKeyEnforced(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	doneCh := make(chan struct{})
+	handler := WrapWithLifecycle(Config{
+		Inner:     inner,
+		APIKey:    "secret123",
+		DoneCh:    doneCh,
+		LogPrefix: "test",
+	})
+
+	// No auth header.
+	req := httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("POST /shutdown without key returned %d, want 401", rec.Code)
+	}
+
+	// Correct auth header.
+	req = httptest.NewRequest(http.MethodPost, "/shutdown", nil)
+	req.Header.Set("Authorization", "Bearer secret123")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("POST /shutdown with correct key returned %d, want 200", rec.Code)
+	}
+}

--- a/pkg/portbind/listenerport_test.go
+++ b/pkg/portbind/listenerport_test.go
@@ -1,0 +1,27 @@
+package portbind
+
+import (
+	"net"
+	"testing"
+)
+
+func TestListenerPort_FromListener(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	want := ln.Addr().(*net.TCPAddr).Port
+	got := ListenerPort(ln, 99999)
+	if got != want {
+		t.Errorf("ListenerPort(ln, 99999) = %d, want %d", got, want)
+	}
+}
+
+func TestListenerPort_NilFallback(t *testing.T) {
+	got := ListenerPort(nil, 49153)
+	if got != 49153 {
+		t.Errorf("ListenerPort(nil, 49153) = %d, want 49153", got)
+	}
+}

--- a/pkg/portbind/portbind.go
+++ b/pkg/portbind/portbind.go
@@ -33,6 +33,18 @@ func Bind(toolName string, port int) (net.Listener, bool, error) {
 	return ln, true, nil
 }
 
+// ListenerPort extracts the port from a net.Listener, falling back to the
+// given fallback if the listener is nil (e.g., non-owner case).
+func ListenerPort(ln net.Listener, fallback int) int {
+	if ln == nil {
+		return fallback
+	}
+	if addr, ok := ln.Addr().(*net.TCPAddr); ok {
+		return addr.Port
+	}
+	return fallback
+}
+
 // HealthResponse is the response from GET /health.
 type HealthResponse struct {
 	Tool    string `json:"tool"`

--- a/pkg/refcount/pathforport_test.go
+++ b/pkg/refcount/pathforport_test.go
@@ -1,0 +1,15 @@
+package refcount
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPathForPort(t *testing.T) {
+	want := filepath.Join(os.TempDir(), ".databricks-claude-sessions-12345")
+	got := PathForPort(".databricks-claude-sessions", 12345)
+	if got != want {
+		t.Errorf("PathForPort(..., 12345) = %q, want %q", got, want)
+	}
+}

--- a/pkg/refcount/refcount.go
+++ b/pkg/refcount/refcount.go
@@ -2,6 +2,18 @@
 // on Windows).
 package refcount
 
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// PathForPort returns the file path used for cross-process session counting.
+// prefix is the tool-specific prefix (e.g. ".databricks-claude-sessions").
+func PathForPort(prefix string, port int) string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("%s-%d", prefix, port))
+}
+
 // Acquire atomically increments the session counter at path.
 func Acquire(path string) error {
 	return withLock(path, func(c *counter) { c.Count++ })

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1,0 +1,79 @@
+// Package state provides generic JSON state persistence and port resolution
+// shared across databricks-claude, databricks-codex, and databricks-opencode.
+package state
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// Save atomically writes v as indented JSON to path.
+// Parent directories are created as needed.
+func Save[T any](path string, v T) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(dir, ".state-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// Load reads and unmarshals JSON from path into a value of type T.
+// Returns the zero value if the file does not exist or cannot be parsed.
+func Load[T any](path string) (T, error) {
+	var zero T
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return zero, nil
+		}
+		return zero, err
+	}
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		log.Printf("state: invalid state file %s, ignoring: %v", path, err)
+		return zero, nil
+	}
+	return v, nil
+}
+
+// ResolvePort returns the port to use, following the resolution chain:
+//  1. flagPort (if > 0)
+//  2. savedPort (if > 0)
+//  3. defaultPort
+func ResolvePort(flagPort, savedPort, defaultPort int) int {
+	if flagPort > 0 {
+		return flagPort
+	}
+	if savedPort > 0 {
+		return savedPort
+	}
+	return defaultPort
+}

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -1,0 +1,96 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type testState struct {
+	Profile string `json:"profile,omitempty"`
+	Port    int    `json:"port,omitempty"`
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	if err := Save(path, testState{Profile: "aidev", Port: 49154}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := Load[testState](path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Profile != "aidev" {
+		t.Errorf("Profile = %q, want %q", got.Profile, "aidev")
+	}
+	if got.Port != 49154 {
+		t.Errorf("Port = %d, want %d", got.Port, 49154)
+	}
+}
+
+func TestLoad_Missing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.json")
+
+	got, err := Load[testState](path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Profile != "" || got.Port != 0 {
+		t.Errorf("expected zero value from missing file, got %+v", got)
+	}
+}
+
+func TestLoad_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	os.WriteFile(path, []byte("not json"), 0o644)
+
+	got, err := Load[testState](path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Profile != "" {
+		t.Errorf("expected zero value from invalid JSON, got %+v", got)
+	}
+}
+
+func TestSave_Overwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	Save(path, testState{Profile: "first"})
+	Save(path, testState{Profile: "second"})
+
+	got, _ := Load[testState](path)
+	if got.Profile != "second" {
+		t.Errorf("Profile = %q, want %q", got.Profile, "second")
+	}
+}
+
+func TestResolvePort(t *testing.T) {
+	tests := []struct {
+		name        string
+		flagPort    int
+		savedPort   int
+		defaultPort int
+		want        int
+	}{
+		{"flag wins", 9999, 8080, 49153, 9999},
+		{"saved wins over default", 0, 8080, 49153, 8080},
+		{"default when no flag and no saved", 0, 0, 49153, 49153},
+		{"flag wins over default", 5555, 0, 49153, 5555},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolvePort(tc.flagPort, tc.savedPort, tc.defaultPort)
+			if got != tc.want {
+				t.Errorf("ResolvePort(%d, %d, %d) = %d, want %d",
+					tc.flagPort, tc.savedPort, tc.defaultPort, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/updater/notice_test.go
+++ b/pkg/updater/notice_test.go
@@ -1,0 +1,102 @@
+package updater
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPrintUpdateNotice_NoUpdate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(githubRelease{
+			TagName:    "v0.10.0",
+			HTMLURL:    "https://github.com/test/repo/releases/tag/v0.10.0",
+			Prerelease: false,
+		})
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	cacheDir := t.TempDir()
+
+	// Capture stderr.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	PrintUpdateNotice(Config{
+		RepoSlug:       "test/repo",
+		CurrentVersion: "0.10.0",
+		BinaryName:     "mybin",
+		CacheFile:      filepath.Join(cacheDir, "cache.json"),
+	})
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	buf := make([]byte, 1024)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	if strings.Contains(output, "update available") {
+		t.Errorf("unexpected update notice: %s", output)
+	}
+}
+
+func TestPrintUpdateNotice_UpdateAvailable(t *testing.T) {
+	assetName := fmt.Sprintf("mybin-%s-%s", runtime.GOOS, runtime.GOARCH)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(githubRelease{
+			TagName:    "v0.11.0",
+			HTMLURL:    "https://github.com/test/repo/releases/tag/v0.11.0",
+			Prerelease: false,
+			Assets: []githubAsset{
+				{Name: assetName, BrowserDownloadURL: "https://dl.example.com/mybin"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	cacheDir := t.TempDir()
+
+	// Capture stderr.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	PrintUpdateNotice(Config{
+		RepoSlug:       "test/repo",
+		CurrentVersion: "0.10.0",
+		BinaryName:     "mybin",
+		CacheFile:      filepath.Join(cacheDir, "cache.json"),
+	})
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	buf := make([]byte, 1024)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	if !strings.Contains(output, "update available") {
+		t.Errorf("expected update notice, got: %q", output)
+	}
+	if !strings.Contains(output, "mybin") {
+		t.Errorf("expected binary name in output, got: %q", output)
+	}
+}

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -225,6 +226,27 @@ func readCache(path string) (cacheEntry, error) {
 		return cacheEntry{}, fmt.Errorf("parsing cache: %w", err)
 	}
 	return entry, nil
+}
+
+// PrintUpdateNotice checks for a newer release and prints a one-line notice
+// to stderr. The 2-second timeout ensures cold misses don't delay startup.
+// Uses cfg.BinaryName for the log prefix and output message.
+func PrintUpdateNotice(cfg Config) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	r, err := Check(ctx, cfg)
+	if err != nil {
+		log.Printf("%s: update check: %v", cfg.BinaryName, err)
+		return
+	}
+	if !r.UpdateAvailable {
+		return
+	}
+	if r.IsHomebrew {
+		fmt.Fprintf(os.Stderr, "%s: update available (v%s). Run: brew upgrade %s\n", cfg.BinaryName, r.LatestVersion, cfg.BinaryName)
+	} else {
+		fmt.Fprintf(os.Stderr, "%s: update available (v%s). Run: %s update\n", cfg.BinaryName, r.LatestVersion, cfg.BinaryName)
+	}
 }
 
 // writeCache writes the cache file atomically (temp + rename).


### PR DESCRIPTION
## Summary

Closes #78. Extracts duplicated proxy/lifecycle/health/state utility functions from the top-level main package into shared `pkg/` packages. Both `databricks-codex` and `databricks-opencode` already import `databricks-claude/pkg/` — this extends that pattern to the remaining copy-pasted code.

*New packages:*
• `pkg/health/` — `ProxyHealthy(port, scheme)`, `IsProxyHealthy(port)`, `WatchProxy(port, handler, tlsCert, tlsKey, logPrefix)`
• `pkg/lifecycle/` — `WrapWithLifecycle(Config)` with refcount-optional shutdown and idle timeout
• `pkg/state/` — generic `Save[T]`/`Load[T]` (atomic JSON write) and `ResolvePort(flag, saved, default)`
• `pkg/headless/` — `Ensure(Config)` with optional refcount acquire/release

*Additions to existing packages:*
• `pkg/updater/` — `PrintUpdateNotice(cfg)` using `cfg.BinaryName` for log prefix
• `pkg/portbind/` — `ListenerPort(ln, fallback)`
• `pkg/refcount/` — `PathForPort(prefix, port)`

*Caller wiring:*
• `main.go` and `hooks.go` updated to call the new `pkg/` functions
• Local implementations removed (~185 lines deleted)
• All tests updated to use shared packages

*Behavior:* Identical to current — no logic changes, only parameterization of string literals (log prefix, binary name, config path).

## Test plan

- [x] `go test ./...` passes (all 13 packages)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] Follow-up PRs for databricks-codex and databricks-opencode to consume the new packages

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>