### PR TITLE
feat: emit databricks-claude-desktop.json for Claude Desktop dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .omc/
 *.mobileconfig
 *.reg
+databricks-claude-desktop.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ Transparent proxy wrapper for Claude Code that auto-refreshes Databricks OAuth t
 | `process.go` | `SettingsManager` (wraps `pkg/settings`): full-setup and save/restore of `~/.claude/settings.json` env keys, OTEL key management, `ClearOTELKeys`, `RunChild`, `ForwardSignals` |
 | `lock.go` | Type alias forwarding `pkg/filelock.FileLock` to package main |
 | `registry.go` | Type alias forwarding `pkg/registry.SessionRegistry` to package main |
+| `desktop_config.go` | `desktop` subcommand handlers: credential-helper alias, `generate-config` (writes `.mobileconfig`, `.reg`, and `.json` artifacts for Claude Desktop), atomic file writes, output safety guard, per-OS install instructions |
+| `desktop_config_test.go` | Tests for `buildMobileconfig`, `buildRegFile`, `buildDevModeJSON`, `writeDesktopConfigByPath`, `guardDevJSONOutputPath`, `writeFileAtomic`, install-instruction routing, and model-list consistency across all three artifacts |
 | `main_test.go` | Tests for `parseArgs`, `handlePrintEnv`, persistent config, `deriveLogsTable`, full integration scenarios |
 | `process_test.go` | Tests for `SettingsManager` save/restore, atomic writes, OTEL handling, signal forwarding, exit code propagation |
 | `proxy_test.go` | Tests for inference and OTEL proxy routing, token injection, panic recovery |

--- a/README.md
+++ b/README.md
@@ -110,13 +110,45 @@ The `.claude-plugin/` directory and `hooks/hooks.json` at the repo root define t
    ```bash
    databricks-claude desktop generate-config --profile <name>
    ```
-   This writes both `databricks-claude-desktop.mobileconfig` (macOS) and `databricks-claude-desktop.reg` (Windows) into the current directory. Pass `--output <path>` for a single file.
+   This writes three artifacts into the current directory, all encoding the same Databricks gateway / credential-helper defaults:
+   - `databricks-claude-desktop.mobileconfig` — ready-to-install macOS configuration profile.
+   - `databricks-claude-desktop.reg` — ready-to-merge Windows registry script.
+   - `databricks-claude-desktop.json` — editable source. Import into Claude Desktop's developer mode if you need to customize allow-lists, tools, branding, etc. — Desktop can then export your edits back to `.mobileconfig` / `.reg` for MDM rollout.
+
+   Pass `--output <path>` for a single file (extension `.mobileconfig`, `.reg`, or `.json` selects the format).
 4. **Install the config:**
    - **macOS**: `open databricks-claude-desktop.mobileconfig`, then approve in System Settings → Privacy & Security → Profiles.
    - **Windows**: double-click the `.reg` file, or `reg import databricks-claude-desktop.reg`.
