### PR TITLE
fix: add keyUsage=digitalSignature to cert — required for macOS codesign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,9 @@ jobs:
         run: |
           echo "Keychain search list:"
           security list-keychains -d user
-          echo "Available codesigning identities:"
+          echo "All identities (including invalid):"
+          security find-identity -p codesigning
+          echo "Valid codesigning identities:"
           security find-identity -v -p codesigning
       - name: Write signing-cert PEM for trust profile
         env:

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ generate-signing-cert:
 	esac
 	openssl req -x509 -newkey rsa:2048 -days 1825 -nodes \
 		-subj "/CN=$(CERT_CN)/O=$(CERT_ORG)/C=$(CERT_COUNTRY)" \
+		-addext "keyUsage=critical,digitalSignature" \
 		-addext "extendedKeyUsage=codeSigning" \
 		-keyout dist/signing-cert.key -out dist/signing-cert.pem
 	openssl pkcs12 -export -legacy -out dist/signing-cert.p12 \


### PR DESCRIPTION
## Root cause

`security find-identity -v -p codesigning` returned **0 valid identities** even though the cert and key were imported into the keychain. This means `codesign --sign` can't find the identity by name.

macOS requires **both** extensions for a cert to be recognized as a valid codesigning identity:
- `extendedKeyUsage = codeSigning` ✓ (already present)
- `keyUsage = critical,digitalSignature` ✗ (was missing)

Without `keyUsage`, the cert is in the keychain but is invisible to `codesign`.

## Changes

1. **Makefile** — add `-addext "keyUsage=critical,digitalSignature"` to the `openssl req` command in `generate-signing-cert`
2. **release.yml** — expand the diagnostic step to also show `find-identity` without `-v` (shows all identities, including invalid ones) so future failures are easier to diagnose

## After merging

Regenerate the cert and update all four secrets:
```bash
CERT_CN="IceRhymers Claude Desktop Code Signing" \
CERT_ORG="IceRhymer's Org" \
P12_PASSWORD=<your-password> \
make generate-signing-cert
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)