### PR TITLE
feat: --install-hooks performs first-run env setup; hook–desktop coexist

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,16 +187,15 @@ The proxy can be wired into Claude Code in two different ways:
 1. **Session hooks** (`databricks-claude --install-hooks`) — registered in `~/.claude/settings.json`. Every Claude Code session that reads that file fires `SessionStart` to bring up the local proxy and points `ANTHROPIC_BASE_URL` at it.
 2. **Claude Desktop mobileconfig** (`databricks-claude desktop generate-config` + install) — installs an MDM profile that points Claude Desktop's third-party-inference path at the AI Gateway via the credential helper.
 
-Claude Desktop ships with Claude Code embedded, and the embedded Claude Code reads the same `~/.claude/settings.json` for skills, plugins, and hooks — so if both modes are configured, every Claude Code session inside Desktop also fires the hook. That spins up the local proxy on session start, but Claude Desktop's inference path is governed by the MDM profile (managed preferences), not by the `ANTHROPIC_BASE_URL` env var the hook sets. The result is a stray proxy that never receives traffic, plus settings churn from the hook lifecycle.
-
-**Pick one mode based on where you actually want to talk to Databricks from:**
+**Both can be installed on the same machine.** Claude Desktop's inference is governed by the MDM-managed `inferenceCredentialHelper` and does not consult `ANTHROPIC_BASE_URL`, so the SessionStart hook's proxy lifecycle has no effect on Desktop — it simply runs unused for the brief embedded-Code session and exits cleanly. Pick whichever modes match your workflow; you don't have to choose.
 
 | Primary client | Recommended setup |
 |----------------|-------------------|
-| CLI Claude Code, VS Code extension, JetBrains plugin | **Hooks** (`databricks-claude --install-hooks`). Don't install the Claude Desktop mobileconfig. |
-| Claude Desktop (chat UI and/or embedded Claude Code) | **Mobileconfig** (`databricks-claude desktop generate-config` + install in System Settings). Run `databricks-claude --uninstall-hooks` if hooks were previously installed. When you want a CLI Claude Code session against Databricks, invoke `databricks-claude` directly — the proxy runs for that session only. |
+| CLI Claude Code, VS Code extension, JetBrains plugin | **Hooks** (`databricks-claude --install-hooks --profile <name>`). |
+| Claude Desktop (chat UI and/or embedded Claude Code) | **Mobileconfig** (`databricks-claude desktop generate-config` + install in System Settings). |
+| Both | Install both. They coexist without conflict. |
 
-The two modes are independent — neither requires the other — and the binary supports either. The collision only shows up if you try to run both at once.
+The two modes are independent — neither requires the other — and the binary supports either or both.
 
 ## Headless Mode
 
@@ -217,26 +216,20 @@ databricks-claude --headless
 
 Install hooks so every Claude Code session auto-starts the proxy on startup and releases it cleanly on exit — no manual `--headless` needed.
 
