### PR TITLE
Feat/self signed pkg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -39,6 +40,75 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload ${{ needs.release-please.outputs.tag_name }} dist/*
+
+  package-macos:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+      - name: Import code-signing cert
+        # SHA verified via: gh api repos/Apple-Actions/import-codesign-certs/git/refs/tags/v3
+        # Both v3 and v3.0.0 resolve to 63fff01cd422d4b7b855d40ca1e9d34d2de9427d (verified 2026-04-28)
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
+        with:
+          p12-file-base64: ${{ secrets.APPLE_INTERNAL_SIGNING_P12_BASE64 }}
+          p12-password: ${{ secrets.APPLE_INTERNAL_SIGNING_P12_PASSWORD }}
+      - name: Configure keychain trust for self-signed cert
+        env:
+          P12_PASSWORD: ${{ secrets.APPLE_INTERNAL_SIGNING_P12_PASSWORD }}
+        run: |
+          # apple-actions/import-codesign-certs creates a temp keychain but
+          # doesn't authorize productsign to use the key. set-key-partition-list
+          # adds the codesign:/apple-tool: ACL so productsign won't fail with
+          # errSecInternalComponent on headless runners.
+          KC="${KEYCHAIN_PATH:-${KEYCHAIN_NAME:-$(security default-keychain -d user | tr -d ' "')}}"
+          echo "Using keychain: $KC"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$P12_PASSWORD" "$KC"
+          security list-keychains -d user -s "$KC" login.keychain-db
+      - name: Write signing-cert PEM for trust profile
+        env:
+          CERT_PEM: ${{ secrets.APPLE_INTERNAL_SIGNING_CERT_PEM }}
+        run: |
+          mkdir -p dist
+          printf '%s\n' "$CERT_PEM" > dist/signing-cert.pem
+      - name: Build signed .pkg
+        env:
+          APPLE_INTERNAL_SIGNING_IDENTITY: ${{ secrets.APPLE_INTERNAL_SIGNING_IDENTITY }}
+        run: make pkg
+      - name: Verify hardened runtime
+        run: codesign -dv --verbose=4 build/databricks-claude 2>&1 | grep -E 'flags=.*runtime'
+      - name: Build trust profile
+        run: make trust-profile
+      - name: Validate trust profile plist
+        run: plutil -lint dist/databricks-claude-trust.mobileconfig
+      - name: Assert canonical helper path is embedded
+        run: |
+          # MUST match desktop_config.MacOSCanonicalHelperPath
+          # (locked by TestMacOSCanonicalHelperPathLiteral).
+          EXPECTED="/usr/local/bin/databricks-claude-credential-helper"
+          pkgutil --payload-files dist/databricks-claude.pkg | grep -F "$EXPECTED"
+      - name: Assert pkg signature
+        run: |
+          # Self-signed certs report 'signed by untrusted identifier' on
+          # runners without the trust profile installed; that's expected.
+          OUT=$(pkgutil --check-signature dist/databricks-claude.pkg)
+          echo "$OUT"
+          echo "$OUT" | grep -E "Status: (signed|signed by untrusted identifier)"
+          echo "$OUT" | grep -F "Databricks Claude Internal Code Signing"
+      - name: Upload pkg + trust profile to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
+            dist/databricks-claude.pkg \
+            dist/databricks-claude-trust.mobileconfig
 
   update-homebrew:
     needs: [release-please, build-and-upload]

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ dist/
 *.mobileconfig
 *.reg
 databricks-claude-desktop.json
+build/
+root/
+scripts/postinstall
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS := -s -w -X main.Version=$(VERSION)
 
+# Subject identity for `make generate-signing-cert`. Override these for your
+# org before rotating into production — admins forking this repo MUST NOT
+# leave the defaults in place for a fleet rollout, as the defaults are
+# deliberately template-y to avoid impersonating any real organization.
+CERT_CN      ?= databricks-claude code signing (REPLACE FOR PROD)
+CERT_ORG     ?= databricks-claude self-signed (REPLACE FOR PROD)
+CERT_COUNTRY ?= US
+
 .DEFAULT_GOAL := build
 
 ## Build the databricks-claude binary (and the credential-helper symlink that
@@ -32,13 +40,102 @@ dist:
 	GOOS=windows GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-claude-windows-amd64.exe .
 	GOOS=windows GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-claude-windows-arm64.exe .
 
+## Build a universal2 macOS .pkg installer. Set APPLE_INTERNAL_SIGNING_IDENTITY
+## (and run inside `apple-actions/import-codesign-certs` keychain) to produce a
+## signed .pkg; otherwise the binary is ad-hoc signed and the .pkg is unsigned
+## (good enough for local dev).
+pkg:
+	rm -rf build root scripts/postinstall dist/databricks-claude*.pkg
+	mkdir -p build dist scripts root/usr/local/bin
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o dist/databricks-claude-darwin-arm64 .
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o dist/databricks-claude-darwin-amd64 .
+	lipo -create -output build/databricks-claude dist/databricks-claude-darwin-arm64 dist/databricks-claude-darwin-amd64
+	@if [ -n "$$APPLE_INTERNAL_SIGNING_IDENTITY" ]; then \
+		echo "Signing binary with identity: $$APPLE_INTERNAL_SIGNING_IDENTITY"; \
+		codesign --force --options runtime --timestamp --sign "$$APPLE_INTERNAL_SIGNING_IDENTITY" build/databricks-claude; \
+	else \
+		echo "APPLE_INTERNAL_SIGNING_IDENTITY unset — ad-hoc signing"; \
+		codesign --force --options runtime --sign - build/databricks-claude; \
+	fi
+	cp build/databricks-claude root/usr/local/bin/databricks-claude
+	printf '#!/bin/sh\nset -e\ncd /usr/local/bin\nln -sf databricks-claude databricks-claude-credential-helper\n' > scripts/postinstall
+	chmod +x scripts/postinstall
+	pkgbuild --root root --scripts scripts \
+		--identifier com.databricks.databricks-claude \
+		--version "$(VERSION)" \
+		--install-location / \
+		dist/databricks-claude-component.pkg
+	productbuild --package dist/databricks-claude-component.pkg \
+		--identifier com.databricks.databricks-claude.dist \
+		--version "$(VERSION)" \
+		dist/databricks-claude-unsigned.pkg
+	@if [ -n "$$APPLE_INTERNAL_SIGNING_IDENTITY" ]; then \
+		echo "Signing .pkg with identity: $$APPLE_INTERNAL_SIGNING_IDENTITY"; \
+		productsign --sign "$$APPLE_INTERNAL_SIGNING_IDENTITY" dist/databricks-claude-unsigned.pkg dist/databricks-claude.pkg; \
+		rm -f dist/databricks-claude-unsigned.pkg; \
+	else \
+		mv dist/databricks-claude-unsigned.pkg dist/databricks-claude.pkg; \
+	fi
+	rm -f dist/databricks-claude-component.pkg
+	@echo "Built dist/databricks-claude.pkg"
+
+## Emit the MDM trust profile (.mobileconfig) that establishes the signing cert
+## as a trusted root for code-signing on managed Macs. Requires
+## dist/signing-cert.pem (run `make generate-signing-cert` first).
+trust-profile: build
+	./databricks-claude desktop generate-trust-profile \
+		--cert dist/signing-cert.pem \
+		--output dist/databricks-claude-trust.mobileconfig
+
+## Generate a 5-year self-signed code-signing cert for the .pkg. Run once;
+## paste the printed values into GitHub repo secrets. Rotate ≥60 days before
+## expiry (see README rotation runbook).
+generate-signing-cert:
+	mkdir -p dist
+	@if [ -z "$$P12_PASSWORD" ]; then \
+		echo "ERROR: set P12_PASSWORD env var (a strong random password)"; \
+		exit 1; \
+	fi
+	@if [ -f dist/signing-cert.key ]; then \
+		echo "ERROR: dist/signing-cert.key already exists. Refusing to overwrite."; \
+		echo "       Move/archive the existing key first if you intend to rotate."; \
+		exit 1; \
+	fi
+	@echo "Generating cert with subject:"
+	@echo "  CN=$(CERT_CN)"
+	@echo "  O=$(CERT_ORG)"
+	@echo "  C=$(CERT_COUNTRY)"
+	@case "$(CERT_CN)$(CERT_ORG)" in *"REPLACE FOR PROD"*) \
+		echo ""; \
+		echo "WARNING: cert subject contains the placeholder 'REPLACE FOR PROD'."; \
+		echo "         For a real fleet rollout, override CERT_CN, CERT_ORG, and"; \
+		echo "         CERT_COUNTRY to your org's identity. Continuing in 3s — Ctrl-C to abort."; \
+		sleep 3 ;; \
+	esac
+	openssl req -x509 -newkey rsa:2048 -days 1825 -nodes \
+		-subj "/CN=$(CERT_CN)/O=$(CERT_ORG)/C=$(CERT_COUNTRY)" \
+		-addext "extendedKeyUsage=codeSigning" \
+		-keyout dist/signing-cert.key -out dist/signing-cert.pem
+	openssl pkcs12 -export -out dist/signing-cert.p12 \
+		-inkey dist/signing-cert.key -in dist/signing-cert.pem \
+		-passout pass:"$$P12_PASSWORD"
+	base64 -i dist/signing-cert.p12 -o dist/signing-cert.p12.b64
+	@echo
+	@echo "Cert generated. Paste the following into GitHub repo secrets:"
+	@echo "  APPLE_INTERNAL_SIGNING_P12_BASE64    = (contents of dist/signing-cert.p12.b64)"
+	@echo "  APPLE_INTERNAL_SIGNING_P12_PASSWORD  = (the value of P12_PASSWORD)"
+	@echo "  APPLE_INTERNAL_SIGNING_IDENTITY      = $(CERT_CN)"
+	@echo "  APPLE_INTERNAL_SIGNING_CERT_PEM      = (contents of dist/signing-cert.pem)"
+	@echo
+	@echo "Rotate this cert >=60 days before expiry."
+
 ## Remove build artifacts
 clean:
 	rm -f databricks-claude databricks-claude-credential-helper
-	rm -rf dist/
+	rm -rf dist/ build/ root/ scripts/postinstall
 
 ## Run go vet
 lint:
 	go vet ./...
 
-.PHONY: build install test dist clean lint
+.PHONY: build install test dist clean lint pkg trust-profile generate-signing-cert

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The `.claude-plugin/` directory and `hooks/hooks.json` at the repo root define t
    - **macOS**: `open databricks-claude-desktop.mobileconfig`, then approve in System Settings → Privacy & Security → Profiles.
    - **Windows**: double-click the `.reg` file, or `reg import databricks-claude-desktop.reg`.
 
-   For fleet rollout via Jamf / Kandji / Intune / Group Policy, ship the same `.mobileconfig` or `.reg` to your endpoints. See [MDM / fleet rollout](#mdm--fleet-rollout) for path-pinning flags.
+   For fleet rollout via Jamf / Kandji / Intune / Group Policy, ship the same `.mobileconfig` or `.reg` to your endpoints. See [MDM / fleet rollout](#mdm--fleet-rollout) for path-pinning flags, or [MDM internal deployment (self-signed)](#mdm-internal-deployment-self-signed) if you are rolling out via a signed `.pkg` installer.
 5. **Restart Claude Desktop.**
 
 After this, Desktop's third-party-inference path runs against your Databricks AI Gateway, with tokens refreshed automatically by the credential helper.
@@ -168,6 +168,60 @@ databricks-claude desktop generate-config \
 - `--databricks-cli-path` pins the `databricks` CLI absolute path. It's persisted to `~/.claude/.databricks-claude.json` on the generating machine; admins should arrange for the same field to be set on every endpoint (either by running this command per-user, or by dropping the state file via the same MDM tooling).
 
 The packaging method (`.pkg` installer, custom `brew` formula, etc.) is responsible for ensuring `databricks-claude` and its `databricks-claude-credential-helper` symlink land at the paths you embed in the config.
+
+For fleet rollout via MDM using the signed `.pkg` installer, see [MDM deployment with signed `.pkg`](#mdm-deployment-with-signed-pkg-self-signed) below.
+
+### MDM deployment with signed `.pkg` (self-signed)
+
+> **Audience**: any admin rolling out Claude Desktop + Databricks AI Gateway to their workforce via MDM (Jamf, Kandji, Intune, etc.). This repo is a template — fork it, set your org's signing identity, and ship signed `.pkg`s to your managed Macs. The `.pkg` is signed with a self-signed certificate that is only trusted on endpoints where the matching trust profile has been deployed via MDM. For unmanaged Macs, use the Homebrew tap.
+
+#### The three artifacts
+
+Each release publishes three artifacts for managed fleet deployment:
+
+- `databricks-claude.pkg` — the installer. Deploys the binary and creates a `databricks-claude-credential-helper` symlink at `/usr/local/bin`.
+- `databricks-claude-trust.mobileconfig` — Configuration Profile that establishes the signing certificate as a trusted root for code-signing. Deploy this once per fleet before deploying the `.pkg`.
+- A workspace-specific `.mobileconfig` — generated per Databricks workspace by an MDM admin:
+  ```bash
+  databricks-claude desktop generate-config --for-pkg --profile <workspace-profile>
+  ```
+  The `--for-pkg` flag bakes the canonical `/usr/local/bin/databricks-claude-credential-helper` path so the credential-helper path matches what the `.pkg` installer places on disk.
+
+#### Deployment order
+
+1. Deploy `databricks-claude-trust.mobileconfig` (once per fleet — establishes cert trust before the signed binary arrives).
+2. Deploy `databricks-claude.pkg` (installs the binary and credential-helper symlink).
+3. Deploy the workspace-specific `.mobileconfig` (points Claude Desktop at the correct AI Gateway and credential helper).
+
+#### Cert rotation runbook
+
+**Cadence**: Rotate at least 60 days before the certificate expires. The cert is 5-year self-signed; track expiry via the `notBefore`/`notAfter` fields in `dist/signing-cert.pem`. Future work: add automated cert-expiry alerting.
+
+**Sequence**:
+
+1. Run `make generate-signing-cert` with `P12_PASSWORD` set to a strong random value, plus `CERT_CN` / `CERT_ORG` / `CERT_COUNTRY` set to your org's identity (see [Maintainer cert bootstrap](#maintainer-cert-bootstrap-one-time)). Keep the CN identical to the previous rotation unless you specifically intend to change the displayed signing identity.
+2. Update GitHub repo secrets: `APPLE_INTERNAL_SIGNING_P12_BASE64`, `APPLE_INTERNAL_SIGNING_P12_PASSWORD`, `APPLE_INTERNAL_SIGNING_CERT_PEM` (and `APPLE_INTERNAL_SIGNING_IDENTITY` only if the certificate CN changed).
+3. Cut a new release — release-please will dispatch the package-macos job, producing a new `.pkg` and a new `databricks-claude-trust.mobileconfig`.
+4. MDM admins deploy the new trust profile **alongside** the old one, before the old certificate expires. This overlap window prevents a gap where no trusted certificate covers endpoints in the middle of the rollout.
+5. Once the new release is broadly deployed, remove the old trust profile.
+
+**Rollback**: Keep the prior `.p12` and identity in a separate secret-vault entry. If the new certificate fails MDM acceptance: restore the old GitHub secrets, redeploy the old trust profile, and cut a hotfix release using the prior identity. Do not overwrite the prior P12 vault entry until the new certificate has been broadly accepted.
+
+#### Maintainer cert bootstrap (one-time)
+
+Generate the initial signing certificate with **your org's identity** baked into the cert subject, then load it into GitHub secrets:
+
+```bash
+P12_PASSWORD=<strong-random-value> \
+CERT_CN="<Your Org> Claude Desktop Code Signing" \
+CERT_ORG="<Your Org>" \
+CERT_COUNTRY=US \
+  make generate-signing-cert
+```
+
+`CERT_CN`, `CERT_ORG`, and `CERT_COUNTRY` set the cert subject. They default to deliberately template-y placeholders (`...REPLACE FOR PROD`) so an unconfigured run is obviously not production-ready; override them before rolling out to your fleet. The CN is what your endpoints will see in `pkgutil --check-signature` and Gatekeeper dialogs once the trust profile is deployed, so pick something your IT/security org will recognize as authoritative.
+
+The command prints the base64-encoded `.p12`, the PEM certificate, and the signing identity string. Paste each into the corresponding GitHub repo secret (`APPLE_INTERNAL_SIGNING_P12_BASE64`, `APPLE_INTERNAL_SIGNING_P12_PASSWORD`, `APPLE_INTERNAL_SIGNING_CERT_PEM`, `APPLE_INTERNAL_SIGNING_IDENTITY`). The `.p12` file itself must not be committed — it is covered by `.gitignore`.
 
 ### Troubleshooting
 

--- a/desktop_config.go
+++ b/desktop_config.go
@@ -59,6 +59,13 @@ const desktopDeveloperModeArticleURL = "https://support.claude.com/en/articles/1
 // can target it directly.
 const credentialHelperBinaryName = "databricks-claude-credential-helper"
 
+// MacOSCanonicalBinaryDir is the canonical install dir for the .pkg-shipped binary on macOS.
+// It is the source of truth for the path baked into the postinstall script and the
+// mobileconfig generated with --for-pkg. Changing this requires updating
+// .github/workflows/release.yml and the locking test in desktop_path_test.go.
+const MacOSCanonicalBinaryDir = "/usr/local/bin"
+const MacOSCanonicalHelperPath = MacOSCanonicalBinaryDir + "/" + credentialHelperBinaryName
+
 // isCredentialHelperBinaryName returns true if the program was invoked under
 // the credential-helper alias. Pass os.Args[0] (or any argv[0]-like value).
 func isCredentialHelperBinaryName(arg0 string) bool {
@@ -80,14 +87,21 @@ func runDesktopCommand(args []string) {
 		printDesktopHelp()
 		os.Exit(0)
 	case "generate-config":
+		forPkg, _ := extractForPkgFlag(args[1:])
 		runGenerateDesktopConfig(
 			extractProfileFlag(args[1:]),
 			extractOutputFlag(args[1:]),
 			extractBinaryPathFlag(args[1:]),
 			extractDatabricksCLIPathFlag(args[1:]),
+			forPkg,
 		)
 	case "credential-helper":
 		runCredentialHelper(extractProfileFlag(args[1:]))
+	case "generate-trust-profile":
+		if err := runGenerateTrustProfile(args[1:]); err != nil {
+			fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
+			os.Exit(1)
+		}
 	default:
 		fmt.Fprintf(os.Stderr, "databricks-claude: unknown desktop action %q\n\n", args[0])
 		printDesktopHelp()
@@ -117,12 +131,20 @@ Actions:
                       path Claude Desktop's inferenceCredentialHelper invokes
                       via the databricks-claude-credential-helper symlink.
                       Useful for scripting and debug.
+  generate-trust-profile
+                      Emit a Configuration Profile (.mobileconfig) that
+                      establishes the .pkg signing certificate as a trusted
+                      root for code-signing on managed Macs. Pair with the
+                      signed .pkg in your MDM rollout so Gatekeeper accepts
+                      the installer without per-device prompts.
 
 Flags:
   --profile string              Databricks CLI profile (default: state file > DEFAULT)
   --output string               Single output path for generate-config; format
                                 inferred from .mobileconfig/.reg/.json extension
-                                or host OS.
+                                or host OS. Also the output path for
+                                generate-trust-profile (default:
+                                dist/databricks-claude-trust.mobileconfig).
   --binary-path string          generate-config: credential-helper path embedded in
                                 the generated config (default: derived from the
                                 running binary). Use this for MDM rollouts so one
@@ -130,6 +152,9 @@ Flags:
   --databricks-cli-path string  generate-config: pin the absolute path of the
                                 'databricks' CLI used by the credential helper.
                                 Persisted to ~/.claude/.databricks-claude.json.
+  --cert string                 generate-trust-profile: path to a PEM-encoded
+                                x509 certificate (the .pkg signing cert) to
+                                wrap as a trusted root.
 
 Examples:
   # First-time setup on your Mac.
@@ -142,6 +167,11 @@ Examples:
 
   # Print a token directly (debug; equivalent to invoking the helper symlink).
   databricks-claude desktop credential-helper --profile myws
+
+  # Emit a code-signing trust profile for MDM (pairs with a signed .pkg).
+  databricks-claude desktop generate-trust-profile \
+    --cert ./codesign-cert.pem \
+    --output dist/databricks-claude-trust.mobileconfig
 `)
 }
 
@@ -217,7 +247,7 @@ func runCredentialHelper(profile string) {
 // When outputPath is empty, both .mobileconfig and .reg are always written so
 // one invocation produces artifacts for every supported Claude Desktop
 // platform. Use --output to write a single specific file.
-func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride, databricksCLIPath string) {
+func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride, databricksCLIPath string, forPkg bool) {
 	log.SetOutput(io.Discard)
 
 	resolved := profile
@@ -265,7 +295,7 @@ func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride, databrick
 	}
 	gatewayURL := ConstructGatewayURL(host, tok)
 
-	helperPath, err := resolveHelperPath(binaryPathOverride)
+	helperPath, err := resolveHelperPath(binaryPathOverride, forPkg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
 		os.Exit(1)
@@ -332,12 +362,19 @@ func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride, databrick
 // resolveHelperPath returns the absolute path embedded into the generated
 // Claude Desktop config. Order:
 //  1. explicit override (e.g. /usr/local/bin/databricks-claude-credential-helper)
-//  2. derived from the running binary: replace its basename with the
+//  2. when forPkg && darwin: the canonical .pkg install path
+//     (MacOSCanonicalHelperPath). Used for MDM rollouts so the same artifact
+//     works on every endpoint regardless of where the generating user ran the
+//     binary from.
+//  3. derived from the running binary: replace its basename with the
 //     credential-helper alias name, preserving the install dir and any .exe
 //     suffix on Windows.
-func resolveHelperPath(override string) (string, error) {
+func resolveHelperPath(override string, forPkg bool) (string, error) {
 	if override != "" {
 		return override, nil
+	}
+	if forPkg && runtime.GOOS == "darwin" {
+		return MacOSCanonicalHelperPath, nil
 	}
 	exe, err := os.Executable()
 	if err != nil {
@@ -769,6 +806,28 @@ func extractDatabricksCLIPathFlag(args []string) string {
 		}
 	}
 	return ""
+}
+
+// extractForPkgFlag scans args for the boolean --for-pkg flag. Mirrors the
+// other extract* helpers in shape but is presence-only: --for-pkg toggles
+// forPkg=true, --for-pkg=true / --for-pkg=false honour the explicit value.
+// Returns the parsed value plus a copy of args with the flag removed.
+func extractForPkgFlag(args []string) (forPkg bool, remaining []string) {
+	remaining = make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--for-pkg" {
+			forPkg = true
+			continue
+		}
+		if strings.HasPrefix(a, "--for-pkg=") {
+			v := strings.TrimPrefix(a, "--for-pkg=")
+			forPkg = v == "true" || v == "1" || v == ""
+			continue
+		}
+		remaining = append(remaining, a)
+	}
+	return forPkg, remaining
 }
 
 // hasFlag returns true if any element of args equals name (or starts with

--- a/desktop_config_test.go
+++ b/desktop_config_test.go
@@ -302,7 +302,7 @@ func TestExtractBinaryPathFlag(t *testing.T) {
 
 func TestResolveHelperPath_Override(t *testing.T) {
 	override := "/usr/local/bin/databricks-claude-credential-helper"
-	got, err := resolveHelperPath(override)
+	got, err := resolveHelperPath(override, false)
 	if err != nil {
 		t.Fatalf("resolveHelperPath: %v", err)
 	}
@@ -315,7 +315,7 @@ func TestResolveHelperPath_DerivedFromExecutable(t *testing.T) {
 	// With no override, the helper path is the running test binary's
 	// directory + the credential-helper alias name. We can't predict the
 	// exact dir but we can assert the basename.
-	got, err := resolveHelperPath("")
+	got, err := resolveHelperPath("", false)
 	if err != nil {
 		t.Fatalf("resolveHelperPath: %v", err)
 	}
@@ -325,6 +325,92 @@ func TestResolveHelperPath_DerivedFromExecutable(t *testing.T) {
 	}
 	if filepath.Base(got) != wantBase {
 		t.Errorf("resolveHelperPath(\"\") basename = %q, want %q (full=%q)", filepath.Base(got), wantBase, got)
+	}
+}
+
+func TestResolveHelperPath_ForPkgDarwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skipf("forPkg darwin branch only fires on darwin; GOOS=%s", runtime.GOOS)
+	}
+	got, err := resolveHelperPath("", true)
+	if err != nil {
+		t.Fatalf("resolveHelperPath: %v", err)
+	}
+	if got != MacOSCanonicalHelperPath {
+		t.Errorf("resolveHelperPath(\"\", true) = %q, want %q", got, MacOSCanonicalHelperPath)
+	}
+}
+
+func TestResolveHelperPath_ForPkgPreservesOverride(t *testing.T) {
+	override := "/custom/path/foo"
+	got, err := resolveHelperPath(override, true)
+	if err != nil {
+		t.Fatalf("resolveHelperPath: %v", err)
+	}
+	if got != override {
+		t.Errorf("resolveHelperPath(%q, true) = %q, want %q (explicit override must win regardless of forPkg/GOOS)", override, got, override)
+	}
+}
+
+func TestExtractForPkgFlag(t *testing.T) {
+	cases := []struct {
+		name          string
+		args          []string
+		wantForPkg    bool
+		wantRemaining []string
+	}{
+		{
+			name:          "absent",
+			args:          []string{"--profile", "prod", "--output", "/tmp/x"},
+			wantForPkg:    false,
+			wantRemaining: []string{"--profile", "prod", "--output", "/tmp/x"},
+		},
+		{
+			name:          "bare flag present",
+			args:          []string{"--for-pkg"},
+			wantForPkg:    true,
+			wantRemaining: []string{},
+		},
+		{
+			name:          "mixed with other flags",
+			args:          []string{"--profile", "prod", "--for-pkg", "--output", "/tmp/x"},
+			wantForPkg:    true,
+			wantRemaining: []string{"--profile", "prod", "--output", "/tmp/x"},
+		},
+		{
+			name:          "explicit =true",
+			args:          []string{"--for-pkg=true"},
+			wantForPkg:    true,
+			wantRemaining: []string{},
+		},
+		{
+			name:          "explicit =false",
+			args:          []string{"--for-pkg=false"},
+			wantForPkg:    false,
+			wantRemaining: []string{},
+		},
+		{
+			name:          "empty args",
+			args:          []string{},
+			wantForPkg:    false,
+			wantRemaining: []string{},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotForPkg, gotRemaining := extractForPkgFlag(c.args)
+			if gotForPkg != c.wantForPkg {
+				t.Errorf("extractForPkgFlag(%v) forPkg = %v, want %v", c.args, gotForPkg, c.wantForPkg)
+			}
+			if len(gotRemaining) != len(c.wantRemaining) {
+				t.Fatalf("extractForPkgFlag(%v) remaining = %v, want %v", c.args, gotRemaining, c.wantRemaining)
+			}
+			for i := range gotRemaining {
+				if gotRemaining[i] != c.wantRemaining[i] {
+					t.Errorf("extractForPkgFlag(%v) remaining[%d] = %q, want %q", c.args, i, gotRemaining[i], c.wantRemaining[i])
+				}
+			}
+		})
 	}
 }
 

--- a/desktop_path_test.go
+++ b/desktop_path_test.go
@@ -1,0 +1,17 @@
+package main
+
+import "testing"
+
+// TestMacOSCanonicalHelperPathLiteral locks the canonical install paths to the
+// exact string literals baked into .github/workflows/release.yml (postinstall
+// scriptlet) and the .pkg layout. Drift between the Go const and the YAML
+// would silently break the .mobileconfig generated with --for-pkg, so this
+// test exists to fail loudly the moment either side changes.
+func TestMacOSCanonicalHelperPathLiteral(t *testing.T) {
+	if got, want := MacOSCanonicalBinaryDir, "/usr/local/bin"; got != want {
+		t.Errorf("MacOSCanonicalBinaryDir = %q, want %q", got, want)
+	}
+	if got, want := MacOSCanonicalHelperPath, "/usr/local/bin/databricks-claude-credential-helper"; got != want {
+		t.Errorf("MacOSCanonicalHelperPath = %q, want %q", got, want)
+	}
+}

--- a/desktop_trust.go
+++ b/desktop_trust.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// defaultTrustProfileOutputPath is the default --output destination for the
+// trust-profile generator. Mirrors the dist/ convention used elsewhere for
+// release artifacts.
+const defaultTrustProfileOutputPath = "dist/databricks-claude-trust.mobileconfig"
+
+// runGenerateTrustProfile emits a Configuration Profile (.mobileconfig) that
+// establishes the .pkg signing certificate as a trusted root for code-signing
+// on managed Macs. Reads a PEM-encoded x509 certificate from --cert and writes
+// the rendered profile to --output (default: dist/databricks-claude-trust.mobileconfig).
+//
+// The PayloadContent of the inner pkcs1 payload is the DER bytes of the cert,
+// emitted as a plist <data> element (NOT a <string>) per Apple's profile spec.
+func runGenerateTrustProfile(args []string) error {
+	log.SetOutput(io.Discard)
+
+	certPath, _ := extractCertFlag(args)
+	if certPath == "" {
+		return fmt.Errorf("--cert <path> is required")
+	}
+	outputPath := extractOutputFlag(args)
+	if outputPath == "" {
+		outputPath = defaultTrustProfileOutputPath
+	}
+
+	pemBytes, err := os.ReadFile(certPath)
+	if err != nil {
+		return fmt.Errorf("read cert %q: %w", certPath, err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return fmt.Errorf("decode cert %q: not a PEM file", certPath)
+	}
+	if block.Type != "CERTIFICATE" {
+		return fmt.Errorf("decode cert %q: expected PEM block type %q, got %q", certPath, "CERTIFICATE", block.Type)
+	}
+
+	plist, err := buildTrustMobileconfig(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("build trust mobileconfig: %w", err)
+	}
+
+	// Ensure the output directory exists. dist/ is the conventional staging
+	// dir but callers may pass any path; create parents on demand.
+	if dir := filepath.Dir(outputPath); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("mkdir %q: %w", dir, err)
+		}
+	}
+
+	if err := writeFileAtomic(outputPath, []byte(plist), 0o600); err != nil {
+		return fmt.Errorf("write %q: %w", outputPath, err)
+	}
+	fmt.Fprintf(os.Stderr, "Wrote trust profile: %s\n", outputPath)
+	return nil
+}
+
+// buildTrustMobileconfig renders a Configuration Profile that installs the
+// given DER-encoded certificate as a trusted code-signing root. Two distinct
+// UUIDs are generated: outer profile wrapper and inner pkcs1 payload.
+//
+// The DER bytes are validated via x509.ParseCertificate to fail fast on
+// malformed input. The base64-of-DER is line-wrapped to 76 columns inside a
+// <data> element per Apple convention — using <string> here would break the
+// profile silently because Apple parses pkcs1 PayloadContent as raw bytes.
+//
+// PayloadScope is deliberately "System" (the desktop config profile in
+// desktop_config.go uses "User"). Code-signing trust must be evaluated
+// system-wide so productsign / pkgutil / installer all see the cert as
+// trusted, not just the installing user — do not harmonize the two scopes.
+func buildTrustMobileconfig(certDER []byte) (string, error) {
+	if _, err := x509.ParseCertificate(certDER); err != nil {
+		return "", fmt.Errorf("parse certificate DER: %w", err)
+	}
+
+	innerUUID, err := newUUID()
+	if err != nil {
+		return "", err
+	}
+	outerUUID, err := newUUID()
+	if err != nil {
+		return "", err
+	}
+
+	b64 := base64.StdEncoding.EncodeToString(certDER)
+	dataElem := buildDataPlistElement(b64)
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>PayloadContent</key>
+		<array>
+			<dict>
+				<key>PayloadType</key>
+				<string>com.apple.security.pkcs1</string>
+				<key>PayloadIdentifier</key>
+				<string>com.databricks.databricks-claude.trust</string>
+				<key>PayloadUUID</key>
+				<string>` + innerUUID + `</string>
+				<key>PayloadVersion</key>
+				<integer>1</integer>
+				<key>PayloadDisplayName</key>
+				<string>Databricks Claude code-signing trust</string>
+				<key>PayloadContent</key>
+				` + dataElem + `
+			</dict>
+		</array>
+		<key>PayloadDisplayName</key>
+		<string>Databricks Claude Code-Signing Trust</string>
+		<key>PayloadIdentifier</key>
+		<string>com.databricks.databricks-claude.trust.profile</string>
+		<key>PayloadType</key>
+		<string>Configuration</string>
+		<key>PayloadUUID</key>
+		<string>` + outerUUID + `</string>
+		<key>PayloadVersion</key>
+		<integer>1</integer>
+		<key>PayloadScope</key>
+		<string>System</string>
+	</dict>
+</plist>
+`, nil
+}
+
+// buildDataPlistElement wraps a base64 string at 76 columns per line and
+// returns a `<data>...</data>` plist element. Pure string manipulation, no
+// I/O. Apple's profile parser tolerates whitespace inside <data>; the 76-col
+// wrap matches the convention used by `security cms -D` and Apple's own
+// Configuration Profile export.
+//
+// Empty input emits "<data>\n</data>" rather than "<data></data>" so the
+// output remains visually consistent with non-empty payloads.
+func buildDataPlistElement(b64 string) string {
+	const cols = 76
+	var b strings.Builder
+	b.WriteString("<data>\n")
+	for i := 0; i < len(b64); i += cols {
+		end := i + cols
+		if end > len(b64) {
+			end = len(b64)
+		}
+		b.WriteString(b64[i:end])
+		b.WriteString("\n")
+	}
+	b.WriteString("</data>")
+	return b.String()
+}
+
+// extractCertFlag scans args for --cert / --cert=value and returns the path.
+// The remaining slice strips the consumed tokens — kept for symmetry with the
+// other extract* helpers, but callers that only need the value can ignore it.
+func extractCertFlag(args []string) (certPath string, remaining []string) {
+	remaining = make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--cert" && i+1 < len(args) {
+			certPath = args[i+1]
+			i++
+			continue
+		}
+		if strings.HasPrefix(a, "--cert=") {
+			certPath = strings.TrimPrefix(a, "--cert=")
+			continue
+		}
+		remaining = append(remaining, a)
+	}
+	return certPath, remaining
+}

--- a/desktop_trust_test.go
+++ b/desktop_trust_test.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// makeTestCert generates a self-signed RSA-2048 certificate suitable for
+// exercising the trust-profile generator. Returns the DER bytes plus the
+// parsed *x509.Certificate (so tests can compare round-tripped values).
+func makeTestCert(t *testing.T) ([]byte, *x509.Certificate) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(424242),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		IsCA:         true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate: %v", err)
+	}
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("x509.ParseCertificate: %v", err)
+	}
+	return der, parsed
+}
+
+// writePEM writes a PEM-wrapped CERTIFICATE block to a temp file and returns
+// the path. Centralised here so tests don't repeat the wrapping boilerplate.
+func writePEM(t *testing.T, der []byte, blockType string) string {
+	t.Helper()
+	tmp := filepath.Join(t.TempDir(), "cert.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der})
+	if err := os.WriteFile(tmp, pemBytes, 0o600); err != nil {
+		t.Fatalf("write pem: %v", err)
+	}
+	return tmp
+}
+
+func TestTrustMobileconfigPayloadIsDataNotString(t *testing.T) {
+	der, want := makeTestCert(t)
+	out, err := buildTrustMobileconfig(der)
+	if err != nil {
+		t.Fatalf("buildTrustMobileconfig: %v", err)
+	}
+
+	if !strings.Contains(out, "<data>") {
+		t.Fatalf("expected <data> element in output, got:\n%s", out)
+	}
+
+	// Bound the search to the inner pkcs1 PayloadContent block by anchoring
+	// on the structural keys around it. Anything between the inner
+	// "<key>PayloadContent</key>" (the second one — the inner payload's)
+	// and "</dict>" must contain <data>, never <string>.
+	const innerKey = "<key>PayloadContent</key>"
+	first := strings.Index(out, innerKey)
+	if first < 0 {
+		t.Fatal("first PayloadContent key not found")
+	}
+	second := strings.Index(out[first+len(innerKey):], innerKey)
+	if second < 0 {
+		t.Fatal("second (inner) PayloadContent key not found")
+	}
+	innerStart := first + len(innerKey) + second + len(innerKey)
+	innerEnd := strings.Index(out[innerStart:], "</dict>")
+	if innerEnd < 0 {
+		t.Fatal("end of inner payload dict not found")
+	}
+	innerSection := out[innerStart : innerStart+innerEnd]
+	if !strings.Contains(innerSection, "<data>") {
+		t.Errorf("inner PayloadContent missing <data>: %q", innerSection)
+	}
+	if strings.Contains(innerSection, "<string>") {
+		t.Errorf("inner PayloadContent must use <data>, not <string>: %q", innerSection)
+	}
+
+	// Round-trip: extract base64 between <data> and </data>, decode, parse.
+	dataStart := strings.Index(out, "<data>")
+	dataEnd := strings.Index(out, "</data>")
+	if dataStart < 0 || dataEnd < 0 || dataEnd <= dataStart {
+		t.Fatalf("malformed <data> element: start=%d end=%d", dataStart, dataEnd)
+	}
+	rawB64 := out[dataStart+len("<data>") : dataEnd]
+	// Strip whitespace introduced by the 76-col line wrap.
+	cleaned := strings.Map(func(r rune) rune {
+		if r == ' ' || r == '\n' || r == '\r' || r == '\t' {
+			return -1
+		}
+		return r
+	}, rawB64)
+	decoded, err := base64.StdEncoding.DecodeString(cleaned)
+	if err != nil {
+		t.Fatalf("decode base64: %v", err)
+	}
+	got, err := x509.ParseCertificate(decoded)
+	if err != nil {
+		t.Fatalf("parse round-tripped cert: %v", err)
+	}
+	if got.SerialNumber.Cmp(want.SerialNumber) != 0 {
+		t.Errorf("serial mismatch: got %v, want %v", got.SerialNumber, want.SerialNumber)
+	}
+	if got.Subject.CommonName != want.Subject.CommonName {
+		t.Errorf("CN mismatch: got %q, want %q", got.Subject.CommonName, want.Subject.CommonName)
+	}
+}
+
+func TestBuildDataPlistElement_LineWrap(t *testing.T) {
+	t.Run("len_200_wraps_at_76", func(t *testing.T) {
+		in := strings.Repeat("A", 200)
+		out := buildDataPlistElement(in)
+		if !strings.HasPrefix(out, "<data>\n") {
+			t.Errorf("missing <data>\\n prefix: %q", out)
+		}
+		if !strings.HasSuffix(out, "</data>") {
+			t.Errorf("missing </data> suffix: %q", out)
+		}
+		// Strip the wrapper and inspect the line shape.
+		body := strings.TrimSuffix(strings.TrimPrefix(out, "<data>\n"), "</data>")
+		body = strings.TrimRight(body, "\n")
+		lines := strings.Split(body, "\n")
+		if len(lines) != 3 {
+			t.Fatalf("expected 3 wrapped lines for 200 chars, got %d: %v", len(lines), lines)
+		}
+		if len(lines[0]) != 76 || len(lines[1]) != 76 || len(lines[2]) != 48 {
+			t.Errorf("unexpected line lengths: %d %d %d", len(lines[0]), len(lines[1]), len(lines[2]))
+		}
+	})
+	t.Run("empty_input", func(t *testing.T) {
+		out := buildDataPlistElement("")
+		// Either "<data></data>" or "<data>\n</data>" is acceptable per spec;
+		// our implementation emits the latter so the data element is visually
+		// consistent with the wrapped case.
+		if out != "<data>\n</data>" && out != "<data></data>" {
+			t.Errorf("unexpected empty output: %q", out)
+		}
+	})
+	t.Run("exactly_76_one_line", func(t *testing.T) {
+		in := strings.Repeat("B", 76)
+		out := buildDataPlistElement(in)
+		body := strings.TrimSuffix(strings.TrimPrefix(out, "<data>\n"), "</data>")
+		body = strings.TrimRight(body, "\n")
+		lines := strings.Split(body, "\n")
+		if len(lines) != 1 {
+			t.Fatalf("expected 1 line for 76 chars, got %d: %v", len(lines), lines)
+		}
+		if len(lines[0]) != 76 {
+			t.Errorf("first line len = %d, want 76", len(lines[0]))
+		}
+	})
+	t.Run("exactly_152_two_lines", func(t *testing.T) {
+		in := strings.Repeat("C", 152)
+		out := buildDataPlistElement(in)
+		body := strings.TrimSuffix(strings.TrimPrefix(out, "<data>\n"), "</data>")
+		body = strings.TrimRight(body, "\n")
+		lines := strings.Split(body, "\n")
+		if len(lines) != 2 {
+			t.Fatalf("expected 2 lines for 152 chars, got %d: %v", len(lines), lines)
+		}
+		if len(lines[0]) != 76 || len(lines[1]) != 76 {
+			t.Errorf("line lengths: %d %d, want 76 76", len(lines[0]), len(lines[1]))
+		}
+	})
+}
+
+func TestBuildTrustMobileconfig_PlistShape(t *testing.T) {
+	der, _ := makeTestCert(t)
+	out, err := buildTrustMobileconfig(der)
+	if err != nil {
+		t.Fatalf("buildTrustMobileconfig: %v", err)
+	}
+
+	wantSubstrings := []string{
+		"<key>PayloadType</key>",
+		"<string>Configuration</string>",
+		"<string>com.apple.security.pkcs1</string>",
+		"<key>PayloadIdentifier</key>",
+		"com.databricks.databricks-claude.trust",
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(out, s) {
+			t.Errorf("output missing %q\n---\n%s", s, out)
+		}
+	}
+
+	// Two distinct UUIDs: extract every <string>...UUID-shaped...</string>
+	// pair by scanning all PayloadUUID keys.
+	const uuidKey = "<key>PayloadUUID</key>"
+	var uuids []string
+	rest := out
+	for {
+		i := strings.Index(rest, uuidKey)
+		if i < 0 {
+			break
+		}
+		rest = rest[i+len(uuidKey):]
+		open := strings.Index(rest, "<string>")
+		closeIdx := strings.Index(rest, "</string>")
+		if open < 0 || closeIdx < 0 || closeIdx <= open {
+			break
+		}
+		uuids = append(uuids, rest[open+len("<string>"):closeIdx])
+		rest = rest[closeIdx+len("</string>"):]
+	}
+	if len(uuids) < 2 {
+		t.Fatalf("expected at least 2 PayloadUUID values, got %d: %v", len(uuids), uuids)
+	}
+	if uuids[0] == uuids[1] {
+		t.Errorf("inner and outer UUIDs must differ, both = %q", uuids[0])
+	}
+}
+
+func TestRunGenerateTrustProfile_BadCert(t *testing.T) {
+	t.Run("non_pem_file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bogus.pem")
+		if err := os.WriteFile(path, []byte("not a pem file"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		out := filepath.Join(dir, "trust.mobileconfig")
+		err := runGenerateTrustProfile([]string{"--cert", path, "--output", out})
+		if err == nil {
+			t.Fatal("expected error for non-PEM input")
+		}
+		if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+			t.Errorf("output file should not exist on error, stat err = %v", statErr)
+		}
+	})
+	t.Run("wrong_block_type", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "wrong.pem")
+		pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: []byte("garbage")})
+		if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		out := filepath.Join(dir, "trust.mobileconfig")
+		err := runGenerateTrustProfile([]string{"--cert", path, "--output", out})
+		if err == nil {
+			t.Fatal("expected error for wrong PEM block type")
+		}
+		if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+			t.Errorf("output file should not exist on error, stat err = %v", statErr)
+		}
+	})
+}
+
+func TestRunGenerateTrustProfile_AtomicWrite(t *testing.T) {
+	der, _ := makeTestCert(t)
+	certPath := writePEM(t, der, "CERTIFICATE")
+
+	dir := t.TempDir()
+	out := filepath.Join(dir, "trust.mobileconfig")
+	if err := runGenerateTrustProfile([]string{"--cert", certPath, "--output", out}); err != nil {
+		t.Fatalf("runGenerateTrustProfile: %v", err)
+	}
+
+	body, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	got := string(body)
+	for _, want := range []string{"Configuration", "com.apple.security.pkcs1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+
+	// No leftover .tmp files in the output dir.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestExtractCertFlag(t *testing.T) {
+	t.Run("present_with_value", func(t *testing.T) {
+		got, _ := extractCertFlag([]string{"--cert", "/tmp/c.pem"})
+		if got != "/tmp/c.pem" {
+			t.Errorf("got %q, want /tmp/c.pem", got)
+		}
+	})
+	t.Run("absent", func(t *testing.T) {
+		got, _ := extractCertFlag([]string{"--other", "x"})
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("equals_form", func(t *testing.T) {
+		got, _ := extractCertFlag([]string{"--cert=/tmp/eq.pem"})
+		if got != "/tmp/eq.pem" {
+			t.Errorf("got %q, want /tmp/eq.pem", got)
+		}
+	})
+	t.Run("mixed_with_other_args", func(t *testing.T) {
+		got, rem := extractCertFlag([]string{"--profile", "foo", "--cert", "/p.pem", "--output", "/o"})
+		if got != "/p.pem" {
+			t.Errorf("got %q, want /p.pem", got)
+		}
+		// Sanity-check remaining args still contain the non-cert flags.
+		joined := strings.Join(rem, " ")
+		if !strings.Contains(joined, "--profile") || !strings.Contains(joined, "--output") {
+			t.Errorf("remaining lost non-cert flags: %v", rem)
+		}
+		if strings.Contains(joined, "--cert") {
+			t.Errorf("remaining still contains --cert: %v", rem)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds a signed `.pkg` installer pipeline so admins can ship the `databricks-claude` credential helper to their workforce's Macs via MDM (Jamf, Kandji, Intune, etc.). Self-signed by default — admins set their own org's signing identity and ship the matching trust profile alongside the `.pkg`.

This is a template, not a Databricks-internal tool. Anyone using Databricks as the AI Gateway backend for Claude Desktop can fork this and stamp their own signing identity into the cert.

## What's in the diff

- `feat(desktop)` — new `generate-trust-profile` subcommand emits a Configuration Profile that installs the signing cert as a trusted code-signing root on managed endpoints. Cert payload is `<data>` (base64 DER, 76-col wrapped) per Apple's `pkcs1` PayloadType convention. New `--for-pkg` flag on `generate-config` bakes the canonical `/usr/local/bin/databricks-claude-credential-helper` path. New `MacOSCanonicalHelperPath` const is the single source of truth, locked by `TestMacOSCanonicalHelperPathLiteral` so the const and the YAML literal in the workflow can't drift.
- `build,ci` — `make pkg` builds a universal2 `.pkg` (auto-falls-back to ad-hoc signing when no secrets, so local iteration works); `make trust-profile` and `make generate-signing-cert` round out the toolchain. New `package-macos` CI job runs on `macos-14`, imports the cert via SHA-pinned `apple-actions/import-codesign-certs`, configures keychain trust (so `productsign` doesn't fail with `errSecInternalComponent`), builds + signs + verifies hardened runtime, lints the trust plist, asserts the canonical helper path is embedded, and uploads both artifacts to the GitHub release. Parallel to the existing `build-and-upload` / Homebrew / Scoop jobs — never gates them. `workflow_dispatch` trigger added for re-runs without cutting a release.
- `docs` — new "MDM deployment with signed `.pkg`" section walking through the three artifacts (`.pkg`, trust `.mobileconfig`, per-workspace `.mobileconfig`), deployment order, cert rotation runbook (cadence / sequence / rollback), and the `CERT_CN` / `CERT_ORG` / `CERT_COUNTRY` override pattern so admins stamp their own org identity instead of leaving the template-y defaults in place.

Pure stdlib. Zero new third-party Go imports. Existing release flow (`release-please`, Homebrew tap, Scoop bucket) is untouched.

## Test plan

- [x] `go vet ./... && go test ./...` clean
- [x] `make pkg` produces `dist/databricks-claude.pkg`; `pkgutil --payload-files` shows `/usr/local/bin/databricks-claude`; `file build/databricks-claude` reports universal binary
- [x] `make trust-profile` produces a `plutil -lint`-clean `.mobileconfig` with `<data>` payload (not `<string>`)
- [x] Local install: `sudo installer -pkg dist/databricks-claude.pkg -target /` lays down the binary + symlink at `/usr/local/bin/`
- [x] End-to-end signed flow: `make generate-signing-cert` with real `CERT_CN`/`CERT_ORG` → `make pkg` with `APPLE_INTERNAL_SIGNING_IDENTITY` set → install trust profile via `System Settings → Profiles` → `pkgutil --check-signature` reports the cert as trusted
- [ ] Configure four GitHub secrets (`APPLE_INTERNAL_SIGNING_{P12_BASE64,P12_PASSWORD,IDENTITY,CERT_PEM}`) and dry-run the `package-macos` job via `workflow_dispatch`

## Bootstrap before first signed release

```bash
P12_PASSWORD=<strong-random> \
CERT_CN="<Your Org> Claude Desktop Code Signing" \
CERT_ORG="<Your Org>" \
  make generate-signing-cert
# paste the printed values into the four GitHub repo secrets
```

## Non-goals

- Apple Developer ID + notarization (a future swap at the `productsign --sign` boundary; current pipeline supports it without restructuring).
- Linux `.deb` / `.rpm` and Windows `.msi` (separate spec; the path-contract pattern is designed to extend).
- Distribution to unmanaged Macs — Gatekeeper will block self-signed installs without the trust profile. Homebrew tap remains the unmanaged-user channel.
