### PR TITLE
feat: --credential-helper and --generate-desktop-config for Claude Desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 databricks-claude
+databricks-claude-credential-helper
 dist/
 *.exe
 .omc/
+*.mobileconfig
+*.reg

--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,26 @@ LDFLAGS := -s -w -X main.Version=$(VERSION)
 
 .DEFAULT_GOAL := build
 
-## Build the databricks-claude binary
+## Build the databricks-claude binary (and the credential-helper symlink that
+## the Claude Desktop mobileconfig field expects).
 build:
 	go build -ldflags="$(LDFLAGS)" -o databricks-claude .
+	ln -sf databricks-claude databricks-claude-credential-helper
 
-## Install to GOPATH/bin
+## Install to GOPATH/bin (also drops the credential-helper symlink so Claude
+## Desktop's inferenceCredentialHelper can target a stable path).
 install:
 	go install -ldflags="$(LDFLAGS)" .
+	ln -sf databricks-claude "$$(go env GOPATH)/bin/databricks-claude-credential-helper"
 
 ## Run tests with verbose output
 test:
 	go test ./... -v
 
-## Cross-compile for linux/darwin/windows amd64 + arm64
+## Cross-compile for linux/darwin/windows amd64 + arm64. Symlinks for the
+## credential-helper alias are NOT generated here — packagers (brew, .pkg,
+## .deb) are responsible for creating them at install time pointing at a
+## predictable system path.
 dist:
 	mkdir -p dist
 	GOOS=darwin  GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-claude-darwin-arm64  .
@@ -27,7 +34,7 @@ dist:
 
 ## Remove build artifacts
 clean:
-	rm -f databricks-claude
+	rm -f databricks-claude databricks-claude-credential-helper
 	rm -rf dist/
 
 ## Run go vet

--- a/README.md
+++ b/README.md
@@ -115,13 +115,9 @@ databricks-claude --tls-cert cert.pem --tls-key key.pem "explain this codebase"
 | `--version` | | Print version and exit |
 | `--print-env` | | Print resolved configuration (token redacted) and exit |
 | `--help`, `-h` | | Print wrapper flags and the full `claude --help` output, then exit |