+
+   For fleet rollout via Jamf / Kandji / Intune / Group Policy, ship the same `.mobileconfig` or `.reg` to your endpoints. See [MDM / fleet rollout](#mdm--fleet-rollout) for path-pinning flags.
 5. **Restart Claude Desktop.**
 
 After this, Desktop's third-party-inference path runs against your Databricks AI Gateway, with tokens refreshed automatically by the credential helper.
+
+### Customizing the configuration
+
+The defaults baked into the generated artifacts (model list, gateway URL, credential-helper path, telemetry/extension toggles) are all you need to get Claude Desktop talking to Databricks. If you want to tweak Claude Desktop's full set of policy keys — allow-lists, available tools, branding, telemetry policy, extension behavior, etc. — load `databricks-claude-desktop.json` into Claude Desktop's developer mode and edit from there:
+
+1. **Enable developer mode** — in the menu bar:
+   **Help → Troubleshooting → Enable Developer mode**.
+2. **Open the third-party inference UI**:
+   **Developer → Configure third-party inference**.
+3. **Create a new configuration**. Click the configuration name in the top-right of the UI to open the **CONFIGURATIONS** menu, then choose **New configuration**. Give it a name (e.g. `Databricks`).
+4. **Reveal the configuration on disk**. Open the same **CONFIGURATIONS** menu and choose **Reveal in Finder** (macOS) / **Reveal in Explorer** (Windows). This opens the configuration library directory:
+   - **macOS**: `~/Library/Application Support/Claude-3p/configLibrary/`
+   - **Windows**: `%APPDATA%\Claude-3p\configLibrary\` (use *Reveal in Explorer* to confirm the exact path on your install)
+
+   Inside that directory you'll find:
+   - One JSON file per configuration, named `<uuid>.json` — the same schema as `databricks-claude-desktop.json`.
+   - An index file (`{ "appliedId": "<uuid>", "entries": [ { "id": "<uuid>", "name": "<config name>" } ] }`) that tracks which configuration is currently applied.
+5. **Replace the new configuration's JSON file** with the contents of `databricks-claude-desktop.json`. Keep the original filename (the `<uuid>.json` Claude Desktop generated) — only the contents change. Do not edit the index file.
+6. **Apply and edit** in Claude Desktop. Switch back to the app, select your new configuration in the dropdown, then edit any of the [Claude Desktop configuration keys](https://support.claude.com/en/articles/14680741-install-and-configure-claude-cowork-with-third-party-platforms) (allow-lists, tools, branding, etc.) directly in the UI.
+7. **Export** for fleet rollout. Claude Desktop's UI has an Export action that writes the configuration out as `.mobileconfig` (macOS) or `.reg` (Windows), ready to ship to MDM (Jamf, Kandji, Intune, Group Policy).
+8. **Restart Claude Desktop**, or distribute the exported file to your fleet.
+
+> Claude Desktop does not have a "Import JSON" UI today — file replacement under `configLibrary/` is the supported import path.
+
+Reference: [Install and configure Claude with third-party platforms](https://support.claude.com/en/articles/14680741-install-and-configure-claude-cowork-with-third-party-platforms) — full list of Claude Desktop configuration keys and the developer-mode workflow.
 
 ### How dispatch works
 

--- a/desktop_config.go
+++ b/desktop_config.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -41,9 +43,14 @@ func helperDebugLog(format string, args ...any) {
 }
 
 // inferenceModelsJSON is the JSON-encoded model list embedded in the generated
-// Claude Desktop configuration. Kept as a single source of truth so the macOS
-// and Windows generators stay aligned.
+// Claude Desktop configuration. Kept as a single source of truth so the macOS,
+// Windows, and developer-mode JSON generators stay aligned.
 const inferenceModelsJSON = `[{"name":"databricks-claude-opus-4-7","supports1m":true},{"name":"databricks-claude-opus-4-6","supports1m":true},{"name":"databricks-claude-sonnet-4-6","supports1m":true},{"name":"databricks-claude-sonnet-4-5","supports1m":true},{"name":"databricks-claude-haiku-4-5"}]`
+
+// desktopDeveloperModeArticleURL is the canonical Anthropic support article
+// describing how to import a JSON config into Claude Desktop's developer mode.
+// Pinned in one place so updates are a single-line edit.
+const desktopDeveloperModeArticleURL = "https://support.claude.com/en/articles/14680741-install-and-configure-claude-cowork-with-third-party-platforms"
 
 // credentialHelperBinaryName is the basename used to dispatch into
 // runCredentialHelper via argv[0]. Each install method is expected to install
@@ -94,10 +101,18 @@ func printDesktopHelp() {
 Set up Claude Desktop's third-party-inference integration with Databricks.
 
 Actions:
-  generate-config     Write Claude Desktop MDM configs. Without --output, writes
-                      both databricks-claude-desktop.mobileconfig (macOS) and
-                      databricks-claude-desktop.reg (Windows) into the current
-                      directory.
+  generate-config     Write Claude Desktop configuration artifacts. Without
+                      --output, writes three files into the current directory.
+                      All three encode the same Databricks gateway and
+                      credential-helper defaults:
+                        databricks-claude-desktop.mobileconfig (install on macOS)
+                        databricks-claude-desktop.reg          (install on Windows)
+                        databricks-claude-desktop.json         (editable source —
+                                                                import into Claude
+                                                                Desktop developer
+                                                                mode to customize
+                                                                further, then
+                                                                re-export for MDM)
   credential-helper   Print a fresh Databricks token to stdout — the same code
                       path Claude Desktop's inferenceCredentialHelper invokes
                       via the databricks-claude-credential-helper symlink.
@@ -106,7 +121,8 @@ Actions:
 Flags:
   --profile string              Databricks CLI profile (default: state file > DEFAULT)
   --output string               Single output path for generate-config; format
-                                inferred from .mobileconfig/.reg extension or host OS.
+                                inferred from .mobileconfig/.reg/.json extension
+                                or host OS.
   --binary-path string          generate-config: credential-helper path embedded in
                                 the generated config (default: derived from the
                                 running binary). Use this for MDM rollouts so one
@@ -265,31 +281,43 @@ func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride, databrick
 		os.Exit(0)
 	}
 
-	// When --output isn't given, write BOTH .mobileconfig and .reg by default
-	// so a single invocation produces an artifact for every supported Claude
-	// Desktop platform.
-	wrote := []string{}
-	{
-		path := "databricks-claude-desktop.mobileconfig"
-		content, err := buildMobileconfig(gatewayURL, helperPath)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
-			os.Exit(1)
-		}
-		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-			fmt.Fprintf(os.Stderr, "databricks-claude: write %s: %v\n", path, err)
-			os.Exit(1)
-		}
-		wrote = append(wrote, path)
+	// When --output isn't given, write all three artifacts so a single
+	// invocation produces install-ready files for both desktop platforms
+	// plus an editable source:
+	//   - .mobileconfig: ready-to-install macOS configuration profile
+	//   - .reg:          ready-to-merge Windows registry script
+	//   - .json:         editable source for Claude Desktop developer mode.
+	//                    Users who want to customize allow-lists, tools,
+	//                    branding, etc. import this, edit in Desktop's UI,
+	//                    and export back to .mobileconfig / .reg for MDM.
+	// All three encode the same Databricks defaults; pick any one to
+	// install or use the .json as the starting point for customization.
+	type artifact struct {
+		path    string
+		content []byte
 	}
-	{
-		path := "databricks-claude-desktop.reg"
-		content := buildRegFile(gatewayURL, helperPath)
-		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-			fmt.Fprintf(os.Stderr, "databricks-claude: write %s: %v\n", path, err)
+	mc, err := buildMobileconfig(gatewayURL, helperPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
+		os.Exit(1)
+	}
+	dev, err := buildDevModeJSON(gatewayURL, helperPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
+		os.Exit(1)
+	}
+	arts := []artifact{
+		{"databricks-claude-desktop.mobileconfig", []byte(mc)},
+		{"databricks-claude-desktop.reg", []byte(buildRegFile(gatewayURL, helperPath))},
+		{"databricks-claude-desktop.json", dev},
+	}
+	wrote := []string{}
+	for _, a := range arts {
+		if err := writeFileAtomic(a.path, a.content, 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "databricks-claude: write %s: %v\n", a.path, err)
 			os.Exit(1)
 		}
-		wrote = append(wrote, path)
+		wrote = append(wrote, a.path)
 	}
 
 	for _, p := range wrote {
@@ -324,28 +352,39 @@ func resolveHelperPath(override string) (string, error) {
 }
 
 // writeDesktopConfigByPath chooses the format based on file extension (or the
-// host OS when no recognised extension is present) and writes to outputPath.
+// host OS when no recognised extension is present) and writes to outputPath
+// atomically. For .json outputs, guardDevJSONOutputPath protects against
+// accidentally clobbering ~/.claude/settings.json via a typo.
 func writeDesktopConfigByPath(outputPath, gatewayURL, exe string) error {
 	lower := strings.ToLower(outputPath)
-	var content string
+	var data []byte
 	var err error
 	switch {
 	case strings.HasSuffix(lower, ".mobileconfig"):
-		content, err = buildMobileconfig(gatewayURL, exe)
+		var s string
+		s, err = buildMobileconfig(gatewayURL, exe)
+		data = []byte(s)
 	case strings.HasSuffix(lower, ".reg"):
-		content = buildRegFile(gatewayURL, exe)
+		data = []byte(buildRegFile(gatewayURL, exe))
+	case strings.HasSuffix(lower, ".json"):
+		if err := guardDevJSONOutputPath(outputPath); err != nil {
+			return err
+		}
+		data, err = buildDevModeJSON(gatewayURL, exe)
 	default:
 		// Fall back to host platform.
 		if runtime.GOOS == "windows" {
-			content = buildRegFile(gatewayURL, exe)
+			data = []byte(buildRegFile(gatewayURL, exe))
 		} else {
-			content, err = buildMobileconfig(gatewayURL, exe)
+			var s string
+			s, err = buildMobileconfig(gatewayURL, exe)
+			data = []byte(s)
 		}
 	}
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(outputPath, []byte(content), 0o600)
+	return writeFileAtomic(outputPath, data, 0o600)
 }
 
 // printInstallInstructions writes user-facing guidance for the produced file
@@ -368,6 +407,42 @@ To install on Windows:
      into HKEY_CURRENT_USER\SOFTWARE\Policies\Claude.
   2. Restart Claude Desktop.
 `, path, path)