-> ⚠️ **Don't combine hooks with Claude Desktop integration.** Claude Desktop's embedded Claude Code reads `~/.claude/settings.json` for skills, plugins, and hooks, so the SessionStart hook fires whenever you start a Claude Code session inside Desktop too. The proxy will spin up — but Desktop won't actually route inference through it (Desktop uses its own MDM-driven `inferenceCredentialHelper` config), so you end up with an unused proxy plus settings churn from the hook lifecycle.
->
-> **Pick one mode:**
-> - **Hooks only** — use Claude Code from your terminal (CLI, VS Code, JetBrains). Don't install the Claude Desktop mobileconfig.
-> - **Claude Desktop only** — install the mobileconfig (see [Claude Desktop Integration](#claude-desktop-integration) above) and run `databricks-claude --uninstall-hooks` if you'd installed the hooks. When you want a CLI Claude Code session, invoke `databricks-claude` directly so the proxy runs only for that session.
->
-> See [Hooks vs Claude Desktop](#hooks-vs-claude-desktop) below for the longer explanation.
+> **Coexists with Claude Desktop.** If you've also installed the Claude Desktop mobileconfig, the hook's proxy lifecycle is harmless inside Desktop sessions — Desktop's inference does not consult `ANTHROPIC_BASE_URL` (it uses its own MDM-driven `inferenceCredentialHelper`). See [Hooks vs Claude Desktop](#hooks-vs-claude-desktop) for details.
 
-> **First-time setup:** Run `databricks-claude` at least once before installing hooks. This writes the correct `ANTHROPIC_BASE_URL` to `~/.claude/settings.json` so the proxy is used for all Claude clients. Once set, the hooks keep the proxy running automatically — including for clients that don't use the `databricks-claude` wrapper directly, such as the [Claude VS Code extension](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude-code) and JetBrains/IntelliJ plugin.
+> **One-step setup:** `databricks-claude --install-hooks --profile <name>` does everything in one shot — it persists your profile/port and writes `ANTHROPIC_BASE_URL` to `~/.claude/settings.json`, then registers the SessionStart and SessionEnd hooks. No prior `databricks-claude` invocation needed. Re-running is idempotent. The hooks keep the proxy running for all Claude clients — including ones that don't use the `databricks-claude` wrapper directly, such as the [Claude VS Code extension](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude-code) and JetBrains/IntelliJ plugin.
 
 ### Install
 
 ```bash
-databricks-claude --install-hooks
+databricks-claude --install-hooks --profile <name>
 ```
 
-This merges two hooks into `~/.claude/settings.json`:
+This merges two hooks into `~/.claude/settings.json` AND performs first-run env setup (persists profile/port, writes `ANTHROPIC_BASE_URL`). No prior `databricks-claude` invocation needed; idempotent on re-run.
 
 - **SessionStart** — calls `databricks-claude --headless-ensure` on session startup: starts the proxy if it isn't already running
-- **Stop** — calls `databricks-claude --headless-release` on session end: decrements the refcount; proxy exits when the last session closes
+- **SessionEnd** — calls `databricks-claude --headless-release` on session end: decrements the refcount; proxy exits when the last session closes
 
 ### Uninstall
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The proxy can be wired into Claude Code in two different ways:
 1. **Session hooks** (`databricks-claude --install-hooks`) — registered in `~/.claude/settings.json`. Every Claude Code session that reads that file fires `SessionStart` to bring up the local proxy and points `ANTHROPIC_BASE_URL` at it.
 2. **Claude Desktop mobileconfig** (`databricks-claude desktop generate-config` + install) — installs an MDM profile that points Claude Desktop's third-party-inference path at the AI Gateway via the credential helper.
 
-**Both can be installed on the same machine.** Claude Desktop's inference is governed by the MDM-managed `inferenceCredentialHelper` and does not consult `ANTHROPIC_BASE_URL`, so the SessionStart hook's proxy lifecycle has no effect on Desktop — it simply runs unused for the brief embedded-Code session and exits cleanly. Pick whichever modes match your workflow; you don't have to choose.
+**Both can be installed on the same machine.** Claude Desktop's inference is governed by the Claude's `inferenceCredentialHelper` and does not consult `ANTHROPIC_BASE_URL`, so the SessionStart hook's proxy lifecycle has no effect on Desktop — it simply runs unused for the brief embedded-Code session and exits cleanly. Pick whichever modes match your workflow; you don't have to choose.
 
 | Primary client | Recommended setup |
 |----------------|-------------------|

--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fileSHA returns the hex SHA-256 of a file's contents.
+// Returns empty string if the file does not exist.
+func fileSHA(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read %s: %v", path, err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// withTempHome redirects HOME and statePath to a temporary directory for the
+// duration of a test. Returns the temp home path.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, ".claude", ".databricks-claude.json") }
+	t.Cleanup(func() { statePath = orig })
+	return dir
+}
+
+func TestBootstrapSettings_FreshMachine(t *testing.T) {
+	home := withTempHome(t)
+	if err := bootstrapSettings(49153, "myws", "http://127.0.0.1:49153", nil); err != nil {
+		t.Fatalf("bootstrapSettings: %v", err)
+	}
+
+	st := loadState()
+	if st.Profile != "myws" {
+		t.Errorf("profile: got %q, want %q", st.Profile, "myws")
+	}
+	if st.Port != 49153 {
+		t.Errorf("port: got %d, want %d", st.Port, 49153)
+	}
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	doc, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	env := envBlock(doc)
+	if got, _ := env["ANTHROPIC_BASE_URL"].(string); got != "http://127.0.0.1:49153" {
+		t.Errorf("ANTHROPIC_BASE_URL: got %q, want %q", got, "http://127.0.0.1:49153")
+	}
+}
+
+func TestBootstrapSettings_PortFlagOnly(t *testing.T) {
+	withTempHome(t)
+	if err := bootstrapSettings(49154, "DEFAULT", "http://127.0.0.1:49154", nil); err != nil {
+		t.Fatalf("bootstrapSettings: %v", err)
+	}
+	st := loadState()
+	if st.Port != 49154 {
+		t.Errorf("port: got %d, want %d", st.Port, 49154)
+	}
+	if st.Profile != "" {
+		t.Errorf("profile: got %q, want empty (DEFAULT not persisted)", st.Profile)
+	}
+}
+
+func TestBootstrapSettings_ProfileOnly(t *testing.T) {
+	withTempHome(t)
+	if err := bootstrapSettings(0, "myws", "http://127.0.0.1:49153", nil); err != nil {
+		t.Fatalf("bootstrapSettings: %v", err)
+	}
+	st := loadState()
+	if st.Profile != "myws" {
+		t.Errorf("profile: got %q, want %q", st.Profile, "myws")
+	}
+	if st.Port != 0 {
+		t.Errorf("port: got %d, want 0 (no flag passed)", st.Port)
+	}
+}
+
+func TestBootstrapSettings_NoMutation(t *testing.T) {
+	withTempHome(t)
+	// portFlag=0 + profile=DEFAULT means nothing should be persisted to state.
+	if err := bootstrapSettings(0, "DEFAULT", "http://127.0.0.1:49153", nil); err != nil {
+		t.Fatalf("bootstrapSettings: %v", err)
+	}
+	if _, err := os.Stat(statePath()); !os.IsNotExist(err) {
+		t.Errorf("state file should not exist: stat err = %v", err)
+	}
+}
+
+func TestBootstrapSettings_Idempotent_NoChange(t *testing.T) {
+	home := withTempHome(t)
+	// First run.
+	if err := bootstrapSettings(49153, "myws", "http://127.0.0.1:49153", nil); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	stateBefore := fileSHA(t, statePath())
+	settingsBefore := fileSHA(t, settingsPath)
+
+	// Re-run with identical args; SHAs must match.
+	if err := bootstrapSettings(49153, "myws", "http://127.0.0.1:49153", nil); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	stateAfter := fileSHA(t, statePath())
+	settingsAfter := fileSHA(t, settingsPath)
+
+	if stateBefore != stateAfter {
+		t.Errorf("state file changed on idempotent re-run\n  before: %s\n  after:  %s", stateBefore, stateAfter)
+	}
+	if settingsBefore != settingsAfter {
+		t.Errorf("settings.json changed on idempotent re-run\n  before: %s\n  after:  %s", settingsBefore, settingsAfter)
+	}
+}
+
+func TestBootstrapSettings_FreshMachine_NoClaudeDir(t *testing.T) {
+	home := withTempHome(t)
+	// Confirm the directory does not exist beforehand.
+	if _, err := os.Stat(filepath.Join(home, ".claude")); !os.IsNotExist(err) {
+		t.Fatalf("expected ~/.claude absent at start, got err=%v", err)
+	}
+	if err := bootstrapSettings(49153, "myws", "http://127.0.0.1:49153", nil); err != nil {
+		t.Fatalf("bootstrapSettings: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(home, ".claude"))
+	if err != nil {
+		t.Fatalf("expected ~/.claude created, got err=%v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o700 {
+		t.Errorf("~/.claude perm: got %o, want 0700", mode)
+	}
+}
+
+func TestBootstrapSettings_OverwritesStaleProfile(t *testing.T) {
+	withTempHome(t)
+	if err := saveState(persistentState{Profile: "old", Port: 49153}); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+	if err := bootstrapSettings(0, "new", "http://127.0.0.1:49153", nil); err != nil {
+		t.Fatalf("bootstrapSettings: %v", err)
+	}
+	st := loadState()
+	if st.Profile != "new" {
+		t.Errorf("profile: got %q, want %q", st.Profile, "new")
+	}
+}
+
+func TestInstallHooks_WritesAtomically(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := installHooks(settingsPath); err != nil {
+		t.Fatalf("installHooks: %v", err)
+	}
+
+	// No leftover .tmp file.
+	if _, err := os.Stat(settingsPath + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("temp file should not exist after install: stat err=%v", err)
+	}
+
+	// File created with hooks.
+	doc, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	hooks, _ := doc["hooks"].(map[string]interface{})
+	if hooks == nil {
+		t.Fatal("hooks block missing")
+	}
+	if _, ok := hooks["SessionStart"]; !ok {
+		t.Error("SessionStart hook missing")
+	}
+	if _, ok := hooks["SessionEnd"]; !ok {
+		t.Error("SessionEnd hook missing")
+	}
+}
+
+func TestInstallHooks_NoSettingsFile_CreatesDir(t *testing.T) {
+	dir := t.TempDir()
+	// settings path inside a subdirectory that doesn't exist yet.
+	settingsPath := filepath.Join(dir, "claude", "settings.json")
+	if err := installHooks(settingsPath); err != nil {
+		t.Fatalf("installHooks: %v", err)
+	}
+	if _, err := os.Stat(settingsPath); err != nil {
+		t.Errorf("settings.json should exist: %v", err)
+	}
+}
+
+func TestInstallHooks_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := installHooks(settingsPath); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	sha1 := fileSHA(t, settingsPath)
+
+	if err := installHooks(settingsPath); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	sha2 := fileSHA(t, settingsPath)
+
+	if sha1 != sha2 {
+		t.Errorf("install-hooks not idempotent\n  before: %s\n  after:  %s", sha1, sha2)
+	}
+}

--- a/ensureconfig.go
+++ b/ensureconfig.go
@@ -3,9 +3,47 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 )
+
+// bootstrapSettings persists profile + port to the state file and writes the
+// env block to settings.json. Idempotent: state is mutated in memory and
+// written via a single saveState call only when something actually changed;
+// settings.json is written only when ANTHROPIC_BASE_URL differs from proxyURL.
+//
+// portFlag is the raw --port CLI flag value (0 if absent). When portFlag > 0,
+// the resolved port is persisted to state — preserving the existing semantics
+// that the user's explicit --port choice is sticky.
+//
+// resolvedProfile is the post-resolution profile string ("DEFAULT" if no
+// override). Persisted only when non-empty and not "DEFAULT".
+//
+// proxyURL is the URL written into ANTHROPIC_BASE_URL. The first-run path
+// passes the discovered gateway URL; --install-hooks passes the placeholder
+// http://127.0.0.1:<port> (which the headless-ensure hook overwrites at
+// session start with the discovered URL).
+//
+// otelEnv is forwarded to ensureConfig; nil for the install-hooks path.
+func bootstrapSettings(portFlag int, resolvedProfile string, proxyURL string, otelEnv map[string]string) error {
+	state := loadState()
+	mutated := false
+	if portFlag > 0 {
+		state.Port = resolvePort(portFlag, state)
+		mutated = true
+	}
+	if resolvedProfile != "" && resolvedProfile != "DEFAULT" && state.Profile != resolvedProfile {
+		state.Profile = resolvedProfile
+		mutated = true
+	}
+	if mutated {
+		if err := saveState(state); err != nil {
+			return fmt.Errorf("persist state: %w", err)
+		}
+	}
+	return ensureConfig(proxyURL, otelEnv)
+}
 
 // ensureConfig writes the env block to ~/.claude/settings.json only if
 // ANTHROPIC_BASE_URL doesn't already point at proxyURL. Idempotent.
@@ -71,13 +109,18 @@ func readSettingsJSON(path string) (map[string]interface{}, error) {
 	return doc, nil
 }
 
-// writeSettingsJSON atomically writes a settings.json file.
+// writeSettingsJSON atomically writes a settings.json file. Creates the parent
+// directory with mode 0700 if absent. Atomic via temp+rename in the same
+// directory (cross-device rename impossible by construction).
 func writeSettingsJSON(path string, doc map[string]interface{}) error {
 	data, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
 		return err
 	}
 	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return err

--- a/hooks.go
+++ b/hooks.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/headless"
@@ -46,7 +44,7 @@ func headlessRelease(port int) {
 // installHooks merges the databricks-claude SessionStart and Stop hooks into
 // ~/.claude/settings.json. Idempotent — safe to run after upgrades.
 func installHooks(settingsPath string) error {
-	doc, err := readSettingsDoc(settingsPath)
+	doc, err := readSettingsJSON(settingsPath)
 	if err != nil {
 		// File may not exist yet — start with an empty document.
 		doc = map[string]interface{}{}
@@ -91,12 +89,12 @@ func installHooks(settingsPath string) error {
 	hooks["SessionEnd"] = sessionEnd
 
 	doc["hooks"] = hooks
-	return writeSettingsDoc(settingsPath, doc)
+	return writeSettingsJSON(settingsPath, doc)
 }
 
 // uninstallHooks removes the databricks-claude hooks from ~/.claude/settings.json.
 func uninstallHooks(settingsPath string) error {
-	doc, err := readSettingsDoc(settingsPath)
+	doc, err := readSettingsJSON(settingsPath)
 	if err != nil {
 		return nil // nothing to remove
 	}
@@ -120,7 +118,7 @@ func uninstallHooks(settingsPath string) error {
 		doc["hooks"] = hooks
 	}
 
-	return writeSettingsDoc(settingsPath, doc)
+	return writeSettingsJSON(settingsPath, doc)
 }
 
 // removeDBXHooks removes any hook entries whose command contains "databricks-claude --headless".
@@ -156,15 +154,3 @@ func isDBXHookEntry(entry interface{}) bool {
 	return false
 }
 
-// writeSettingsDoc writes a settings document back to disk as indented JSON.
-func writeSettingsDoc(path string, doc map[string]interface{}) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return fmt.Errorf("creating settings dir: %w", err)
-	}
-	data, err := json.MarshalIndent(doc, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshalling settings: %w", err)
-	}
-	data = append(data, '\n')
-	return os.WriteFile(path, data, 0o600)
-}

--- a/main.go
+++ b/main.go
@@ -107,10 +107,24 @@ func main() {
 		}
 		sp := filepath.Join(homeDir, ".claude", "settings.json")
 		if installHooksFlag {
+			// First-run env setup: persist profile/port and write
+			// ANTHROPIC_BASE_URL placeholder so users no longer need to run
+			// `databricks-claude` once before installing hooks. The placeholder
+			// URL is overwritten by --headless-ensure at session start with
+			// the discovered gateway URL.
+			resolvedProfile := profile
+			if resolvedProfile == "" {
+				resolvedProfile = "DEFAULT"
+			}
+			port := resolvePort(portFlag, loadState())
+			placeholder := fmt.Sprintf("http://127.0.0.1:%d", port)
+			if err := bootstrapSettings(portFlag, resolvedProfile, placeholder, nil); err != nil {
+				log.Fatalf("databricks-claude: --install-hooks bootstrap: %v", err)
+			}
 			if err := installHooks(sp); err != nil {
 				log.Fatalf("databricks-claude: --install-hooks: %v", err)
 			}
-			fmt.Fprintln(os.Stderr, "databricks-claude: hooks installed — SessionStart and Stop hooks added to ~/.claude/settings.json")
+			fmt.Fprintln(os.Stderr, "databricks-claude: hooks installed — SessionStart and SessionEnd hooks added to ~/.claude/settings.json")
 		} else {
 			if err := uninstallHooks(sp); err != nil {
 				log.Fatalf("databricks-claude: --uninstall-hooks: %v", err)
@@ -174,7 +188,7 @@ func main() {
 	}
 	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
 
-	settingsDoc, err := readSettingsDoc(settingsPath)
+	settingsDoc, err := readSettingsJSON(settingsPath)
 	if err != nil {
 		log.Fatalf("databricks-claude: cannot read settings.json: %v", err)
 	}
@@ -306,26 +320,12 @@ func main() {
 		ucLogsTable = deriveLogsTable(ucMetricsTable)
 	}
 
-	// --- Load persistent state and resolve port ---
-	state := loadState()
-
-	port := resolvePort(portFlag, state)
-	if portFlag > 0 {
-		state.Port = port
-		if err := saveState(state); err != nil {
-			log.Printf("databricks-claude: warning: failed to save port: %v", err)
-		}
-	}
-
-	// Persist profile so future runs don't need --profile.
-	if resolvedProfile != "DEFAULT" {
-		state.Profile = resolvedProfile
-		if err := saveState(state); err != nil {
-			log.Printf("databricks-claude: warning: failed to persist profile: %v", err)
-		} else {
-			log.Printf("databricks-claude: persisted profile %q", resolvedProfile)
-		}
-	}
+	// --- Resolve port for downstream binding ---
+	// State persistence (port + profile) and settings.json env-block writes
+	// happen together via bootstrapSettings near line 447. Note: --print-env
+	// (line 331) now exits before bootstrapSettings — diagnostic invocations
+	// no longer have write side effects.
+	port := resolvePort(portFlag, loadState())
 
 	// --- Print env and exit if requested ---
 	if printEnv {
@@ -444,7 +444,7 @@ func main() {
 		otelEnv["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] = "1"
 	}
 
-	if err := ensureConfig(proxyURL, otelEnv); err != nil {
+	if err := bootstrapSettings(portFlag, resolvedProfile, proxyURL, otelEnv); err != nil {
 		if headless {
 			fmt.Fprintf(os.Stderr, "databricks-claude: warning: config write failed: %v\n", err)
 		} else {
@@ -512,23 +512,6 @@ func runHeadless(proxyURL string, ln net.Listener, isOwner bool, refcountPath st
 	}
 }
 
-
-// readSettingsDoc reads and parses settings.json, returning the full document.
-// If the file does not exist, an empty document is returned.
-func readSettingsDoc(path string) (map[string]interface{}, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return map[string]interface{}{}, nil
-		}
-		return nil, err
-	}
-	var doc map[string]interface{}
-	if err := json.Unmarshal(data, &doc); err != nil {
-		return nil, err
-	}
-	return doc, nil
-}
 
 // envBlock returns the "env" sub-map from a settings document, or an empty map.
 func envBlock(doc map[string]interface{}) map[string]interface{} {
@@ -731,7 +714,9 @@ Databricks-Claude Flags:
   --headless-ensure            Start proxy if not running (called by SessionStart hook)
   --headless-release           Decrement proxy refcount (called by Stop hook)
   --idle-timeout duration      Idle timeout for headless mode (default 30m, 0 disables, bare number = minutes)
-  --install-hooks              Install SessionStart/Stop hooks into ~/.claude/settings.json
+  --install-hooks              Install SessionStart/SessionEnd hooks AND perform first-run
+                               env setup (idempotent). Accepts --profile and --port to
+                               persist them; no prior databricks-claude invocation needed.
   --uninstall-hooks            Remove databricks-claude hooks from ~/.claude/settings.json
   --no-update-check            Skip the automatic update check on startup
   --version                    Print version and exit


### PR DESCRIPTION
Collapses the two-step setup (databricks-claude --profile X then --install-hooks) into one command. Removes the README warning that overstated hook+Desktop incompatibility.

Empirical test confirmed Claude Desktop's inference is governed solely by its MDM-managed inferenceCredentialHelper and ignores ANTHROPIC_BASE_URL. The two modes are functionally non-conflicting; the existing per-session proxy is harmless inside Desktop-embedded Claude Code sessions (runs unused, idle-times-out).

Changes:
- New bootstrapSettings(portFlag, resolvedProfile, proxyURL, otelEnv) in ensureconfig.go. Idempotent: persists state and writes settings.json env block in one operation. Single saveState call covers both port + profile mutations (today's two-call pattern is non-transactional).
- Refactor first-run path: state persistence at main.go:309-328 and the ensureConfig() call site collapse into a single bootstrapSettings call.
- Wire bootstrapSettings into the --install-hooks branch with a http://127.0.0.1:<port> placeholder URL (overwritten correctly by --headless-ensure at session start).
- Consolidate duplicate read/write functions: delete readSettingsDoc (main.go) and writeSettingsDoc (hooks.go), replace callers with the atomic readSettingsJSON / writeSettingsJSON in ensureconfig.go. Fixes a latent atomicity bug at hooks.go:169 (was using non-atomic os.WriteFile, violating CLAUDE.md's atomic-write rule).
- writeSettingsJSON now does MkdirAll(filepath.Dir(path), 0o700) so callers don't need to create ~/.claude/ themselves.
- Update --install-hooks help text; fix Stop → SessionEnd in user-facing messages (the actual hook is SessionEnd).
- README: remove "Don't combine hooks with Claude Desktop" warning; replace with positive coexistence note. Update Hooks-vs-Desktop section to remove "pick one" framing. Drop the "run databricks-claude once first" prerequisite. Show --profile <name> in install snippet.

Behavior changes worth flagging:
- --print-env no longer persists state as a side effect (state writes moved to alongside the env-block write). Diagnostic command shouldn't have write side effects; minor and arguably correct.
- State-persistence failure in the first-run path is now fatal (was: warning). Filesystem failures are serious; defensible.

Tests: 7 new for bootstrapSettings (fresh machine, port-only, profile-only, no-mutation, idempotent SHA, missing dir, stale-profile overwrite), 3 new for installHooks (atomicity, missing dir, idempotent SHA). All existing tests pass; lint clean.