-| `--credential-helper` | | Print a fresh Databricks token to stdout (used as Claude Desktop's `inferenceCredentialHelper`). Also dispatched automatically when invoked under the `databricks-claude-credential-helper` symlink. |
-| `--generate-desktop-config` | | Write Claude Desktop MDM configs. Without `--output`, writes both `databricks-claude-desktop.mobileconfig` and `databricks-claude-desktop.reg` so one invocation covers macOS and Windows. |
-| `--output` | | Single output path for `--generate-desktop-config`; format inferred from `.mobileconfig` / `.reg` extension or host OS. |
-| `--binary-path` | derived from running binary | Credential-helper path baked into the generated config. Set this for MDM rollouts so one config works on every endpoint. |
-| `--databricks-cli-path` | | Pin the absolute path of the `databricks` CLI used by the credential helper subprocess. Persisted to `~/.claude/.databricks-claude.json`. Useful when the CLI is installed somewhere the launchd-PATH fallback dir scan can't see. |
-
 All other flags and args are forwarded to `claude`.
+
+Claude Desktop integration lives under the `desktop` subcommand — see [Claude Desktop Integration](#claude-desktop-integration) below or run `databricks-claude desktop` for its action list and flags.
 
 ## Auto-Discovery
 
@@ -143,9 +139,9 @@ If workspace ID resolution fails, it falls back to `<host>/serving-endpoints/ant
 2. **Authenticate** with the workspace you want Desktop to talk to: `databricks auth login --profile <name>`.
 3. **Generate the desktop config:**
    ```bash
-   databricks-claude --profile <name> --generate-desktop-config
+   databricks-claude desktop generate-config --profile <name>
    ```
-   This writes both `databricks-claude-desktop.mobileconfig` (macOS) and `databricks-claude-desktop.reg` (Windows) into the current directory.
+   This writes both `databricks-claude-desktop.mobileconfig` (macOS) and `databricks-claude-desktop.reg` (Windows) into the current directory. Pass `--output <path>` for a single file.
 4. **Install the config:**
    - **macOS**: `open databricks-claude-desktop.mobileconfig`, then approve in System Settings → Privacy & Security → Profiles.
    - **Windows**: double-click the `.reg` file, or `reg import databricks-claude-desktop.reg`.
@@ -163,9 +159,8 @@ For rolling this out to a fleet via Jamf, Kandji, Intune, etc., generate the con
 
 ```bash
 # Bake fleet-wide paths into the generated config
-databricks-claude \
+databricks-claude desktop generate-config \
   --profile <name> \
-  --generate-desktop-config \
   --binary-path /usr/local/bin/databricks-claude-credential-helper \
   --databricks-cli-path /usr/local/bin/databricks
 ```

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ If workspace ID resolution fails, it falls back to `<host>/serving-endpoints/ant
 
 `databricks-claude` can act as the credential helper for the Claude Desktop app's third-party-inference mode. Desktop calls a single executable (no args allowed) once per token TTL and uses whatever it prints to stdout as the bearer token for AI Gateway requests.
 
+> ⚠️ **Uninstall the session hooks first** if you previously installed them: `databricks-claude --uninstall-hooks`. Otherwise the SessionStart hook will fire whenever you use Claude Code embedded in Desktop and start an unused proxy in the background. See [Hooks vs Claude Desktop](#hooks-vs-claude-desktop) for the full reasoning.
+
 ### One-time setup
 
 1. **Install** `databricks-claude` (Homebrew, `make install`, or `go install`). All install methods drop a `databricks-claude-credential-helper` symlink next to the main binary; that symlink is the path Claude Desktop will invoke.
@@ -178,6 +180,24 @@ The helper logs every invocation (best-effort, silent on failure) to:
 
 Each entry records the resolved profile, CLI path, and either the token length on success or the underlying error. If Desktop reports `invalid_config` or 401, check this log first.
 
+### Hooks vs Claude Desktop
+
+The proxy can be wired into Claude Code in two different ways:
+
+1. **Session hooks** (`databricks-claude --install-hooks`) — registered in `~/.claude/settings.json`. Every Claude Code session that reads that file fires `SessionStart` to bring up the local proxy and points `ANTHROPIC_BASE_URL` at it.
+2. **Claude Desktop mobileconfig** (`databricks-claude desktop generate-config` + install) — installs an MDM profile that points Claude Desktop's third-party-inference path at the AI Gateway via the credential helper.
+
+Claude Desktop ships with Claude Code embedded, and the embedded Claude Code reads the same `~/.claude/settings.json` for skills, plugins, and hooks — so if both modes are configured, every Claude Code session inside Desktop also fires the hook. That spins up the local proxy on session start, but Claude Desktop's inference path is governed by the MDM profile (managed preferences), not by the `ANTHROPIC_BASE_URL` env var the hook sets. The result is a stray proxy that never receives traffic, plus settings churn from the hook lifecycle.
+
+**Pick one mode based on where you actually want to talk to Databricks from:**
+
+| Primary client | Recommended setup |
+|----------------|-------------------|
+| CLI Claude Code, VS Code extension, JetBrains plugin | **Hooks** (`databricks-claude --install-hooks`). Don't install the Claude Desktop mobileconfig. |
+| Claude Desktop (chat UI and/or embedded Claude Code) | **Mobileconfig** (`databricks-claude desktop generate-config` + install in System Settings). Run `databricks-claude --uninstall-hooks` if hooks were previously installed. When you want a CLI Claude Code session against Databricks, invoke `databricks-claude` directly — the proxy runs for that session only. |
+
+The two modes are independent — neither requires the other — and the binary supports either. The collision only shows up if you try to run both at once.
+
 ## Headless Mode
 
 `--headless` starts the proxy without launching a `claude` child process, for use by IDE extensions and external tooling.
@@ -196,6 +216,14 @@ databricks-claude --headless
 ## Session Hooks (automatic proxy lifecycle)
 
 Install hooks so every Claude Code session auto-starts the proxy on startup and releases it cleanly on exit — no manual `--headless` needed.
+
+> ⚠️ **Don't combine hooks with Claude Desktop integration.** Claude Desktop's embedded Claude Code reads `~/.claude/settings.json` for skills, plugins, and hooks, so the SessionStart hook fires whenever you start a Claude Code session inside Desktop too. The proxy will spin up — but Desktop won't actually route inference through it (Desktop uses its own MDM-driven `inferenceCredentialHelper` config), so you end up with an unused proxy plus settings churn from the hook lifecycle.
+>
+> **Pick one mode:**
+> - **Hooks only** — use Claude Code from your terminal (CLI, VS Code, JetBrains). Don't install the Claude Desktop mobileconfig.
+> - **Claude Desktop only** — install the mobileconfig (see [Claude Desktop Integration](#claude-desktop-integration) above) and run `databricks-claude --uninstall-hooks` if you'd installed the hooks. When you want a CLI Claude Code session, invoke `databricks-claude` directly so the proxy runs only for that session.
+>
+> See [Hooks vs Claude Desktop](#hooks-vs-claude-desktop) below for the longer explanation.
 
 > **First-time setup:** Run `databricks-claude` at least once before installing hooks. This writes the correct `ANTHROPIC_BASE_URL` to `~/.claude/settings.json` so the proxy is used for all Claude clients. Once set, the hooks keep the proxy running automatically — including for clients that don't use the `databricks-claude` wrapper directly, such as the [Claude VS Code extension](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude-code) and JetBrains/IntelliJ plugin.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ databricks-claude --tls-cert cert.pem --tls-key key.pem "explain this codebase"
 | `--version` | | Print version and exit |
 | `--print-env` | | Print resolved configuration (token redacted) and exit |
 | `--help`, `-h` | | Print wrapper flags and the full `claude --help` output, then exit |
+| `--credential-helper` | | Print a fresh Databricks token to stdout (used as Claude Desktop's `inferenceCredentialHelper`). Also dispatched automatically when invoked under the `databricks-claude-credential-helper` symlink. |
+| `--generate-desktop-config` | | Write Claude Desktop MDM configs. Without `--output`, writes both `databricks-claude-desktop.mobileconfig` and `databricks-claude-desktop.reg` so one invocation covers macOS and Windows. |
+| `--output` | | Single output path for `--generate-desktop-config`; format inferred from `.mobileconfig` / `.reg` extension or host OS. |
+| `--binary-path` | derived from running binary | Credential-helper path baked into the generated config. Set this for MDM rollouts so one config works on every endpoint. |
+| `--databricks-cli-path` | | Pin the absolute path of the `databricks` CLI used by the credential helper subprocess. Persisted to `~/.claude/.databricks-claude.json`. Useful when the CLI is installed somewhere the launchd-PATH fallback dir scan can't see. |
 
 All other flags and args are forwarded to `claude`.
 
@@ -127,6 +132,56 @@ On first run (when `ANTHROPIC_BASE_URL` is not set), `databricks-claude` auto-di
 - Constructs the AI Gateway URL: `https://<workspace-id>.ai-gateway.cloud.databricks.com/anthropic`
 
 If workspace ID resolution fails, it falls back to `<host>/serving-endpoints/anthropic`.
+
+## Claude Desktop Integration
+
+`databricks-claude` can act as the credential helper for the Claude Desktop app's third-party-inference mode. Desktop calls a single executable (no args allowed) once per token TTL and uses whatever it prints to stdout as the bearer token for AI Gateway requests.
+
+### One-time setup
+
+1. **Install** `databricks-claude` (Homebrew, `make install`, or `go install`). All install methods drop a `databricks-claude-credential-helper` symlink next to the main binary; that symlink is the path Claude Desktop will invoke.
+2. **Authenticate** with the workspace you want Desktop to talk to: `databricks auth login --profile <name>`.
+3. **Generate the desktop config:**
+   ```bash
+   databricks-claude --profile <name> --generate-desktop-config
+   ```
+   This writes both `databricks-claude-desktop.mobileconfig` (macOS) and `databricks-claude-desktop.reg` (Windows) into the current directory.
+4. **Install the config:**
+   - **macOS**: `open databricks-claude-desktop.mobileconfig`, then approve in System Settings → Privacy & Security → Profiles.
+   - **Windows**: double-click the `.reg` file, or `reg import databricks-claude-desktop.reg`.
+5. **Restart Claude Desktop.**
+
+After this, Desktop's third-party-inference path runs against your Databricks AI Gateway, with tokens refreshed automatically by the credential helper.
+
+### How dispatch works
+
+The `inferenceCredentialHelper` MDM key in the generated config points at `…/databricks-claude-credential-helper` (the symlink). When invoked under that name, the binary checks `argv[0]` and routes directly to the credential-helper code path — no flags required. The same binary still runs as a Claude Code wrapper when invoked under its primary name.
+
+### MDM / fleet rollout
+
+For rolling this out to a fleet via Jamf, Kandji, Intune, etc., generate the config from a reference workstation with paths that match your endpoint layout:
+
+```bash
+# Bake fleet-wide paths into the generated config
+databricks-claude \
+  --profile <name> \
+  --generate-desktop-config \
+  --binary-path /usr/local/bin/databricks-claude-credential-helper \
+  --databricks-cli-path /usr/local/bin/databricks
+```
+
+- `--binary-path` is the absolute path of the credential-helper symlink (or hardlink/copy) on every target endpoint.
+- `--databricks-cli-path` pins the `databricks` CLI absolute path. It's persisted to `~/.claude/.databricks-claude.json` on the generating machine; admins should arrange for the same field to be set on every endpoint (either by running this command per-user, or by dropping the state file via the same MDM tooling).
+
+The packaging method (`.pkg` installer, custom `brew` formula, etc.) is responsible for ensuring `databricks-claude` and its `databricks-claude-credential-helper` symlink land at the paths you embed in the config.
+
+### Troubleshooting
+
+The helper logs every invocation (best-effort, silent on failure) to:
+- macOS: `~/Library/Logs/databricks-claude/credential-helper.log`
+- Linux: `~/.cache/databricks-claude/credential-helper.log`
+
+Each entry records the resolved profile, CLI path, and either the token length on success or the underlying error. If Desktop reports `invalid_config` or 401, check this log first.
 
 ## Headless Mode
 

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -34,11 +34,6 @@ var flagDefs = []completion.FlagDef{
 	{Name: "headless-ensure", Description: "Start proxy if not running — called by the SessionStart hook"},
 	{Name: "headless-release", Description: "Decrement proxy refcount — called by the Stop hook"},
 	{Name: "no-update-check", Description: "Skip the automatic update check on startup"},
-	{Name: "credential-helper", Description: "Print a fresh Databricks token to stdout (called by Claude Desktop inferenceCredentialHelper)"},
-	{Name: "generate-desktop-config", Description: "Generate a Claude Desktop MDM config file (.mobileconfig on macOS, .reg on Windows)"},
-	{Name: "output", Description: "Explicit output path for --generate-desktop-config", TakesArg: true, Completer: "__files"},
-	{Name: "binary-path", Description: "Override the credential-helper path embedded in the generated config (for MDM rollouts)", TakesArg: true, Completer: "__files"},
-	{Name: "databricks-cli-path", Description: "Pin the absolute path to the `databricks` CLI used by the credential helper subprocess", TakesArg: true, Completer: "__files"},
 }
 
 // knownFlags is the set of flag names (with "--" prefix) that databricks-claude

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -34,6 +34,9 @@ var flagDefs = []completion.FlagDef{
 	{Name: "headless-ensure", Description: "Start proxy if not running — called by the SessionStart hook"},
 	{Name: "headless-release", Description: "Decrement proxy refcount — called by the Stop hook"},
 	{Name: "no-update-check", Description: "Skip the automatic update check on startup"},
+	{Name: "credential-helper", Description: "Print a fresh Databricks token to stdout (called by Claude Desktop inferenceCredentialHelper)"},
+	{Name: "generate-desktop-config", Description: "Generate a Claude Desktop MDM config file (.mobileconfig on macOS, .reg on Windows)"},
+	{Name: "output", Description: "Explicit output path for --generate-desktop-config", TakesArg: true, Completer: "__files"},
 }
 
 // knownFlags is the set of flag names (with "--" prefix) that databricks-claude

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -38,6 +38,7 @@ var flagDefs = []completion.FlagDef{
 	{Name: "generate-desktop-config", Description: "Generate a Claude Desktop MDM config file (.mobileconfig on macOS, .reg on Windows)"},
 	{Name: "output", Description: "Explicit output path for --generate-desktop-config", TakesArg: true, Completer: "__files"},
 	{Name: "binary-path", Description: "Override the credential-helper path embedded in the generated config (for MDM rollouts)", TakesArg: true, Completer: "__files"},
+	{Name: "databricks-cli-path", Description: "Pin the absolute path to the `databricks` CLI used by the credential helper subprocess", TakesArg: true, Completer: "__files"},
 }
 
 // knownFlags is the set of flag names (with "--" prefix) that databricks-claude

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -37,6 +37,7 @@ var flagDefs = []completion.FlagDef{
 	{Name: "credential-helper", Description: "Print a fresh Databricks token to stdout (called by Claude Desktop inferenceCredentialHelper)"},
 	{Name: "generate-desktop-config", Description: "Generate a Claude Desktop MDM config file (.mobileconfig on macOS, .reg on Windows)"},
 	{Name: "output", Description: "Explicit output path for --generate-desktop-config", TakesArg: true, Completer: "__files"},
+	{Name: "binary-path", Description: "Override the credential-helper path embedded in the generated config (for MDM rollouts)", TakesArg: true, Completer: "__files"},
 }
 
 // knownFlags is the set of flag names (with "--" prefix) that databricks-claude

--- a/desktop_config.go
+++ b/desktop_config.go
@@ -61,6 +61,74 @@ func isCredentialHelperBinaryName(arg0 string) bool {
 	return base == credentialHelperBinaryName
 }
 
+// runDesktopCommand handles the `databricks-claude desktop ...` subcommand.
+// args is everything after the literal "desktop" token in os.Args.
+func runDesktopCommand(args []string) {
+	if len(args) == 0 {
+		printDesktopHelp()
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "-h", "--help":
+		printDesktopHelp()
+		os.Exit(0)
+	case "generate-config":
+		runGenerateDesktopConfig(
+			extractProfileFlag(args[1:]),
+			extractOutputFlag(args[1:]),
+			extractBinaryPathFlag(args[1:]),
+			extractDatabricksCLIPathFlag(args[1:]),
+		)
+	case "credential-helper":
+		runCredentialHelper(extractProfileFlag(args[1:]))
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-claude: unknown desktop action %q\n\n", args[0])
+		printDesktopHelp()
+		os.Exit(1)
+	}
+}
+
+func printDesktopHelp() {
+	fmt.Fprint(os.Stderr, `Usage: databricks-claude desktop <action> [flags]
+
+Set up Claude Desktop's third-party-inference integration with Databricks.
+
+Actions:
+  generate-config     Write Claude Desktop MDM configs. Without --output, writes
+                      both databricks-claude-desktop.mobileconfig (macOS) and
+                      databricks-claude-desktop.reg (Windows) into the current
+                      directory.
+  credential-helper   Print a fresh Databricks token to stdout — the same code
+                      path Claude Desktop's inferenceCredentialHelper invokes
+                      via the databricks-claude-credential-helper symlink.
+                      Useful for scripting and debug.
+
+Flags:
+  --profile string              Databricks CLI profile (default: state file > DEFAULT)
+  --output string               Single output path for generate-config; format
+                                inferred from .mobileconfig/.reg extension or host OS.
+  --binary-path string          generate-config: credential-helper path embedded in
+                                the generated config (default: derived from the
+                                running binary). Use this for MDM rollouts so one
+                                config works on every endpoint.
+  --databricks-cli-path string  generate-config: pin the absolute path of the
+                                'databricks' CLI used by the credential helper.
+                                Persisted to ~/.claude/.databricks-claude.json.
+
+Examples:
+  # First-time setup on your Mac.
+  databricks-claude desktop generate-config --profile myws
+
+  # MDM rollout — bake fleet-wide paths into one config.
+  databricks-claude desktop generate-config --profile myws \
+    --binary-path /usr/local/bin/databricks-claude-credential-helper \
+    --databricks-cli-path /usr/local/bin/databricks
+
+  # Print a token directly (debug; equivalent to invoking the helper symlink).
+  databricks-claude desktop credential-helper --profile myws
+`)
+}
+
 // runCredentialHelper fetches a fresh Databricks OAuth token and writes only
 // the raw token to stdout. Intended to be called by Claude Desktop via the
 // inferenceCredentialHelper MDM key. Stays silent on stderr on success.

--- a/desktop_config.go
+++ b/desktop_config.go
@@ -75,18 +75,19 @@ func runCredentialHelper(profile string) {
 	helperDebugLog("invoked args=%q HOME=%q PATH=%q USER=%q",
 		os.Args, os.Getenv("HOME"), os.Getenv("PATH"), os.Getenv("USER"))
 
+	state := loadState()
 	resolved := profile
-	if resolved == "" {
-		if saved := loadState(); saved.Profile != "" {
-			resolved = saved.Profile
-		}
+	if resolved == "" && state.Profile != "" {
+		resolved = state.Profile
 	}
 	if resolved == "" {
 		resolved = "DEFAULT"
 	}
-	helperDebugLog("profile resolved=%q (input=%q)", resolved, profile)
+	helperDebugLog("profile resolved=%q (input=%q) cli_path=%q", resolved, profile, state.DatabricksCLIPath)
 
-	tp := NewTokenProvider(resolved, "")
+	// state.DatabricksCLIPath ("" → fall through to PATH/fallback scan in
+	// resolveDatabricksCLI) overrides the default "databricks" lookup.
+	tp := NewTokenProvider(resolved, state.DatabricksCLIPath)
 	tok, err := tp.Token(context.Background())
 	if err != nil {
 		helperDebugLog("FAIL profile=%q err=%v", resolved, err)
@@ -122,7 +123,17 @@ func runCredentialHelper(profile string) {
 // config (e.g. /usr/local/bin/databricks-claude-credential-helper) so the same
 // .mobileconfig works on every endpoint regardless of the generating user's
 // install layout. When empty, the path is derived from the running binary.
-func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride string) {
+//
+// databricksCLIPath, when non-empty, is persisted to the state file so the
+// credential helper subprocess (which has no way to receive flags) can pin
+// the `databricks` binary location. Useful when the CLI is installed at a
+// non-standard path that the fallback dir scan in resolveDatabricksCLI
+// wouldn't find.
+//
+// When outputPath is empty, both .mobileconfig and .reg are always written so
+// one invocation produces artifacts for every supported Claude Desktop
+// platform. Use --output to write a single specific file.
+func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride, databricksCLIPath string) {
 	log.SetOutput(io.Discard)
 
 	resolved := profile
@@ -133,6 +144,26 @@ func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride string) {
 	}
 	if resolved == "" {
 		resolved = "DEFAULT"
+	}
+
+	// Validate and persist the databricks-cli-path BEFORE network calls so a
+	// bad path fails fast.
+	if databricksCLIPath != "" {
+		if !filepath.IsAbs(databricksCLIPath) {
+			fmt.Fprintf(os.Stderr, "databricks-claude: --databricks-cli-path must be absolute, got %q\n", databricksCLIPath)
+			os.Exit(1)
+		}
+		if !isExecutableFile(databricksCLIPath) {
+			fmt.Fprintf(os.Stderr, "databricks-claude: --databricks-cli-path %q is not an executable file\n", databricksCLIPath)
+			os.Exit(1)
+		}
+		st := loadState()
+		st.DatabricksCLIPath = databricksCLIPath
+		if err := saveState(st); err != nil {
+			fmt.Fprintf(os.Stderr, "databricks-claude: failed to persist databricks-cli-path: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "Pinned databricks CLI path: %s\n", databricksCLIPath)
 	}
 
 	host, err := DiscoverHost(resolved, "")
@@ -166,8 +197,11 @@ func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride string) {
 		os.Exit(0)
 	}
 
+	// When --output isn't given, write BOTH .mobileconfig and .reg by default
+	// so a single invocation produces an artifact for every supported Claude
+	// Desktop platform.
 	wrote := []string{}
-	if runtime.GOOS == "darwin" || (runtime.GOOS != "darwin" && runtime.GOOS != "windows") {
+	{
 		path := "databricks-claude-desktop.mobileconfig"
 		content, err := buildMobileconfig(gatewayURL, helperPath)
 		if err != nil {
@@ -180,7 +214,7 @@ func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride string) {
 		}
 		wrote = append(wrote, path)
 	}
-	if runtime.GOOS == "windows" || (runtime.GOOS != "darwin" && runtime.GOOS != "windows") {
+	{
 		path := "databricks-claude-desktop.reg"
 		content := buildRegFile(gatewayURL, helperPath)
 		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
@@ -444,6 +478,23 @@ func extractBinaryPathFlag(args []string) string {
 		}
 		if strings.HasPrefix(a, "--binary-path=") {
 			return strings.TrimPrefix(a, "--binary-path=")
+		}
+	}
+	return ""
+}
+
+// extractDatabricksCLIPathFlag is the analogous helper for --databricks-cli-path.
+// Pins the absolute path to the `databricks` binary that the credential
+// helper subprocess will exec. Persisted to the state file so the helper —
+// which can't receive flags — picks it up on each invocation.
+func extractDatabricksCLIPathFlag(args []string) string {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--databricks-cli-path" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "--databricks-cli-path=") {
+			return strings.TrimPrefix(a, "--databricks-cli-path=")
 		}
 	}
 	return ""

--- a/desktop_config.go
+++ b/desktop_config.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"runtime"
+	"strings"
+)
+
+// inferenceModelsJSON is the JSON-encoded model list embedded in the generated
+// Claude Desktop configuration. Kept as a single source of truth so the macOS
+// and Windows generators stay aligned.
+const inferenceModelsJSON = `[{"name":"databricks-claude-opus-4-7","supports1m":true},{"name":"databricks-claude-opus-4-6","supports1m":true},{"name":"databricks-claude-sonnet-4-6","supports1m":true},{"name":"databricks-claude-sonnet-4-5","supports1m":true},{"name":"databricks-claude-haiku-4-5"}]`
+
+// runCredentialHelper fetches a fresh Databricks OAuth token and writes only
+// the raw token to stdout. Intended to be called by Claude Desktop via the
+// inferenceCredentialHelper MDM key. Stays silent on stderr on success.
+//
+// Profile resolution mirrors the main flow: explicit --profile flag > saved
+// state file > "DEFAULT".
+func runCredentialHelper(profile string) {
+	// Suppress all stdlib logging so the upstream tokencache cannot leak
+	// anything onto stderr while Claude Desktop is watching.
+	log.SetOutput(io.Discard)
+
+	resolved := profile
+	if resolved == "" {
+		if saved := loadState(); saved.Profile != "" {
+			resolved = saved.Profile
+		}
+	}
+	if resolved == "" {
+		resolved = "DEFAULT"
+	}
+
+	tp := NewTokenProvider(resolved, "")
+	tok, err := tp.Token(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "databricks-claude: credential helper failed: %v\n", err)
+		os.Exit(1)
+	}
+	tok = strings.TrimSpace(tok)
+	if tok == "" {
+		fmt.Fprintln(os.Stderr, "databricks-claude: credential helper got empty token")
+		os.Exit(1)
+	}
+	// Write raw token, no trailing newline. Desktop reads stdout verbatim.
+	if _, err := io.WriteString(os.Stdout, tok); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// runGenerateDesktopConfig discovers the AI Gateway URL for the active profile
+// and writes a platform-appropriate Claude Desktop MDM config file.
+//
+// On darwin → .mobileconfig (Apple Configuration Profile).
+// On windows → .reg (Windows Registry script).
+// On other OSes both are written so the user can transfer them.
+//
+// If outputPath is non-empty, that single path is used (the platform is
+// inferred from the file extension when present, otherwise from runtime.GOOS).
+func runGenerateDesktopConfig(profile, outputPath string) {
+	log.SetOutput(io.Discard)
+
+	resolved := profile
+	if resolved == "" {
+		if saved := loadState(); saved.Profile != "" {
+			resolved = saved.Profile
+		}
+	}
+	if resolved == "" {
+		resolved = "DEFAULT"
+	}
+
+	host, err := DiscoverHost(resolved, "")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "databricks-claude: failed to discover host for profile %q: %v\n", resolved, err)
+		fmt.Fprintf(os.Stderr, "Run 'databricks auth login --profile %s' first.\n", resolved)
+		os.Exit(1)
+	}
+
+	tp := NewTokenProvider(resolved, "")
+	tok, err := tp.Token(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "databricks-claude: failed to fetch token for profile %q: %v\n", resolved, err)
+		os.Exit(1)
+	}
+	gatewayURL := ConstructGatewayURL(host, tok)
+
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "databricks-claude: cannot resolve own executable path: %v\n", err)
+		os.Exit(1)
+	}
+
+	if outputPath != "" {
+		if err := writeDesktopConfigByPath(outputPath, gatewayURL, exe); err != nil {
+			fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "Wrote Claude Desktop config: %s\n", outputPath)
+		printInstallInstructions(outputPath)
+		os.Exit(0)
+	}
+
+	wrote := []string{}
+	if runtime.GOOS == "darwin" || (runtime.GOOS != "darwin" && runtime.GOOS != "windows") {
+		path := "databricks-claude-desktop.mobileconfig"
+		content, err := buildMobileconfig(gatewayURL, exe)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "databricks-claude: write %s: %v\n", path, err)
+			os.Exit(1)
+		}
+		wrote = append(wrote, path)
+	}
+	if runtime.GOOS == "windows" || (runtime.GOOS != "darwin" && runtime.GOOS != "windows") {
+		path := "databricks-claude-desktop.reg"
+		content := buildRegFile(gatewayURL, exe)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "databricks-claude: write %s: %v\n", path, err)
+			os.Exit(1)
+		}
+		wrote = append(wrote, path)
+	}
+
+	for _, p := range wrote {
+		fmt.Fprintf(os.Stderr, "Wrote Claude Desktop config: %s\n", p)
+	}
+	for _, p := range wrote {
+		printInstallInstructions(p)
+	}
+	os.Exit(0)
+}
+
+// writeDesktopConfigByPath chooses the format based on file extension (or the
+// host OS when no recognised extension is present) and writes to outputPath.
+func writeDesktopConfigByPath(outputPath, gatewayURL, exe string) error {
+	lower := strings.ToLower(outputPath)
+	var content string
+	var err error
+	switch {
+	case strings.HasSuffix(lower, ".mobileconfig"):
+		content, err = buildMobileconfig(gatewayURL, exe)
+	case strings.HasSuffix(lower, ".reg"):
+		content = buildRegFile(gatewayURL, exe)
+	default:
+		// Fall back to host platform.
+		if runtime.GOOS == "windows" {
+			content = buildRegFile(gatewayURL, exe)
+		} else {
+			content, err = buildMobileconfig(gatewayURL, exe)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(outputPath, []byte(content), 0o600)
+}
+
+// printInstallInstructions writes user-facing guidance for the produced file
+// to stderr (so it doesn't pollute stdout if anything is piping the binary).
+func printInstallInstructions(path string) {
+	lower := strings.ToLower(path)
+	switch {
+	case strings.HasSuffix(lower, ".mobileconfig"):
+		fmt.Fprintf(os.Stderr, `
+To install on macOS:
+  1. Open the file:    open %q
+  2. System Settings → Privacy & Security → Profiles → install the
+     "Claude Desktop Third-Party Inference" profile.
+  3. Restart Claude Desktop.
+`, path)
+	case strings.HasSuffix(lower, ".reg"):
+		fmt.Fprintf(os.Stderr, `
+To install on Windows:
+  1. Double-click %q (or run: reg import "%s") to merge the keys
+     into HKEY_CURRENT_USER\SOFTWARE\Policies\Claude.
+  2. Restart Claude Desktop.
+`, path, path)
+	}
+}
+
+// newUUID returns an RFC 4122 v4 UUID string built from 16 random bytes.
+// Pure stdlib (crypto/rand) — no third-party dependency.
+func newUUID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("crypto/rand: %w", err)
+	}
+	// Set version (4) and variant (RFC 4122) bits.
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08X-%04X-%04X-%04X-%012X",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+// buildMobileconfig renders the macOS Claude Desktop Configuration Profile.
+// Two distinct UUIDs are generated: one for the inner payload, one for the
+// outer profile wrapper.
+func buildMobileconfig(gatewayURL, helperPath string) (string, error) {
+	innerUUID, err := newUUID()
+	if err != nil {
+		return "", err
+	}
+	outerUUID, err := newUUID()
+	if err != nil {
+		return "", err
+	}
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>PayloadContent</key>
+		<array>
+			<dict>
+				<key>PayloadType</key>
+				<string>com.anthropic.claudefordesktop</string>
+				<key>PayloadIdentifier</key>
+				<string>com.anthropic.claudefordesktop.settings</string>
+				<key>PayloadUUID</key>
+				<string>` + innerUUID + `</string>
+				<key>PayloadVersion</key>
+				<integer>1</integer>
+				<key>PayloadDisplayName</key>
+				<string>Claude Desktop</string>
+				<key>disableDeploymentModeChooser</key>
+				<true/>
+				<key>inferenceProvider</key>
+				<string>gateway</string>
+				<key>inferenceGatewayBaseUrl</key>
+				<string>` + plistEscape(gatewayURL) + `</string>
+				<key>inferenceGatewayApiKey</key>
+				<string>managed-by-credential-helper</string>
+				<key>inferenceGatewayAuthScheme</key>
+				<string>bearer</string>
+				<key>inferenceModels</key>
+				<string>` + plistEscape(inferenceModelsJSON) + `</string>
+				<key>inferenceCredentialHelper</key>
+				<string>` + plistEscape(helperPath) + `</string>
+				<key>inferenceCredentialHelperTtlSec</key>
+				<integer>55</integer>
+				<key>isClaudeCodeForDesktopEnabled</key>
+				<true/>
+				<key>isDesktopExtensionEnabled</key>
+				<true/>
+				<key>isDesktopExtensionDirectoryEnabled</key>
+				<true/>
+				<key>isDesktopExtensionSignatureRequired</key>
+				<false/>
+				<key>isLocalDevMcpEnabled</key>
+				<true/>
+			</dict>
+		</array>
+		<key>PayloadDisplayName</key>
+		<string>Claude Desktop Third-Party Inference</string>
+		<key>PayloadIdentifier</key>
+		<string>com.anthropic.claudefordesktop.profile</string>
+		<key>PayloadType</key>
+		<string>Configuration</string>
+		<key>PayloadUUID</key>
+		<string>` + outerUUID + `</string>
+		<key>PayloadVersion</key>
+		<integer>1</integer>
+		<key>PayloadScope</key>
+		<string>User</string>
+	</dict>
+</plist>
+`, nil
+}
+
+// plistEscape escapes characters that are illegal inside a plist <string>
+// element: &, <, >. Quotes/apostrophes don't strictly need escaping inside
+// element content but we encode them defensively for safety.
+func plistEscape(s string) string {
+	r := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+		"'", "&apos;",
+	)
+	return r.Replace(s)
+}
+
+// buildRegFile renders a Windows .reg script that writes the Claude Desktop
+// MDM keys under HKCU\SOFTWARE\Policies\Claude.
+func buildRegFile(gatewayURL, helperPath string) string {
+	// .reg uses CRLF line endings and a UTF-16-or-UTF-8-with-BOM header.
+	// Plain UTF-8 with the documented header works on modern Windows.
+	var b strings.Builder
+	b.WriteString("Windows Registry Editor Version 5.00\r\n\r\n")
+	b.WriteString("[HKEY_CURRENT_USER\\SOFTWARE\\Policies\\Claude]\r\n")
+	b.WriteString(`"disableDeploymentModeChooser"=dword:00000001` + "\r\n")
+	b.WriteString(`"inferenceProvider"="gateway"` + "\r\n")
+	fmt.Fprintf(&b, "\"inferenceGatewayBaseUrl\"=\"%s\"\r\n", regEscape(gatewayURL))
+	b.WriteString(`"inferenceGatewayApiKey"="managed-by-credential-helper"` + "\r\n")
+	b.WriteString(`"inferenceGatewayAuthScheme"="bearer"` + "\r\n")
+	fmt.Fprintf(&b, "\"inferenceModels\"=\"%s\"\r\n", regEscape(inferenceModelsJSON))
+	fmt.Fprintf(&b, "\"inferenceCredentialHelper\"=\"%s\"\r\n", regEscape(helperPath))
+	b.WriteString(`"inferenceCredentialHelperTtlSec"="55"` + "\r\n")
+	b.WriteString(`"isClaudeCodeForDesktopEnabled"=dword:00000001` + "\r\n")
+	b.WriteString(`"isDesktopExtensionEnabled"=dword:00000001` + "\r\n")
+	b.WriteString(`"isDesktopExtensionDirectoryEnabled"=dword:00000001` + "\r\n")
+	b.WriteString(`"isDesktopExtensionSignatureRequired"=dword:00000000` + "\r\n")
+	b.WriteString(`"isLocalDevMcpEnabled"=dword:00000001` + "\r\n")
+	return b.String()
+}
+
+// regEscape escapes a string for use inside a Windows .reg REG_SZ value:
+// backslashes and quotes get backslash-escaped.
+func regEscape(s string) string {
+	r := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+	)
+	return r.Replace(s)
+}
+
+// extractProfileFlag scans args for --profile/--profile=value and returns the
+// profile string if present. Used by the early-exit credential-helper and
+// generate-desktop-config paths so they don't have to wait for parseArgs.
+func extractProfileFlag(args []string) string {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--profile" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "--profile=") {
+			return strings.TrimPrefix(a, "--profile=")
+		}
+	}
+	return ""
+}
+
+// extractOutputFlag is the analogous helper for --output / --output=value.
+func extractOutputFlag(args []string) string {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--output" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "--output=") {
+			return strings.TrimPrefix(a, "--output=")
+		}
+	}
+	return ""
+}
+
+// hasFlag returns true if any element of args equals name (or starts with
+// name+"="). Used for early-exit flag detection at the top of main().
+func hasFlag(args []string, name string) bool {
+	for _, a := range args {
+		if a == name || strings.HasPrefix(a, name+"=") {
+			return true
+		}
+	}
+	return false
+}

--- a/desktop_config.go
+++ b/desktop_config.go
@@ -7,14 +7,59 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
+
+// helperDebugLog appends a single diagnostic line to
+// ~/Library/Logs/databricks-claude/credential-helper.log (or the platform
+// equivalent). Best-effort: failures are silent. Used only to diagnose how
+// Claude Desktop spawns the helper.
+func helperDebugLog(format string, args ...any) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return
+	}
+	dir := filepath.Join(home, "Library", "Logs", "databricks-claude")
+	if runtime.GOOS != "darwin" {
+		dir = filepath.Join(home, ".cache", "databricks-claude")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(dir, "credential-helper.log"),
+		os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "%s pid=%d ppid=%d ", time.Now().Format(time.RFC3339Nano), os.Getpid(), os.Getppid())
+	fmt.Fprintf(f, format, args...)
+	fmt.Fprintln(f)
+}
 
 // inferenceModelsJSON is the JSON-encoded model list embedded in the generated
 // Claude Desktop configuration. Kept as a single source of truth so the macOS
 // and Windows generators stay aligned.
 const inferenceModelsJSON = `[{"name":"databricks-claude-opus-4-7","supports1m":true},{"name":"databricks-claude-opus-4-6","supports1m":true},{"name":"databricks-claude-sonnet-4-6","supports1m":true},{"name":"databricks-claude-sonnet-4-5","supports1m":true},{"name":"databricks-claude-haiku-4-5"}]`
+
+// credentialHelperBinaryName is the basename used to dispatch into
+// runCredentialHelper via argv[0]. Each install method is expected to install
+// a symlink (or hard copy) at this name pointing at the main binary so that
+// Claude Desktop's mobileconfig — which can only specify a path, not args —
+// can target it directly.
+const credentialHelperBinaryName = "databricks-claude-credential-helper"
+
+// isCredentialHelperBinaryName returns true if the program was invoked under
+// the credential-helper alias. Pass os.Args[0] (or any argv[0]-like value).
+func isCredentialHelperBinaryName(arg0 string) bool {
+	base := filepath.Base(arg0)
+	// On Windows the symlink name will carry an .exe suffix.
+	base = strings.TrimSuffix(base, ".exe")
+	return base == credentialHelperBinaryName
+}
 
 // runCredentialHelper fetches a fresh Databricks OAuth token and writes only
 // the raw token to stdout. Intended to be called by Claude Desktop via the
@@ -27,6 +72,9 @@ func runCredentialHelper(profile string) {
 	// anything onto stderr while Claude Desktop is watching.
 	log.SetOutput(io.Discard)
 
+	helperDebugLog("invoked args=%q HOME=%q PATH=%q USER=%q",
+		os.Args, os.Getenv("HOME"), os.Getenv("PATH"), os.Getenv("USER"))
+
 	resolved := profile
 	if resolved == "" {
 		if saved := loadState(); saved.Profile != "" {
@@ -36,20 +84,25 @@ func runCredentialHelper(profile string) {
 	if resolved == "" {
 		resolved = "DEFAULT"
 	}
+	helperDebugLog("profile resolved=%q (input=%q)", resolved, profile)
 
 	tp := NewTokenProvider(resolved, "")
 	tok, err := tp.Token(context.Background())
 	if err != nil {
+		helperDebugLog("FAIL profile=%q err=%v", resolved, err)
 		fmt.Fprintf(os.Stderr, "databricks-claude: credential helper failed: %v\n", err)
 		os.Exit(1)
 	}
 	tok = strings.TrimSpace(tok)
 	if tok == "" {
+		helperDebugLog("FAIL profile=%q empty token", resolved)
 		fmt.Fprintln(os.Stderr, "databricks-claude: credential helper got empty token")
 		os.Exit(1)
 	}
+	helperDebugLog("OK profile=%q tok_len=%d tok_prefix=%q", resolved, len(tok), tok[:min(20, len(tok))])
 	// Write raw token, no trailing newline. Desktop reads stdout verbatim.
 	if _, err := io.WriteString(os.Stdout, tok); err != nil {
+		helperDebugLog("FAIL stdout write err=%v", err)
 		os.Exit(1)
 	}
 	os.Exit(0)
@@ -64,7 +117,12 @@ func runCredentialHelper(profile string) {
 //
 // If outputPath is non-empty, that single path is used (the platform is
 // inferred from the file extension when present, otherwise from runtime.GOOS).
-func runGenerateDesktopConfig(profile, outputPath string) {
+//
+// binaryPathOverride lets MDM admins bake a fleet-wide path into the generated
+// config (e.g. /usr/local/bin/databricks-claude-credential-helper) so the same
+// .mobileconfig works on every endpoint regardless of the generating user's
+// install layout. When empty, the path is derived from the running binary.
+func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride string) {
 	log.SetOutput(io.Discard)
 
 	resolved := profile
@@ -92,14 +150,14 @@ func runGenerateDesktopConfig(profile, outputPath string) {
 	}
 	gatewayURL := ConstructGatewayURL(host, tok)
 
-	exe, err := os.Executable()
+	helperPath, err := resolveHelperPath(binaryPathOverride)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "databricks-claude: cannot resolve own executable path: %v\n", err)
+		fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
 		os.Exit(1)
 	}
 
 	if outputPath != "" {
-		if err := writeDesktopConfigByPath(outputPath, gatewayURL, exe); err != nil {
+		if err := writeDesktopConfigByPath(outputPath, gatewayURL, helperPath); err != nil {
 			fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
 			os.Exit(1)
 		}
@@ -111,7 +169,7 @@ func runGenerateDesktopConfig(profile, outputPath string) {
 	wrote := []string{}
 	if runtime.GOOS == "darwin" || (runtime.GOOS != "darwin" && runtime.GOOS != "windows") {
 		path := "databricks-claude-desktop.mobileconfig"
-		content, err := buildMobileconfig(gatewayURL, exe)
+		content, err := buildMobileconfig(gatewayURL, helperPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
 			os.Exit(1)
@@ -124,7 +182,7 @@ func runGenerateDesktopConfig(profile, outputPath string) {
 	}
 	if runtime.GOOS == "windows" || (runtime.GOOS != "darwin" && runtime.GOOS != "windows") {
 		path := "databricks-claude-desktop.reg"
-		content := buildRegFile(gatewayURL, exe)
+		content := buildRegFile(gatewayURL, helperPath)
 		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 			fmt.Fprintf(os.Stderr, "databricks-claude: write %s: %v\n", path, err)
 			os.Exit(1)
@@ -139,6 +197,28 @@ func runGenerateDesktopConfig(profile, outputPath string) {
 		printInstallInstructions(p)
 	}
 	os.Exit(0)
+}
+
+// resolveHelperPath returns the absolute path embedded into the generated
+// Claude Desktop config. Order:
+//  1. explicit override (e.g. /usr/local/bin/databricks-claude-credential-helper)
+//  2. derived from the running binary: replace its basename with the
+//     credential-helper alias name, preserving the install dir and any .exe
+//     suffix on Windows.
+func resolveHelperPath(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve own executable path: %w", err)
+	}
+	dir := filepath.Dir(exe)
+	name := credentialHelperBinaryName
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(dir, name), nil
 }
 
 // writeDesktopConfigByPath chooses the format based on file extension (or the
@@ -239,8 +319,6 @@ func buildMobileconfig(gatewayURL, helperPath string) (string, error) {
 				<string>gateway</string>
 				<key>inferenceGatewayBaseUrl</key>
 				<string>` + plistEscape(gatewayURL) + `</string>
-				<key>inferenceGatewayApiKey</key>
-				<string>managed-by-credential-helper</string>
 				<key>inferenceGatewayAuthScheme</key>
 				<string>bearer</string>
 				<key>inferenceModels</key>
@@ -303,7 +381,6 @@ func buildRegFile(gatewayURL, helperPath string) string {
 	b.WriteString(`"disableDeploymentModeChooser"=dword:00000001` + "\r\n")
 	b.WriteString(`"inferenceProvider"="gateway"` + "\r\n")
 	fmt.Fprintf(&b, "\"inferenceGatewayBaseUrl\"=\"%s\"\r\n", regEscape(gatewayURL))
-	b.WriteString(`"inferenceGatewayApiKey"="managed-by-credential-helper"` + "\r\n")
 	b.WriteString(`"inferenceGatewayAuthScheme"="bearer"` + "\r\n")
 	fmt.Fprintf(&b, "\"inferenceModels\"=\"%s\"\r\n", regEscape(inferenceModelsJSON))
 	fmt.Fprintf(&b, "\"inferenceCredentialHelper\"=\"%s\"\r\n", regEscape(helperPath))
@@ -351,6 +428,22 @@ func extractOutputFlag(args []string) string {
 		}
 		if strings.HasPrefix(a, "--output=") {
 			return strings.TrimPrefix(a, "--output=")
+		}
+	}
+	return ""
+}
+
+// extractBinaryPathFlag is the analogous helper for --binary-path. Used by
+// MDM admins to override the credential-helper path embedded in the generated
+// Claude Desktop config.
+func extractBinaryPathFlag(args []string) string {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--binary-path" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "--binary-path=") {
+			return strings.TrimPrefix(a, "--binary-path=")
 		}
 	}
 	return ""

--- a/desktop_config_test.go
+++ b/desktop_config_test.go
@@ -249,6 +249,26 @@ func TestIsCredentialHelperBinaryName(t *testing.T) {
 	}
 }
 
+func TestExtractDatabricksCLIPathFlag(t *testing.T) {
+	cases := []struct {
+		args []string
+		want string
+	}{
+		{[]string{}, ""},
+		{[]string{"--generate-desktop-config"}, ""},
+		{[]string{"--databricks-cli-path", "/usr/local/bin/databricks"}, "/usr/local/bin/databricks"},
+		{[]string{"--databricks-cli-path=/opt/homebrew/bin/databricks"}, "/opt/homebrew/bin/databricks"},
+		{[]string{"--generate-desktop-config", "--databricks-cli-path", "/x"}, "/x"},
+		// Bare flag without a value must not panic and must return "".
+		{[]string{"--databricks-cli-path"}, ""},
+	}
+	for _, c := range cases {
+		if got := extractDatabricksCLIPathFlag(c.args); got != c.want {
+			t.Errorf("extractDatabricksCLIPathFlag(%v) = %q, want %q", c.args, got, c.want)
+		}
+	}
+}
+
 func TestExtractBinaryPathFlag(t *testing.T) {
 	cases := []struct {
 		args []string

--- a/desktop_config_test.go
+++ b/desktop_config_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -105,7 +107,6 @@ func TestBuildRegFile_ContainsRequiredKeys(t *testing.T) {
 		`"disableDeploymentModeChooser"=dword:00000001`,
 		`"inferenceProvider"="gateway"`,
 		`"inferenceGatewayBaseUrl"="` + gateway + `"`,
-		`"inferenceGatewayApiKey"="managed-by-credential-helper"`,
 		`"inferenceGatewayAuthScheme"="bearer"`,
 		`"inferenceCredentialHelperTtlSec"="55"`,
 		`"isClaudeCodeForDesktopEnabled"=dword:00000001`,
@@ -217,5 +218,81 @@ func TestHasFlag(t *testing.T) {
 	}
 	if hasFlag(nil, "--credential-helper") {
 		t.Error("hasFlag on nil should return false")
+	}
+}
+
+func TestIsCredentialHelperBinaryName(t *testing.T) {
+	cases := []struct {
+		arg0 string
+		want bool
+	}{
+		{"databricks-claude-credential-helper", true},
+		{"/usr/local/bin/databricks-claude-credential-helper", true},
+		{"/opt/homebrew/bin/databricks-claude-credential-helper", true},
+		{"databricks-claude-credential-helper.exe", true},
+		// Backslash path-separator handling is exercised in the platform-specific
+		// test below; filepath.Base on darwin/linux treats backslashes as
+		// literal characters, so we don't include a Windows-style path here.
+		// Main binary name must NOT trigger helper dispatch.
+		{"databricks-claude", false},
+		{"/usr/local/bin/databricks-claude", false},
+		{"databricks-claude.exe", false},
+		// Near-misses must not match.
+		{"databricks-claude-credential-helper-extra", false},
+		{"my-databricks-claude-credential-helper", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isCredentialHelperBinaryName(c.arg0); got != c.want {
+			t.Errorf("isCredentialHelperBinaryName(%q) = %v, want %v", c.arg0, got, c.want)
+		}
+	}
+}
+
+func TestExtractBinaryPathFlag(t *testing.T) {
+	cases := []struct {
+		args []string
+		want string
+	}{
+		{[]string{}, ""},
+		{[]string{"--generate-desktop-config"}, ""},
+		{[]string{"--binary-path", "/usr/local/bin/databricks-claude-credential-helper"}, "/usr/local/bin/databricks-claude-credential-helper"},
+		{[]string{"--binary-path=/opt/homebrew/bin/databricks-claude-credential-helper"}, "/opt/homebrew/bin/databricks-claude-credential-helper"},
+		{[]string{"--generate-desktop-config", "--binary-path", "/x"}, "/x"},
+		// Bare --binary-path without a value must not panic and must return "".
+		{[]string{"--binary-path"}, ""},
+	}
+	for _, c := range cases {
+		if got := extractBinaryPathFlag(c.args); got != c.want {
+			t.Errorf("extractBinaryPathFlag(%v) = %q, want %q", c.args, got, c.want)
+		}
+	}
+}
+
+func TestResolveHelperPath_Override(t *testing.T) {
+	override := "/usr/local/bin/databricks-claude-credential-helper"
+	got, err := resolveHelperPath(override)
+	if err != nil {
+		t.Fatalf("resolveHelperPath: %v", err)
+	}
+	if got != override {
+		t.Errorf("resolveHelperPath(%q) = %q, want %q", override, got, override)
+	}
+}
+
+func TestResolveHelperPath_DerivedFromExecutable(t *testing.T) {
+	// With no override, the helper path is the running test binary's
+	// directory + the credential-helper alias name. We can't predict the
+	// exact dir but we can assert the basename.
+	got, err := resolveHelperPath("")
+	if err != nil {
+		t.Fatalf("resolveHelperPath: %v", err)
+	}
+	wantBase := credentialHelperBinaryName
+	if runtime.GOOS == "windows" {
+		wantBase += ".exe"
+	}
+	if filepath.Base(got) != wantBase {
+		t.Errorf("resolveHelperPath(\"\") basename = %q, want %q (full=%q)", filepath.Base(got), wantBase, got)
 	}
 }

--- a/desktop_config_test.go
+++ b/desktop_config_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// uuidPattern matches the canonical 8-4-4-4-12 hex UUID layout produced by
+// newUUID(). Hex is upper-case to mirror the format string in newUUID.
+var uuidPattern = regexp.MustCompile(`^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$`)
+
+func TestNewUUID_FormatAndUniqueness(t *testing.T) {
+	a, err := newUUID()
+	if err != nil {
+		t.Fatalf("newUUID: %v", err)
+	}
+	b, err := newUUID()
+	if err != nil {
+		t.Fatalf("newUUID: %v", err)
+	}
+	if !uuidPattern.MatchString(a) {
+		t.Errorf("UUID %q does not match v4 layout", a)
+	}
+	if !uuidPattern.MatchString(b) {
+		t.Errorf("UUID %q does not match v4 layout", b)
+	}
+	if a == b {
+		t.Errorf("two consecutive UUIDs collided: %q", a)
+	}
+}
+
+func TestBuildMobileconfig_ContainsRequiredKeys(t *testing.T) {
+	gateway := "https://abc-123.ai-gateway.cloud.databricks.com/anthropic"
+	helper := "/usr/local/bin/databricks-claude"
+	out, err := buildMobileconfig(gateway, helper)
+	if err != nil {
+		t.Fatalf("buildMobileconfig: %v", err)
+	}
+
+	// Spot-check the must-have keys and values.
+	for _, want := range []string{
+		`<?xml version="1.0" encoding="UTF-8"?>`,
+		`<key>PayloadType</key>`,
+		`<string>com.anthropic.claudefordesktop</string>`,
+		`<key>inferenceProvider</key>`,
+		`<string>gateway</string>`,
+		`<key>inferenceGatewayBaseUrl</key>`,
+		`<string>` + gateway + `</string>`,
+		`<key>inferenceCredentialHelper</key>`,
+		`<string>` + helper + `</string>`,
+		`<key>inferenceCredentialHelperTtlSec</key>`,
+		`<integer>55</integer>`,
+		`<key>inferenceModels</key>`,
+		`databricks-claude-opus-4-7`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("mobileconfig missing %q", want)
+		}
+	}
+}
+
+func TestBuildMobileconfig_EscapesSpecialChars(t *testing.T) {
+	// Gateway URL with an ampersand should be plist-escaped.
+	gateway := "https://example.com/anthropic?a=1&b=2"
+	helper := "/Applications/Foo & Bar/databricks-claude"
+	out, err := buildMobileconfig(gateway, helper)
+	if err != nil {
+		t.Fatalf("buildMobileconfig: %v", err)
+	}
+	if strings.Contains(out, "?a=1&b=2</string>") {
+		t.Errorf("ampersand in gateway URL was not escaped")
+	}
+	if !strings.Contains(out, "?a=1&amp;b=2") {
+		t.Errorf("expected escaped ampersand, got: %s", out)
+	}
+	if !strings.Contains(out, "Foo &amp; Bar") {
+		t.Errorf("expected escaped ampersand in helper path")
+	}
+}
+
+func TestBuildMobileconfig_UniqueUUIDs(t *testing.T) {
+	out, err := buildMobileconfig("https://x", "/bin/x")
+	if err != nil {
+		t.Fatalf("buildMobileconfig: %v", err)
+	}
+	uuidsRe := regexp.MustCompile(`<string>([0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12})</string>`)
+	matches := uuidsRe.FindAllStringSubmatch(out, -1)
+	if len(matches) != 2 {
+		t.Fatalf("expected exactly 2 UUIDs in mobileconfig, got %d", len(matches))
+	}
+	if matches[0][1] == matches[1][1] {
+		t.Errorf("inner and outer UUIDs must differ, got %q for both", matches[0][1])
+	}
+}
+
+func TestBuildRegFile_ContainsRequiredKeys(t *testing.T) {
+	gateway := "https://abc-123.ai-gateway.cloud.databricks.com/anthropic"
+	helper := `C:\Program Files\databricks-claude\databricks-claude.exe`
+	out := buildRegFile(gateway, helper)
+
+	for _, want := range []string{
+		`Windows Registry Editor Version 5.00`,
+		`[HKEY_CURRENT_USER\SOFTWARE\Policies\Claude]`,
+		`"disableDeploymentModeChooser"=dword:00000001`,
+		`"inferenceProvider"="gateway"`,
+		`"inferenceGatewayBaseUrl"="` + gateway + `"`,
+		`"inferenceGatewayApiKey"="managed-by-credential-helper"`,
+		`"inferenceGatewayAuthScheme"="bearer"`,
+		`"inferenceCredentialHelperTtlSec"="55"`,
+		`"isClaudeCodeForDesktopEnabled"=dword:00000001`,
+		`"isDesktopExtensionSignatureRequired"=dword:00000000`,
+		`"isLocalDevMcpEnabled"=dword:00000001`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf(".reg missing %q", want)
+		}
+	}
+
+	// Backslashes in the helper path must be doubled.
+	if !strings.Contains(out, `C:\\Program Files\\databricks-claude\\databricks-claude.exe`) {
+		t.Errorf("helper path backslashes not escaped, got: %s", out)
+	}
+
+	// JSON quotes in the inferenceModels string must be escaped.
+	if !strings.Contains(out, `\"name\":\"databricks-claude-opus-4-7\"`) {
+		t.Errorf("inferenceModels JSON quotes not escaped")
+	}
+
+	// Lines must end with CRLF (the .reg format requires it).
+	if !strings.Contains(out, "\r\n") {
+		t.Errorf(".reg output is missing CRLF line endings")
+	}
+}
+
+func TestRegEscape(t *testing.T) {
+	cases := map[string]string{
+		`plain`:                      `plain`,
+		`with "quotes"`:              `with \"quotes\"`,
+		`C:\path\to\bin`:             `C:\\path\\to\\bin`,
+		`"quote at start`:            `\"quote at start`,
+		`back\slash and "quote"`:     `back\\slash and \"quote\"`,
+	}
+	for in, want := range cases {
+		if got := regEscape(in); got != want {
+			t.Errorf("regEscape(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPlistEscape(t *testing.T) {
+	cases := map[string]string{
+		`plain`:           `plain`,
+		`a & b`:           `a &amp; b`,
+		`<tag>`:           `&lt;tag&gt;`,
+		`he said "hi"`:    `he said &quot;hi&quot;`,
+		`it's & <ok>`:     `it&apos;s &amp; &lt;ok&gt;`,
+	}
+	for in, want := range cases {
+		if got := plistEscape(in); got != want {
+			t.Errorf("plistEscape(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestExtractProfileFlag(t *testing.T) {
+	cases := []struct {
+		args []string
+		want string
+	}{
+		{[]string{}, ""},
+		{[]string{"--credential-helper"}, ""},
+		{[]string{"--profile", "prod", "--credential-helper"}, "prod"},
+		{[]string{"--credential-helper", "--profile", "dev"}, "dev"},
+		{[]string{"--profile=staging"}, "staging"},
+		{[]string{"--credential-helper", "--profile=qa"}, "qa"},
+		// Bare --profile without a value must not panic and must return "".
+		{[]string{"--profile"}, ""},
+	}
+	for _, c := range cases {
+		if got := extractProfileFlag(c.args); got != c.want {
+			t.Errorf("extractProfileFlag(%v) = %q, want %q", c.args, got, c.want)
+		}
+	}
+}
+
+func TestExtractOutputFlag(t *testing.T) {
+	cases := []struct {
+		args []string
+		want string
+	}{
+		{[]string{}, ""},
+		{[]string{"--generate-desktop-config"}, ""},
+		{[]string{"--output", "/tmp/foo.mobileconfig"}, "/tmp/foo.mobileconfig"},
+		{[]string{"--output=/tmp/foo.reg"}, "/tmp/foo.reg"},
+		{[]string{"--generate-desktop-config", "--output", "/tmp/x"}, "/tmp/x"},
+	}
+	for _, c := range cases {
+		if got := extractOutputFlag(c.args); got != c.want {
+			t.Errorf("extractOutputFlag(%v) = %q, want %q", c.args, got, c.want)
+		}
+	}
+}
+
+func TestHasFlag(t *testing.T) {
+	if !hasFlag([]string{"--credential-helper"}, "--credential-helper") {
+		t.Error("hasFlag should match exact flag")
+	}
+	if !hasFlag([]string{"--credential-helper=true"}, "--credential-helper") {
+		t.Error("hasFlag should match --flag=value form")
+	}
+	if hasFlag([]string{"--credential-helper-thing"}, "--credential-helper") {
+		t.Error("hasFlag must not match a flag with a longer name")
+	}
+	if hasFlag([]string{"--other"}, "--credential-helper") {
+		t.Error("hasFlag should not match unrelated flag")
+	}
+	if hasFlag(nil, "--credential-helper") {
+		t.Error("hasFlag on nil should return false")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -69,7 +69,13 @@ func main() {
 	// --credential-helper — invoked by Claude Desktop (inferenceCredentialHelper).
 	// Must be handled VERY early: outputs only the raw token to stdout, exits.
 	// Profile resolution mirrors the main flow (state file > "DEFAULT").
-	if hasFlag(os.Args[1:], "--credential-helper") {
+	//
+	// Two dispatch paths:
+	//   1. Explicit `--credential-helper` flag — useful for scripting/debug.
+	//   2. argv[0] alias `databricks-claude-credential-helper` — Desktop's
+	//      mobileconfig accepts only a path, no args; install methods drop a
+	//      symlink at this name pointing at the main binary.
+	if hasFlag(os.Args[1:], "--credential-helper") || isCredentialHelperBinaryName(os.Args[0]) {
 		runCredentialHelper(extractProfileFlag(os.Args[1:]))
 		// runCredentialHelper always calls os.Exit; this return is unreachable.
 		return
@@ -82,6 +88,7 @@ func main() {
 		runGenerateDesktopConfig(
 			extractProfileFlag(os.Args[1:]),
 			extractOutputFlag(os.Args[1:]),
+			extractBinaryPathFlag(os.Args[1:]),
 		)
 		return
 	}
@@ -737,11 +744,16 @@ Databricks-Claude Flags:
   --install-hooks              Install SessionStart/Stop hooks into ~/.claude/settings.json
   --uninstall-hooks            Remove databricks-claude hooks from ~/.claude/settings.json
   --no-update-check            Skip the automatic update check on startup
-  --credential-helper          Print a fresh Databricks token to stdout (called by Claude
-                               Desktop's inferenceCredentialHelper); honours --profile
+  --credential-helper          Print a fresh Databricks token to stdout (also dispatched
+                               via the databricks-claude-credential-helper symlink that
+                               Claude Desktop's inferenceCredentialHelper points at);
+                               honours --profile
   --generate-desktop-config    Write a Claude Desktop MDM config (.mobileconfig on macOS,
-                               .reg on Windows); honours --profile and --output
+                               .reg on Windows); honours --profile, --output, --binary-path
   --output string              Explicit output path for --generate-desktop-config
+  --binary-path string         Credential-helper path to embed in the generated config
+                               (default: derived from the running binary). Use this for
+                               MDM rollouts so one config works on every endpoint.
   --version                    Print version and exit
   --help, -h                   Show this help message
 

--- a/main.go
+++ b/main.go
@@ -66,31 +66,20 @@ func main() {
 		os.Exit(0)
 	}
 
-	// --credential-helper — invoked by Claude Desktop (inferenceCredentialHelper).
-	// Must be handled VERY early: outputs only the raw token to stdout, exits.
-	// Profile resolution mirrors the main flow (state file > "DEFAULT").
-	//
-	// Two dispatch paths:
-	//   1. Explicit `--credential-helper` flag — useful for scripting/debug.
-	//   2. argv[0] alias `databricks-claude-credential-helper` — Desktop's
-	//      mobileconfig accepts only a path, no args; install methods drop a
-	//      symlink at this name pointing at the main binary.
-	if hasFlag(os.Args[1:], "--credential-helper") || isCredentialHelperBinaryName(os.Args[0]) {
+	// argv[0] alias `databricks-claude-credential-helper` — Desktop's
+	// mobileconfig accepts only a path with no arguments; install methods
+	// drop a symlink at this name pointing at the main binary so Desktop's
+	// inferenceCredentialHelper can target a stable path.
+	if isCredentialHelperBinaryName(os.Args[0]) {
 		runCredentialHelper(extractProfileFlag(os.Args[1:]))
-		// runCredentialHelper always calls os.Exit; this return is unreachable.
 		return
 	}
 
-	// --generate-desktop-config — write the platform-specific Claude Desktop
-	// MDM config file (mobileconfig on macOS, .reg on Windows). Optional
-	// --output <path> selects an explicit target.
-	if hasFlag(os.Args[1:], "--generate-desktop-config") {
-		runGenerateDesktopConfig(
-			extractProfileFlag(os.Args[1:]),
-			extractOutputFlag(os.Args[1:]),
-			extractBinaryPathFlag(os.Args[1:]),
-			extractDatabricksCLIPathFlag(os.Args[1:]),
-		)
+	// `desktop` subcommand — Claude Desktop integration setup. Encapsulates
+	// `generate-config` and an explicit `credential-helper` action so these
+	// flags don't pollute the root flag namespace.
+	if len(os.Args) >= 2 && os.Args[1] == "desktop" {
+		runDesktopCommand(os.Args[2:])
 		return
 	}
 
@@ -745,32 +734,14 @@ Databricks-Claude Flags:
   --install-hooks              Install SessionStart/Stop hooks into ~/.claude/settings.json
   --uninstall-hooks            Remove databricks-claude hooks from ~/.claude/settings.json
   --no-update-check            Skip the automatic update check on startup
-  --credential-helper          Print a fresh Databricks token to stdout (also dispatched
-                               via the databricks-claude-credential-helper symlink that
-                               Claude Desktop's inferenceCredentialHelper points at);
-                               honours --profile
-  --generate-desktop-config    Write Claude Desktop MDM configs. By default writes BOTH
-                               databricks-claude-desktop.mobileconfig (macOS) and
-                               databricks-claude-desktop.reg (Windows) so one invocation
-                               covers every supported platform. Honours --profile,
-                               --output, --binary-path, --databricks-cli-path.
-  --output string              Explicit output path; the format is chosen from the file
-                               extension (.mobileconfig / .reg) or the host OS. When set,
-                               only this single file is written.
-  --binary-path string         Credential-helper path to embed in the generated config
-                               (default: derived from the running binary). Use this for
-                               MDM rollouts so one config works on every endpoint.
-  --databricks-cli-path string Pin the absolute path of the 'databricks' CLI binary used
-                               by the credential helper subprocess. Persisted to the
-                               state file (~/.claude/.databricks-claude.json). Useful
-                               when the CLI is installed somewhere the launchd-PATH
-                               fallback dir scan can't see.
   --version                    Print version and exit
   --help, -h                   Show this help message
 
 Subcommands:
   completion <shell>           Generate shell completions (bash, zsh, fish)
   update                       Check for a newer release and print upgrade instructions
+  desktop <action>             Claude Desktop integration. Run 'databricks-claude desktop'
+                               for actions (generate-config, credential-helper) and flags.
 
 Example Unity Catalog table setup (run in a Databricks SQL warehouse):
 

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func main() {
 			extractProfileFlag(os.Args[1:]),
 			extractOutputFlag(os.Args[1:]),
 			extractBinaryPathFlag(os.Args[1:]),
+			extractDatabricksCLIPathFlag(os.Args[1:]),
 		)
 		return
 	}
@@ -748,12 +749,22 @@ Databricks-Claude Flags:
                                via the databricks-claude-credential-helper symlink that
                                Claude Desktop's inferenceCredentialHelper points at);
                                honours --profile
-  --generate-desktop-config    Write a Claude Desktop MDM config (.mobileconfig on macOS,
-                               .reg on Windows); honours --profile, --output, --binary-path
-  --output string              Explicit output path for --generate-desktop-config
+  --generate-desktop-config    Write Claude Desktop MDM configs. By default writes BOTH
+                               databricks-claude-desktop.mobileconfig (macOS) and
+                               databricks-claude-desktop.reg (Windows) so one invocation
+                               covers every supported platform. Honours --profile,
+                               --output, --binary-path, --databricks-cli-path.
+  --output string              Explicit output path; the format is chosen from the file
+                               extension (.mobileconfig / .reg) or the host OS. When set,
+                               only this single file is written.
   --binary-path string         Credential-helper path to embed in the generated config
                                (default: derived from the running binary). Use this for
                                MDM rollouts so one config works on every endpoint.
+  --databricks-cli-path string Pin the absolute path of the 'databricks' CLI binary used
+                               by the credential helper subprocess. Persisted to the
+                               state file (~/.claude/.databricks-claude.json). Useful
+                               when the CLI is installed somewhere the launchd-PATH
+                               fallback dir scan can't see.
   --version                    Print version and exit
   --help, -h                   Show this help message
 

--- a/main.go
+++ b/main.go
@@ -66,6 +66,26 @@ func main() {
 		os.Exit(0)
 	}
 
+	// --credential-helper — invoked by Claude Desktop (inferenceCredentialHelper).
+	// Must be handled VERY early: outputs only the raw token to stdout, exits.
+	// Profile resolution mirrors the main flow (state file > "DEFAULT").
+	if hasFlag(os.Args[1:], "--credential-helper") {
+		runCredentialHelper(extractProfileFlag(os.Args[1:]))
+		// runCredentialHelper always calls os.Exit; this return is unreachable.
+		return
+	}
+
+	// --generate-desktop-config — write the platform-specific Claude Desktop
+	// MDM config file (mobileconfig on macOS, .reg on Windows). Optional
+	// --output <path> selects an explicit target.
+	if hasFlag(os.Args[1:], "--generate-desktop-config") {
+		runGenerateDesktopConfig(
+			extractProfileFlag(os.Args[1:]),
+			extractOutputFlag(os.Args[1:]),
+		)
+		return
+	}
+
 	// Parse databricks-claude flags, passing everything else through to claude.
 	// Usage: databricks-claude [databricks-claude-flags] [--] [claude-args...]
 	// Unknown flags are forwarded to claude automatically.
@@ -717,6 +737,11 @@ Databricks-Claude Flags:
   --install-hooks              Install SessionStart/Stop hooks into ~/.claude/settings.json
   --uninstall-hooks            Remove databricks-claude hooks from ~/.claude/settings.json
   --no-update-check            Skip the automatic update check on startup
+  --credential-helper          Print a fresh Databricks token to stdout (called by Claude
+                               Desktop's inferenceCredentialHelper); honours --profile
+  --generate-desktop-config    Write a Claude Desktop MDM config (.mobileconfig on macOS,
+                               .reg on Windows); honours --profile and --output
+  --output string              Explicit output path for --generate-desktop-config
   --version                    Print version and exit
   --help, -h                   Show this help message
 

--- a/state.go
+++ b/state.go
@@ -12,6 +12,14 @@ import (
 type persistentState struct {
 	Profile string `json:"profile,omitempty"`
 	Port    int    `json:"port,omitempty"`
+	// DatabricksCLIPath pins the absolute path to the `databricks` CLI binary.
+	// Used by the credential helper running under Claude Desktop's GUI subprocess
+	// context, where the inherited PATH (launchd's /usr/bin:/bin:/usr/sbin:/sbin)
+	// can't see standard install locations like /opt/homebrew/bin or
+	// ~/.local/bin. Falls back to PATH search and the fallback dir scan when
+	// empty. Set via `--generate-desktop-config --databricks-cli-path …` for
+	// per-user pinning, or by an MDM admin dropping the state file directly.
+	DatabricksCLIPath string `json:"databricks_cli_path,omitempty"`
 }
 
 const defaultPort = 49153

--- a/token.go
+++ b/token.go
@@ -6,12 +6,75 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/tokencache"
 )
+
+// fallbackCLIDirs lists install locations to probe when "databricks" is not on
+// PATH. Order matters: most-likely first. GUI-launched subprocesses (e.g.
+// Claude Desktop invoking the credential helper) inherit launchd's minimal
+// PATH (/usr/bin:/bin:/usr/sbin:/sbin), which omits all of these.
+var fallbackCLIDirs = []string{
+	"/usr/local/bin",
+	"/opt/homebrew/bin",
+	"/opt/homebrew/sbin",
+	".local/bin", // resolved against $HOME
+	"go/bin",     // resolved against $HOME
+	"bin",        // resolved against $HOME
+}
+
+// resolveDatabricksCLI returns an executable path for the Databricks CLI.
+// Lookup order:
+//  1. Absolute or path-qualified cmdName → returned unchanged (back-compat for tests).
+//  2. $DATABRICKS_CLI env override, if set and executable.
+//  3. exec.LookPath(cmdName), which honors the inherited PATH.
+//  4. A scan of common install dirs (/usr/local/bin, /opt/homebrew/bin, ~/.local/bin, ~/go/bin, ~/bin).
+//
+// If none match, cmdName is returned unchanged so the eventual exec error
+// surfaces with its original message.
+func resolveDatabricksCLI(cmdName string) string {
+	if cmdName == "" {
+		cmdName = "databricks"
+	}
+	if filepath.IsAbs(cmdName) || filepath.Base(cmdName) != cmdName {
+		return cmdName
+	}
+	if override := os.Getenv("DATABRICKS_CLI"); override != "" {
+		if isExecutableFile(override) {
+			return override
+		}
+	}
+	if p, err := exec.LookPath(cmdName); err == nil {
+		return p
+	}
+	home, _ := os.UserHomeDir()
+	for _, dir := range fallbackCLIDirs {
+		if !filepath.IsAbs(dir) {
+			if home == "" {
+				continue
+			}
+			dir = filepath.Join(home, dir)
+		}
+		candidate := filepath.Join(dir, cmdName)
+		if isExecutableFile(candidate) {
+			return candidate
+		}
+	}
+	return cmdName
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode()&0o111 != 0
+}
 
 // TokenProvider is an alias to the pkg type for backward compatibility.
 type TokenProvider = tokencache.TokenProvider
@@ -32,7 +95,7 @@ func (f *databricksFetcher) FetchToken(ctx context.Context) (string, time.Time, 
 	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(fetchCtx, f.cmdName, "auth", "token", "--profile", f.profile)
+	cmd := exec.CommandContext(fetchCtx, resolveDatabricksCLI(f.cmdName), "auth", "token", "--profile", f.profile)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("databricks auth token failed: %w", err)
@@ -99,7 +162,7 @@ func DiscoverHost(profile, cmdName string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, cmdName, "auth", "env", "--profile", profile, "--output", "json")
+	cmd := exec.CommandContext(ctx, resolveDatabricksCLI(cmdName), "auth", "env", "--profile", profile, "--output", "json")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("databricks auth env failed: %w", err)

--- a/token_test.go
+++ b/token_test.go
@@ -393,3 +393,73 @@ func TestConstructGatewayURL_Fallback(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+// TestResolveDatabricksCLI_AbsolutePathPassthrough: absolute path is returned unchanged.
+func TestResolveDatabricksCLI_AbsolutePathPassthrough(t *testing.T) {
+	tmp := t.TempDir()
+	absPath := filepath.Join(tmp, "myexec")
+	if err := os.WriteFile(absPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	got := resolveDatabricksCLI(absPath)
+	if got != absPath {
+		t.Errorf("got %q, want %q", got, absPath)
+	}
+}
+
+// TestResolveDatabricksCLI_EnvOverride: $DATABRICKS_CLI is used when set and executable.
+func TestResolveDatabricksCLI_EnvOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o755 not portable on windows")
+	}
+	tmp := t.TempDir()
+	overridePath := filepath.Join(tmp, "override-databricks")
+	if err := os.WriteFile(overridePath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	t.Setenv("DATABRICKS_CLI", overridePath)
+	got := resolveDatabricksCLI("databricks")
+	if got != overridePath {
+		t.Errorf("got %q, want %q", got, overridePath)
+	}
+}
+
+// TestResolveDatabricksCLI_FallbackDirScan: binary found in ~/.local/bin when PATH is empty.
+// Uses a name that cannot exist in the absolute fallback dirs (/usr/local/bin, /opt/homebrew/bin).
+func TestResolveDatabricksCLI_FallbackDirScan(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o755 not portable on windows")
+	}
+	tmp := t.TempDir()
+	localBin := filepath.Join(tmp, ".local", "bin")
+	if err := os.MkdirAll(localBin, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Use a name that is guaranteed not to exist in any absolute fallback dir.
+	uniqueName := "databricks-test-resolve-fallback-unique"
+	fakeBin := filepath.Join(localBin, uniqueName)
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	t.Setenv("PATH", "")
+	t.Setenv("HOME", tmp)
+	t.Setenv("DATABRICKS_CLI", "")
+	got := resolveDatabricksCLI(uniqueName)
+	if got != fakeBin {
+		t.Errorf("got %q, want %q", got, fakeBin)
+	}
+}
+
+// TestResolveDatabricksCLI_NotFoundReturnsBareName: no binary anywhere → bare name returned.
+func TestResolveDatabricksCLI_NotFoundReturnsBareName(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("PATH", "")
+	t.Setenv("HOME", tmp)
+	t.Setenv("DATABRICKS_CLI", "")
+	// Use a name that is guaranteed not to exist anywhere on this machine.
+	uniqueName := "databricks-test-resolve-notfound-unique"
+	got := resolveDatabricksCLI(uniqueName)
+	if got != uniqueName {
+		t.Errorf("got %q, want %q", got, uniqueName)
+	}
+}


### PR DESCRIPTION
## Summary

Adds two new flags to the `databricks-claude` binary so it can act as the inference provider for Claude Desktop via the new MDM configuration scheme.

- `--credential-helper` — invoked by Claude Desktop on demand for `inferenceCredentialHelper`. Resolves the active profile (`--profile` flag > saved state file > `DEFAULT`), fetches a fresh Databricks OAuth token using the existing `token.go` logic, and writes the raw token to stdout. Stays silent on stderr on success and exits non-zero on failure.
- `--generate-desktop-config` — discovers the AI Gateway URL from the active profile (re-using `DiscoverHost` + `ConstructGatewayURL`), captures the absolute path of the running binary via `os.Executable()`, and writes a platform-specific MDM config:
  - **macOS** → `databricks-claude-desktop.mobileconfig` (Apple Configuration Profile XML plist with two distinct UUIDs, generated from `crypto/rand`).
  - **Windows** → `databricks-claude-desktop.reg` (registry script under `HKCU\SOFTWARE\Policies\Claude` with CRLF line endings, escaped backslashes, and escaped JSON quotes for `inferenceModels`).
  - On other OSes both files are written so the user can transfer them. `--output <path>` overrides the default filename and infers the format from the extension.
- Help text and shell completions updated; the new paths are handled before `parseArgs` runs so the existing return tuple and its tests are untouched.
- Pure stdlib only — no new dependencies introduced.

## Test plan

- [x] `go test ./... -count=1` (all existing + new tests pass)
- [x] `go vet ./...` clean
- [x] `go build .` succeeds; `--help` lists the new flags
- [x] Unit tests cover: UUID format/uniqueness, mobileconfig content/escaping/UUID separation, .reg content/escaping/CRLF, `regEscape`, `plistEscape`, `extractProfileFlag`, `extractOutputFlag`, `hasFlag`
- [x] Manual smoke test on macOS: run `databricks-claude --generate-desktop-config`, install the resulting `.mobileconfig`, restart Claude Desktop, verify it calls back into `--credential-helper` and gets a working token
- [ ] Manual smoke test on Windows: import the resulting `.reg`, restart Claude Desktop, verify the same end-to-end flow

Closes #92