### PR TITLE
fix: scheme-aware health check and TLS arg forwarding in headless.Ensure

### DIFF
--- a/pkg/headless/headless.go
+++ b/pkg/headless/headless.go
@@ -37,6 +37,14 @@ type Config struct {
 	// refcount around the operation (claude behavior). When empty, refcount
 	// is skipped (codex/opencode behavior).
 	RefcountPath string
+
+	// TLSCert is the path to the TLS certificate file.
+	// When non-empty, --tls-cert is forwarded to the subprocess.
+	TLSCert string
+
+	// TLSKey is the path to the TLS key file.
+	// When non-empty, --tls-key is forwarded to the subprocess.
+	TLSKey string
 }
 
 // Ensure checks whether the proxy is healthy on the given port.
@@ -54,7 +62,7 @@ func Ensure(cfg Config) {
 		}
 	}
 
-	if health.IsProxyHealthy(cfg.Port) {
+	if health.ProxyHealthy(cfg.Port, cfg.Scheme) {
 		return // already running, refcount incremented
 	}
 
@@ -70,7 +78,7 @@ func Ensure(cfg Config) {
 		}
 	}
 
-	cmd := exec.Command(self, "--headless", fmt.Sprintf("--port=%d", cfg.Port))
+	cmd := exec.Command(self, buildArgs(cfg)...)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	if err := cmd.Start(); err != nil {
@@ -86,7 +94,7 @@ func Ensure(cfg Config) {
 	// Poll until healthy or timeout.
 	for i := 0; i < 20; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if health.IsProxyHealthy(cfg.Port) {
+		if health.ProxyHealthy(cfg.Port, cfg.Scheme) {
 			return
 		}
 	}
@@ -94,4 +102,16 @@ func Ensure(cfg Config) {
 		refcount.Release(cfg.RefcountPath) // undo acquire on failure
 	}
 	log.Fatalf("%s: --headless-ensure: proxy did not become healthy within 10s", cfg.LogPrefix)
+}
+
+// buildArgs constructs the CLI arguments for the detached proxy subprocess.
+func buildArgs(cfg Config) []string {
+	args := []string{"--headless", fmt.Sprintf("--port=%d", cfg.Port)}
+	if cfg.TLSCert != "" {
+		args = append(args, "--tls-cert="+cfg.TLSCert)
+	}
+	if cfg.TLSKey != "" {
+		args = append(args, "--tls-key="+cfg.TLSKey)
+	}
+	return args
 }

--- a/pkg/headless/headless.go
+++ b/pkg/headless/headless.go
@@ -50,6 +50,9 @@ type Config struct {
 // Ensure checks whether the proxy is healthy on the given port.
 // If not, it starts a detached headless proxy and polls until ready (max 10s).
 func Ensure(cfg Config) {
+	if cfg.Scheme == "" {
+		cfg.Scheme = "http"
+	}
 	if cfg.ManagedEnvVar != "" && os.Getenv(cfg.ManagedEnvVar) == "1" {
 		log.Printf("%s: --headless-ensure: skipped (managed session)", cfg.LogPrefix)
 		return

--- a/pkg/headless/headless_test.go
+++ b/pkg/headless/headless_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
@@ -32,6 +33,43 @@ func TestEnsure_AlreadyHealthy(t *testing.T) {
 	// Should return immediately without trying to start a new proxy.
 	Ensure(Config{
 		Port:      port,
+		Scheme:    "http",
 		LogPrefix: "test",
 	})
+}
+
+func TestBuildArgs_NoTLS(t *testing.T) {
+	args := buildArgs(Config{Port: 8080})
+	expected := []string{"--headless", "--port=8080"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Errorf("expected %v, got %v", expected, args)
+	}
+}
+
+func TestBuildArgs_WithTLSCert(t *testing.T) {
+	args := buildArgs(Config{Port: 8080, TLSCert: "/path/to/cert.pem"})
+	expected := []string{"--headless", "--port=8080", "--tls-cert=/path/to/cert.pem"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Errorf("expected %v, got %v", expected, args)
+	}
+}
+
+func TestBuildArgs_WithTLSKey(t *testing.T) {
+	args := buildArgs(Config{Port: 8080, TLSKey: "/path/to/key.pem"})
+	expected := []string{"--headless", "--port=8080", "--tls-key=/path/to/key.pem"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Errorf("expected %v, got %v", expected, args)
+	}
+}
+
+func TestBuildArgs_WithTLSCertAndKey(t *testing.T) {
+	args := buildArgs(Config{
+		Port:    8443,
+		TLSCert: "/cert.pem",
+		TLSKey:  "/key.pem",
+	})
+	expected := []string{"--headless", "--port=8443", "--tls-cert=/cert.pem", "--tls-key=/key.pem"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Errorf("expected %v, got %v", expected, args)
+	}
 }

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -27,14 +27,3 @@ func ProxyHealthy(port int, scheme string) bool {
 	return resp.StatusCode == http.StatusOK
 }
 
-// IsProxyHealthy returns true if the proxy on port responds to GET /health
-// over plain HTTP.
-func IsProxyHealthy(port int) bool {
-	client := &http.Client{Timeout: 500 * time.Millisecond}
-	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
-	if err != nil {
-		return false
-	}
-	resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
-}

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -49,7 +49,8 @@ func TestProxyHealthy_Non200(t *testing.T) {
 	}
 }
 
-func TestIsProxyHealthy_Healthy(t *testing.T) {
+func TestProxyHealthy_SchemeMismatch(t *testing.T) {
+	// Plain-HTTP server should not be detected as healthy when scheme is "https".
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/health" {
 			w.WriteHeader(http.StatusOK)
@@ -60,20 +61,8 @@ func TestIsProxyHealthy_Healthy(t *testing.T) {
 	defer srv.Close()
 
 	port := srv.Listener.Addr().(*net.TCPAddr).Port
-	if !IsProxyHealthy(port) {
-		t.Error("expected IsProxyHealthy to return true for healthy server")
+	if ProxyHealthy(port, "https") {
+		t.Error("expected ProxyHealthy to return false for HTTP server checked with https scheme")
 	}
 }
 
-func TestIsProxyHealthy_Unhealthy(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	ln.Close()
-
-	if IsProxyHealthy(port) {
-		t.Error("expected IsProxyHealthy to return false for closed port")
-	}
-}


### PR DESCRIPTION
## Summary

Closes #83

- *Bug 1*: `headless.Ensure` called `health.IsProxyHealthy` (HTTP-only) instead of `health.ProxyHealthy(port, scheme)`. When the proxy runs with TLS, the health check always failed. Now uses the scheme-aware variant.
- *Bug 2*: When spawning a detached proxy subprocess, `--tls-cert` and `--tls-key` flags were not forwarded. Added `TLSCert` and `TLSKey` fields to `headless.Config` and appended them to subprocess args when set.
- Removed dead code: `IsProxyHealthy` from `pkg/health` (no remaining callers).

## Test plan

- [x] `TestBuildArgs_NoTLS` — TLS args absent when TLSCert/TLSKey empty
- [x] `TestBuildArgs_WithTLSCert` — --tls-cert appears when TLSCert set
- [x] `TestBuildArgs_WithTLSKey` — --tls-key appears when TLSKey set
- [x] `TestBuildArgs_WithTLSCertAndKey` — both flags appear together
- [x] `TestProxyHealthy_SchemeMismatch` — HTTP server not detected as healthy with https scheme
- [x] `TestEnsure_AlreadyHealthy` — updated to pass Scheme field
- [x] `go build ./...` passes
- [x] `go vet ./...` passes