+	case strings.HasSuffix(lower, ".json"):
+		libDir := "~/Library/Application Support/Claude-3p/configLibrary/"
+		if runtime.GOOS == "windows" {
+			libDir = "%APPDATA%\\Claude-3p\\configLibrary\\"
+		}
+		fmt.Fprintf(os.Stderr, `
+To customize the configuration further (allow-lists, tools, branding, etc.),
+load this JSON into Claude Desktop's developer mode:
+
+  1. Enable developer mode:
+     Help → Troubleshooting → Enable Developer mode
+  2. Open the third-party inference UI:
+     Developer → Configure third-party inference
+  3. Click the configuration name in the top-right and choose
+     "New configuration", then give it a name (e.g. "Databricks").
+  4. From the same dropdown, choose "Reveal in Finder" (macOS) or
+     "Reveal in Explorer" (Windows). This opens:
+       %s
+     The new configuration is stored as <uuid>.json inside that folder.
+  5. Replace that <uuid>.json file's contents with %q
+     (keep the original filename — only the contents change).
+  6. Switch back to Claude Desktop, select your new configuration, and
+     edit any Claude Desktop configuration keys in the UI.
+  7. Use Desktop's "Export" action to write the edited config out as
+     .mobileconfig (macOS) or .reg (Windows). Ship that to MDM
+     (Jamf, Kandji, Intune, Group Policy).
+  8. Restart Claude Desktop, or distribute the exported file to your fleet.
+
+The defaults in this JSON are sufficient on their own; only use this flow
+if you need to customize beyond the Databricks gateway + credential helper.
+
+Note: Claude Desktop does not have a "Import JSON" UI today — file
+replacement under configLibrary/ is the supported import path.
+
+Reference (full list of Claude Desktop configuration keys): %s
+`, libDir, path, desktopDeveloperModeArticleURL)
 	}
 }
 
