### PR TITLE
fix: treat missing settings.json as empty document

### DIFF
--- a/ensureconfig.go
+++ b/ensureconfig.go
@@ -55,9 +55,13 @@ func ensureConfig(proxyURL string, otelEnv map[string]string) error {
 }
 
 // readSettingsJSON reads and parses a settings.json file.
+// If the file does not exist, an empty document is returned.
 func readSettingsJSON(path string) (map[string]interface{}, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]interface{}{}, nil
+		}
 		return nil, err
 	}
 	var doc map[string]interface{}

--- a/main.go
+++ b/main.go
@@ -580,9 +580,13 @@ func listenerPort(ln net.Listener, fallback int) int {
 }
 
 // readSettingsDoc reads and parses settings.json, returning the full document.
+// If the file does not exist, an empty document is returned.
 func readSettingsDoc(path string) (map[string]interface{}, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]interface{}{}, nil
+		}
 		return nil, err
 	}
 	var doc map[string]interface{}


### PR DESCRIPTION
## Summary
- `readSettingsDoc` (main.go) and `readSettingsJSON` (ensureconfig.go) both crashed with a fatal error if `~/.claude/settings.json` did not exist
- Fix: check `os.IsNotExist` and return an empty map instead of propagating the error

## Test plan
- [x] Run `databricks-claude` in an environment where `~/.claude/settings.json` does not exist — should start normally
- [x] Existing behavior preserved when file is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)