### PR TITLE
fix: use APPLE_INTERNAL_SIGNING_IDENTITY secret in pkg signature assert

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,13 +93,15 @@ jobs:
           EXPECTED="/usr/local/bin/databricks-claude-credential-helper"
           pkgutil --payload-files dist/databricks-claude.pkg | grep -F "$EXPECTED"
       - name: Assert pkg signature
+        env:
+          APPLE_INTERNAL_SIGNING_IDENTITY: ${{ secrets.APPLE_INTERNAL_SIGNING_IDENTITY }}
         run: |
           # Self-signed certs report 'signed by untrusted identifier' on
           # runners without the trust profile installed; that's expected.
           OUT=$(pkgutil --check-signature dist/databricks-claude.pkg)
           echo "$OUT"
           echo "$OUT" | grep -E "Status: (signed|signed by untrusted identifier)"
-          echo "$OUT" | grep -F "Databricks Claude Internal Code Signing"
+          echo "$OUT" | grep -F "$APPLE_INTERNAL_SIGNING_IDENTITY"
       - name: Upload pkg + trust profile to release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

The `Assert pkg signature` step hardcodes `"Databricks Claude Internal Code Signing"` which doesn't match the actual `APPLE_INTERNAL_SIGNING_IDENTITY` secret value (`IceRhymers Claude Desktop Code Signing`).

## Fix

Expose `APPLE_INTERNAL_SIGNING_IDENTITY` as an env var in the assert step and use `$APPLE_INTERNAL_SIGNING_IDENTITY` in the grep. The assert now stays in sync with whatever identity is configured in secrets — no more stale hardcoded strings.

## Also needed (not in this PR)

The cert needs to be regenerated with the CN matching the secret value:
```bash
CERT_CN="IceRhymers Claude Desktop Code Signing" \
CERT_ORG="IceRhymers" \
P12_PASSWORD=<your-password> \
make generate-signing-cert
```
Then update the four GitHub secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)