@@ -439,6 +514,14 @@ func buildMobileconfig(gatewayURL, helperPath string) (string, error) {
 				<false/>
 				<key>isLocalDevMcpEnabled</key>
 				<true/>
+				<key>disableAutoUpdates</key>
+				<false/>
+				<key>disableEssentialTelemetry</key>
+				<false/>
+				<key>disableNonessentialTelemetry</key>
+				<false/>
+				<key>disableNonessentialServices</key>
+				<false/>
 			</dict>
 		</array>
 		<key>PayloadDisplayName</key>
@@ -492,7 +575,127 @@ func buildRegFile(gatewayURL, helperPath string) string {
 	b.WriteString(`"isDesktopExtensionDirectoryEnabled"=dword:00000001` + "\r\n")
 	b.WriteString(`"isDesktopExtensionSignatureRequired"=dword:00000000` + "\r\n")
 	b.WriteString(`"isLocalDevMcpEnabled"=dword:00000001` + "\r\n")
+	b.WriteString(`"disableAutoUpdates"=dword:00000000` + "\r\n")
+	b.WriteString(`"disableEssentialTelemetry"=dword:00000000` + "\r\n")
+	b.WriteString(`"disableNonessentialTelemetry"=dword:00000000` + "\r\n")
+	b.WriteString(`"disableNonessentialServices"=dword:00000000` + "\r\n")
 	return b.String()
+}
+
+// buildDevModeJSON renders the Claude Desktop developer-mode importable JSON.
+// Use case: an individual user wants to customize allow-lists, tools, or
+// branding via Desktop's developer-mode UI without touching the fleet MDM
+// artifacts. The .mobileconfig/.reg are the right format for fleet rollout;
+// this is the right format for per-user customization.
+//
+// inferenceCredentialHelperTtlSec is set to 55 (NOT the validated example's
+// 3600) to match the MDM artifacts. The OAuth helper refreshes tokens with a
+// 5-minute buffer, so a 55-second TTL forces Desktop to re-invoke the helper
+// at a cadence that always sees a fresh token. Diverging from the MDM TTL
+// would give dev-mode users different effective behavior than fleet users.
+//
+// inferenceGatewayApiKey is intentionally absent: the validated example shows
+// "••••••••" which is Desktop's UI placeholder. Our auth flow uses the OAuth
+// credential helper, so no static key is needed.
+//
+// inferenceModels is reused from inferenceModelsJSON via []json.RawMessage so
+// the model list never drifts between the three artifacts.
+func buildDevModeJSON(gatewayURL, helperPath string) ([]byte, error) {
+	var models []json.RawMessage
+	if err := json.Unmarshal([]byte(inferenceModelsJSON), &models); err != nil {
+		return nil, fmt.Errorf("inferenceModelsJSON is malformed: %w", err)
+	}
+
+	cfg := struct {
+		DisableDeploymentModeChooser        bool              `json:"disableDeploymentModeChooser"`
+		InferenceProvider                   string            `json:"inferenceProvider"`
+		InferenceGatewayBaseUrl             string            `json:"inferenceGatewayBaseUrl"`
+		InferenceGatewayAuthScheme          string            `json:"inferenceGatewayAuthScheme"`
+		InferenceModels                     []json.RawMessage `json:"inferenceModels"`
+		InferenceCredentialHelper           string            `json:"inferenceCredentialHelper"`
+		InferenceCredentialHelperTtlSec     int               `json:"inferenceCredentialHelperTtlSec"`
+		IsClaudeCodeForDesktopEnabled       bool              `json:"isClaudeCodeForDesktopEnabled"`
+		IsDesktopExtensionEnabled           bool              `json:"isDesktopExtensionEnabled"`
+		IsDesktopExtensionDirectoryEnabled  bool              `json:"isDesktopExtensionDirectoryEnabled"`
+		IsDesktopExtensionSignatureRequired bool              `json:"isDesktopExtensionSignatureRequired"`
+		IsLocalDevMcpEnabled                bool              `json:"isLocalDevMcpEnabled"`
+		DisableAutoUpdates                  bool              `json:"disableAutoUpdates"`
+		DisableEssentialTelemetry           bool              `json:"disableEssentialTelemetry"`
+		DisableNonessentialTelemetry        bool              `json:"disableNonessentialTelemetry"`
+		DisableNonessentialServices         bool              `json:"disableNonessentialServices"`
+	}{
+		DisableDeploymentModeChooser:        true,
+		InferenceProvider:                   "gateway",
+		InferenceGatewayBaseUrl:             gatewayURL,
+		InferenceGatewayAuthScheme:          "bearer",
+		InferenceModels:                     models,
+		InferenceCredentialHelper:           helperPath,
+		InferenceCredentialHelperTtlSec:     55,
+		IsClaudeCodeForDesktopEnabled:       true,
+		IsDesktopExtensionEnabled:           true,
+		IsDesktopExtensionDirectoryEnabled:  true,
+		IsDesktopExtensionSignatureRequired: false,
+		IsLocalDevMcpEnabled:                true,
+		DisableAutoUpdates:                  false,
+		DisableEssentialTelemetry:           false,
+		DisableNonessentialTelemetry:        false,
+		DisableNonessentialServices:         false,
+	}
+
+	out, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal dev-mode config: %w", err)
+	}
+	out = append(out, '\n')
+	return out, nil
+}
+
+// writeFileAtomic writes data to path atomically: write to <path>.tmp in the
+// same directory, then os.Rename. Mirrors the pattern used by pkg/settings to
+// satisfy the CLAUDE.md "atomic file writes everywhere" mandate.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// guardDevJSONOutputPath refuses to overwrite a JSON file that does not look
+// like a previously-generated dev-mode config. Specifically: if the target
+// exists, parses as JSON, and lacks an `inferenceProvider:"gateway"` field,
+// we abort. This protects against accidental clobbers of e.g.
+// ~/.claude/settings.json via a typo on --output.
+//
+// Non-existent file → allow.
+// Empty file        → allow (nothing to lose).
+// Valid JSON with inferenceProvider == "gateway" → allow (regeneration).
+// Any other case    → refuse with an explicit error mentioning the path.
+func guardDevJSONOutputPath(path string) error {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Size() == 0 {
+		return nil
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var probe struct {
+		InferenceProvider string `json:"inferenceProvider"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return fmt.Errorf("refusing to overwrite %q: not a databricks-claude dev-mode JSON (failed to parse as JSON: %v)", path, err)
+	}
+	if probe.InferenceProvider != "gateway" {
+		return fmt.Errorf("refusing to overwrite %q: not a databricks-claude dev-mode JSON (inferenceProvider=%q, expected %q)", path, probe.InferenceProvider, "gateway")
+	}
+	return nil
 }
 
 // regEscape escapes a string for use inside a Windows .reg REG_SZ value:

--- a/desktop_config_test.go
+++ b/desktop_config_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -55,6 +58,10 @@ func TestBuildMobileconfig_ContainsRequiredKeys(t *testing.T) {
 		`<integer>55</integer>`,
 		`<key>inferenceModels</key>`,
 		`databricks-claude-opus-4-7`,
+		`<key>disableAutoUpdates</key>`,
+		`<key>disableEssentialTelemetry</key>`,
+		`<key>disableNonessentialTelemetry</key>`,
+		`<key>disableNonessentialServices</key>`,
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("mobileconfig missing %q", want)
@@ -112,6 +119,10 @@ func TestBuildRegFile_ContainsRequiredKeys(t *testing.T) {
 		`"isClaudeCodeForDesktopEnabled"=dword:00000001`,
 		`"isDesktopExtensionSignatureRequired"=dword:00000000`,
 		`"isLocalDevMcpEnabled"=dword:00000001`,
+		`"disableAutoUpdates"=dword:00000000`,
+		`"disableEssentialTelemetry"=dword:00000000`,
+		`"disableNonessentialTelemetry"=dword:00000000`,
+		`"disableNonessentialServices"=dword:00000000`,
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf(".reg missing %q", want)
@@ -314,5 +325,373 @@ func TestResolveHelperPath_DerivedFromExecutable(t *testing.T) {
 	}
 	if filepath.Base(got) != wantBase {
 		t.Errorf("resolveHelperPath(\"\") basename = %q, want %q (full=%q)", filepath.Base(got), wantBase, got)
+	}
+}
+
+// ---- buildDevModeJSON ------------------------------------------------------
+
+const (
+	devTestGateway = "https://abc-123.ai-gateway.cloud.databricks.com/anthropic"
+	devTestHelper  = "/usr/local/bin/databricks-claude-credential-helper"
+)
+
+func decodeDevJSON(t *testing.T) map[string]any {
+	t.Helper()
+	out, err := buildDevModeJSON(devTestGateway, devTestHelper)
+	if err != nil {
+		t.Fatalf("buildDevModeJSON: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("decode dev-mode JSON: %v\nbody: %s", err, out)
+	}
+	return m
+}
+
+func TestBuildDevModeJSON_ContainsRequiredKeys(t *testing.T) {
+	m := decodeDevJSON(t)
+	wantBool := map[string]bool{
+		"disableDeploymentModeChooser":        true,
+		"isClaudeCodeForDesktopEnabled":       true,
+		"isDesktopExtensionEnabled":           true,
+		"isDesktopExtensionDirectoryEnabled":  true,
+		"isDesktopExtensionSignatureRequired": false,
+		"isLocalDevMcpEnabled":                true,
+		"disableAutoUpdates":                  false,
+		"disableEssentialTelemetry":           false,
+		"disableNonessentialTelemetry":        false,
+		"disableNonessentialServices":         false,
+	}
+	for k, want := range wantBool {
+		got, ok := m[k].(bool)
+		if !ok {
+			t.Errorf("dev JSON key %q: not a bool (got %T = %v)", k, m[k], m[k])
+			continue
+		}
+		if got != want {
+			t.Errorf("dev JSON key %q = %v, want %v", k, got, want)
+		}
+	}
+	wantStr := map[string]string{
+		"inferenceProvider":          "gateway",
+		"inferenceGatewayBaseUrl":    devTestGateway,
+		"inferenceGatewayAuthScheme": "bearer",
+		"inferenceCredentialHelper":  devTestHelper,
+	}
+	for k, want := range wantStr {
+		got, ok := m[k].(string)
+		if !ok {
+			t.Errorf("dev JSON key %q: not a string (got %T = %v)", k, m[k], m[k])
+			continue
+		}
+		if got != want {
+			t.Errorf("dev JSON key %q = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestBuildDevModeJSON_ValidJSONAndTrailingNewline(t *testing.T) {
+	out, err := buildDevModeJSON(devTestGateway, devTestHelper)
+	if err != nil {
+		t.Fatalf("buildDevModeJSON: %v", err)
+	}
+	if len(out) == 0 || out[len(out)-1] != '\n' {
+		t.Errorf("dev-mode JSON must end with newline; last byte = %q", out[len(out)-1])
+	}
+	var sink map[string]any
+	if err := json.Unmarshal(out, &sink); err != nil {
+		t.Errorf("output is not valid JSON: %v", err)
+	}
+}
+
+func TestBuildDevModeJSON_NoInferenceGatewayApiKey(t *testing.T) {
+	out, err := buildDevModeJSON(devTestGateway, devTestHelper)
+	if err != nil {
+		t.Fatalf("buildDevModeJSON: %v", err)
+	}
+	if strings.Contains(string(out), "inferenceGatewayApiKey") {
+		t.Errorf("dev-mode JSON must NOT contain inferenceGatewayApiKey (UI placeholder, OAuth via helper)")
+	}
+}
+
+func TestBuildDevModeJSON_ModelsArrayShape(t *testing.T) {
+	m := decodeDevJSON(t)
+	models, ok := m["inferenceModels"].([]any)
+	if !ok {
+		t.Fatalf("inferenceModels: not a JSON array, got %T", m["inferenceModels"])
+	}
+	// Should match the count in inferenceModelsJSON.
+	var want []json.RawMessage
+	if err := json.Unmarshal([]byte(inferenceModelsJSON), &want); err != nil {
+		t.Fatalf("inferenceModelsJSON malformed: %v", err)
+	}
+	if len(models) != len(want) {
+		t.Fatalf("inferenceModels length = %d, want %d", len(models), len(want))
+	}
+	first, ok := models[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first model: not an object, got %T", models[0])
+	}
+	if first["name"] != "databricks-claude-opus-4-7" {
+		t.Errorf("first model name = %v, want databricks-claude-opus-4-7", first["name"])
+	}
+	if first["supports1m"] != true {
+		t.Errorf("first model supports1m = %v, want true", first["supports1m"])
+	}
+}
+
+func TestBuildDevModeJSON_TtlIs55(t *testing.T) {
+	m := decodeDevJSON(t)
+	ttl, ok := m["inferenceCredentialHelperTtlSec"].(float64)
+	if !ok {
+		t.Fatalf("inferenceCredentialHelperTtlSec: not a number, got %T", m["inferenceCredentialHelperTtlSec"])
+	}
+	if ttl != 55 {
+		t.Errorf("inferenceCredentialHelperTtlSec = %v, want 55 (matches MDM TTL; do not drift to 3600)", ttl)
+	}
+}
+
+func TestBuildDevModeJSON_PreservesPaths(t *testing.T) {
+	gateway := "https://example.com/anthropic?a=1&b=2"
+	helper := "/Applications/Foo Bar/databricks-claude-credential-helper"
+	out, err := buildDevModeJSON(gateway, helper)
+	if err != nil {
+		t.Fatalf("buildDevModeJSON: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if m["inferenceGatewayBaseUrl"] != gateway {
+		t.Errorf("gateway URL not preserved: got %q", m["inferenceGatewayBaseUrl"])
+	}
+	if m["inferenceCredentialHelper"] != helper {
+		t.Errorf("helper path not preserved: got %q", m["inferenceCredentialHelper"])
+	}
+}
+
+// TestInferenceModelsConsistencyAcrossArtifacts proves the model list is
+// byte-identical across all three artifacts so a future model addition
+// to inferenceModelsJSON propagates everywhere automatically.
+func TestInferenceModelsConsistencyAcrossArtifacts(t *testing.T) {
+	gateway := "https://x.example.com/anthropic"
+	helper := "/path/to/helper"
+
+	// JSON: models array elements should byte-equal the constant elements.
+	devOut, err := buildDevModeJSON(gateway, helper)
+	if err != nil {
+		t.Fatalf("buildDevModeJSON: %v", err)
+	}
+	var devShape struct {
+		Models []json.RawMessage `json:"inferenceModels"`
+	}
+	if err := json.Unmarshal(devOut, &devShape); err != nil {
+		t.Fatalf("decode dev JSON: %v", err)
+	}
+	var want []json.RawMessage
+	if err := json.Unmarshal([]byte(inferenceModelsJSON), &want); err != nil {
+		t.Fatalf("inferenceModelsJSON malformed: %v", err)
+	}
+	if len(devShape.Models) != len(want) {
+		t.Fatalf("dev JSON model count = %d, want %d", len(devShape.Models), len(want))
+	}
+	// MarshalIndent re-indents json.RawMessage elements, so compare the
+	// compact form of each side. Compact bytes are byte-equal iff the JSON
+	// is semantically identical down to key order — which is what "single
+	// source of truth" demands.
+	for i := range want {
+		gotC, errG := compactJSON(devShape.Models[i])
+		wantC, errW := compactJSON(want[i])
+		if errG != nil || errW != nil {
+			t.Fatalf("compact: got err=%v want err=%v", errG, errW)
+		}
+		if !bytes.Equal(gotC, wantC) {
+			t.Errorf("dev JSON model[%d] (compact) = %s, want %s", i, gotC, wantC)
+		}
+	}
+
+	// Mobileconfig: extract the <string>...</string> body for inferenceModels
+	// and reverse plistEscape; should equal inferenceModelsJSON verbatim.
+	mc, err := buildMobileconfig(gateway, helper)
+	if err != nil {
+		t.Fatalf("buildMobileconfig: %v", err)
+	}
+	mcModels := extractMobileconfigModels(t, mc)
+	mcUnescaped := unescapePlist(mcModels)
+	if mcUnescaped != inferenceModelsJSON {
+		t.Errorf("mobileconfig models (unescaped) = %q,\nwant %q", mcUnescaped, inferenceModelsJSON)
+	}
+
+	// Reg: extract the inferenceModels="..." value and reverse regEscape.
+	reg := buildRegFile(gateway, helper)
+	regModels := extractRegModels(t, reg)
+	regUnescaped := unescapeReg(regModels)
+	if regUnescaped != inferenceModelsJSON {
+		t.Errorf("reg models (unescaped) = %q,\nwant %q", regUnescaped, inferenceModelsJSON)
+	}
+}
+
+// compactJSON returns the canonical compact form of a JSON byte slice. Two
+// byte slices that compact-equal are semantically identical to encoding/json,
+// regardless of whitespace or MarshalIndent re-formatting.
+func compactJSON(in []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, in); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func extractMobileconfigModels(t *testing.T, plist string) string {
+	t.Helper()
+	re := regexp.MustCompile(`<key>inferenceModels</key>\s*<string>([^<]*)</string>`)
+	m := re.FindStringSubmatch(plist)
+	if len(m) != 2 {
+		t.Fatalf("could not find inferenceModels <string> in mobileconfig")
+	}
+	return m[1]
+}
+
+func unescapePlist(s string) string {
+	r := strings.NewReplacer(
+		"&apos;", "'",
+		"&quot;", `"`,
+		"&gt;", ">",
+		"&lt;", "<",
+		"&amp;", "&",
+	)
+	return r.Replace(s)
+}
+
+func extractRegModels(t *testing.T, reg string) string {
+	t.Helper()
+	re := regexp.MustCompile(`"inferenceModels"="([^"\\]*(?:\\.[^"\\]*)*)"`)
+	m := re.FindStringSubmatch(reg)
+	if len(m) != 2 {
+		t.Fatalf("could not find inferenceModels in reg file")
+	}
+	return m[1]
+}
+
+func unescapeReg(s string) string {
+	// Reverse regEscape: \" → ", \\ → \. Order matters: \" first, then \\.
+	r := strings.NewReplacer(
+		`\"`, `"`,
+		`\\`, `\`,
+	)
+	return r.Replace(s)
+}
+
+// ---- writeFileAtomic & writeDesktopConfigByPath ----------------------------
+
+func TestWriteFileAtomic_RenamesFromTempInSameDir(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.json")
+	want := []byte("hello\n")
+	if err := writeFileAtomic(target, want, 0o600); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("contents = %q, want %q", got, want)
+	}
+	// .tmp must not exist after success.
+	if _, err := os.Stat(target + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf(".tmp file leaked: stat err = %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Errorf("perm = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestWriteDesktopConfigByPath_JsonExtension(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.json")
+	if err := writeDesktopConfigByPath(target, "https://x.example.com/anthropic", "/bin/h"); err != nil {
+		t.Fatalf("writeDesktopConfigByPath: %v", err)
+	}
+	raw, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("file is not valid JSON: %v", err)
+	}
+	if m["inferenceProvider"] != "gateway" {
+		t.Errorf("inferenceProvider = %v, want gateway", m["inferenceProvider"])
+	}
+}
+
+// ---- guardDevJSONOutputPath ------------------------------------------------
+
+func TestGuardDevJSONOutputPath_NonExistent(t *testing.T) {
+	dir := t.TempDir()
+	if err := guardDevJSONOutputPath(filepath.Join(dir, "does-not-exist.json")); err != nil {
+		t.Errorf("expected nil for non-existent file, got %v", err)
+	}
+}
+
+func TestGuardDevJSONOutputPath_Empty(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(p, []byte{}, 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := guardDevJSONOutputPath(p); err != nil {
+		t.Errorf("expected nil for empty file, got %v", err)
+	}
+}
+
+func TestGuardDevJSONOutputPath_OurOwnConfig(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "ours.json")
+	body, err := buildDevModeJSON("https://x", "/bin/h")
+	if err != nil {
+		t.Fatalf("buildDevModeJSON: %v", err)
+	}
+	if err := os.WriteFile(p, body, 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := guardDevJSONOutputPath(p); err != nil {
+		t.Errorf("expected nil for our own config (regeneration is allowed), got %v", err)
+	}
+}
+
+func TestGuardDevJSONOutputPath_ClaudeSettingsJSON(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "settings.json")
+	settings := []byte(`{"env":{"FOO":"bar"},"hooks":{}}`)
+	if err := os.WriteFile(p, settings, 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	err := guardDevJSONOutputPath(p)
+	if err == nil {
+		t.Fatalf("expected error refusing to overwrite settings.json-shaped file, got nil")
+	}
+	if !strings.Contains(err.Error(), p) {
+		t.Errorf("error must mention the path %q, got %v", p, err)
+	}
+}
+
+func TestGuardDevJSONOutputPath_NotJSON(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "garbage.json")
+	if err := os.WriteFile(p, []byte("not json at all <<<"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	err := guardDevJSONOutputPath(p)
+	if err == nil {
+		t.Fatalf("expected error refusing to overwrite non-JSON file, got nil")
+	}
+	if !strings.Contains(err.Error(), p) {
+		t.Errorf("error must mention the path %q, got %v", p, err)
 	}
 }


### PR DESCRIPTION
`desktop generate-config` now writes a third artifact alongside the existing .mobileconfig and .reg: an editable JSON that loads into Claude Desktop's developer-mode configuration library. Users who need to customize beyond the Databricks gateway + credential-helper defaults (allow-lists, tools, branding, telemetry policy) replace the file inside ~/Library/Application Support/Claude-3p/configLibrary/, edit in Desktop's UI, and export back to .mobileconfig / .reg for MDM rollout.

The new buildDevModeJSON reuses inferenceModelsJSON via []json.RawMessage so the model list is byte-identical across all three artifacts (verified by TestInferenceModelsConsistencyAcrossArtifacts). All artifact writes now go through writeFileAtomic to satisfy the CLAUDE.md atomic-write mandate. A guardDevJSONOutputPath check refuses to overwrite a .json target that does not look like a previously-generated dev-mode config, preventing accidental clobber of ~/.claude/settings.json via --output typos.

For parity, the four telemetry/update keys (disableAutoUpdates, disableEssentialTelemetry, disableNonessentialTelemetry, disableNonessentialServices) are now also emitted by buildMobileconfig and buildRegFile so all three artifacts encode identical Desktop behavior. Existing TestBuild{Mobileconfig,RegFile}_ContainsRequiredKeys updated.

README documents the configLibrary/ file-replacement workflow and links the Anthropic support article. AGENTS.md adds desktop_config.go and desktop_config_test.go to the Key Files table. .gitignore picks up databricks-claude-desktop.json so generated artifacts don't get accidentally committed.