### PR TITLE
fix: explicitly unlock + list keychain before codesign; add identity diagnostic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,17 @@ jobs:
         # but productsign also needs codesign: on headless runners. We run a second
         # pass using the keychain password from the action output.
         run: |
-          security set-key-partition-list \
-            -S apple-tool:,apple:,codesign: \
-            -s -k "${{ steps.import-cert.outputs.keychain-password }}" \
-            "$HOME/Library/Keychains/signing_temp.keychain"
+          KC="$HOME/Library/Keychains/signing_temp.keychain"
+          KC_PASS="${{ steps.import-cert.outputs.keychain-password }}"
+          security unlock-keychain -p "$KC_PASS" "$KC"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KC_PASS" "$KC"
+          security list-keychains -d user -s "$KC" login.keychain-db
+      - name: Verify signing identity is available
+        run: |
+          echo "Keychain search list:"
+          security list-keychains -d user
+          echo "Available codesigning identities:"
+          security find-identity -v -p codesigning
       - name: Write signing-cert PEM for trust profile
         env:
           CERT_PEM: ${{ secrets.APPLE_INTERNAL_SIGNING_CERT_PEM }}


### PR DESCRIPTION
## Problem

`codesign` reports "The specified item could not be found in the keychain" even though the import and `set-key-partition-list` steps pass. The cert is in the keychain but `codesign` can't see it.

## Likely causes

- `signing_temp.keychain` may not be in the search list at the point `codesign` runs (the action uses `login.keychain`, we need `login.keychain-db`)
- Keychain may need an explicit unlock before use

## Changes

1. **Configure step**: explicitly `unlock-keychain` before `set-key-partition-list`, and call `list-keychains` with `login.keychain-db` (not `login.keychain`) to ensure the right search list
2. **New diagnostic step**: prints `security list-keychains` and `security find-identity -v -p codesigning` output before `make pkg` — will confirm what identities are visible to `codesign`

🤖 Generated with [Claude Code](https://claude.com/claude-code)