### PR TITLE
feat: document release-please conventional commit requirements

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -23,3 +23,23 @@ GitHub Actions CI pipeline. Runs on pull requests to `master`.
 - CI must pass: `go test ./... -v`, `go vet ./...`, and `go build`.
 
 <!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->
+
+## Release Process (release-please)
+
+Releases are automated via [release-please](https://github.com/googleapis/release-please). It watches commits merged to `master` and opens a release PR automatically — **but only when commits follow the Conventional Commits format**.
+
+### Commit prefix rules
+
+| Prefix | Version bump | When to use |
+|--------|-------------|-------------|
+| `feat:` | minor (0.X.0) | New user-facing feature or behaviour change |
+| `fix:` | patch (0.0.X) | Bug fix |
+| `feat!:` / `fix!:` / `BREAKING CHANGE:` | major (X.0.0) | Breaking API or behaviour change |
+| `chore:`, `docs:`, `refactor:`, `test:` | none | Internal — **will NOT trigger a release PR** |
+
+### Rules for AI agents
+
+- **Every PR that changes user-facing behaviour must include at least one `feat:` or `fix:` commit.** Without it, release-please skips the run and no release PR is opened.
+- Squash-merge is fine — the squash commit message is what release-please reads.
+- `chore:` is safe for housekeeping (formatting, test updates, doc-only changes) but will not produce a release.
+- If a release PR is unexpectedly missing after a merge, check the release workflow logs: the most common cause is a non-conventional commit message.


### PR DESCRIPTION
## Summary

- Documents the conventional commit requirements for release-please in `.github/workflows/AGENTS.md`
- Explains which prefixes trigger a release PR (`feat:`, `fix:`) vs which are skipped (`chore:`, `docs:`, `refactor:`)
- Adds guidance for AI agents to always use `feat:` or `fix:` for user-facing changes

## Context

PR #88 (Opus 4-7 upgrade) used `chore:` prefix which caused release-please to skip the run. This PR documents the requirement so future PRs (especially AI-generated ones) always trigger a release.

## Test plan
- [x] CI passes
- [ ] After merge, release-please should open a release PR for the accumulated `feat:` commits