### PR TITLE
fix: add -legacy flag to openssl pkcs12 export for macOS compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ generate-signing-cert:
 		-subj "/CN=$(CERT_CN)/O=$(CERT_ORG)/C=$(CERT_COUNTRY)" \
 		-addext "extendedKeyUsage=codeSigning" \
 		-keyout dist/signing-cert.key -out dist/signing-cert.pem
-	openssl pkcs12 -export -out dist/signing-cert.p12 \
+	openssl pkcs12 -export -legacy -out dist/signing-cert.p12 \
 		-inkey dist/signing-cert.key -in dist/signing-cert.pem \
 		-passout pass:"$$P12_PASSWORD"
 	base64 -i dist/signing-cert.p12 -o dist/signing-cert.p12.b64


### PR DESCRIPTION
## Problem

The `package-macos` CI job fails at "Import code-signing cert" with:
```
security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)
```

## Root cause

OpenSSL 3.x (the Homebrew default on macOS 14, which is what the runner uses and what most devs have locally) exports PKCS12 files with **SHA-256 MAC** by default. macOS's native `security import` command only understands **SHA-1 MAC** and reports the incompatibility as "wrong password?" — even when the password is correct.

Base64 corruption was ruled out: the secret decodes cleanly to a valid PKCS12 binary.

## Fix

Add `-legacy` to the `openssl pkcs12 -export` invocation in `generate-signing-cert`. This forces SHA-1 MAC output, which is what macOS and `apple-actions/import-codesign-certs` expect.

## After merging

Tanner needs to regenerate the cert locally and update the four GitHub secrets:
```bash
make generate-signing-cert   # uses fixed -legacy flag
base64 -i dist/signing-cert.p12 | tr -d '\n' > dist/signing-cert.p12.b64
```
Then update `APPLE_INTERNAL_SIGNING_P12_BASE64` and `APPLE_INTERNAL_SIGNING_P12_PASSWORD` in repo secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)