### PR TITLE
fix: add Apple installer OID to cert so productsign accepts it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ pkg:
 		dist/databricks-claude-unsigned.pkg
 	@if [ -n "$$APPLE_INTERNAL_SIGNING_IDENTITY" ]; then \
 		echo "Signing .pkg with identity: $$APPLE_INTERNAL_SIGNING_IDENTITY"; \
-		productsign --sign "$$APPLE_INTERNAL_SIGNING_IDENTITY" dist/databricks-claude-unsigned.pkg dist/databricks-claude.pkg; \
+		productsign --sign "$$APPLE_INTERNAL_SIGNING_IDENTITY" dist/databricks-claude-unsigned.pkg dist/databricks-claude.pkg || exit 1; \
 		rm -f dist/databricks-claude-unsigned.pkg; \
 	else \
 		mv dist/databricks-claude-unsigned.pkg dist/databricks-claude.pkg; \
@@ -115,7 +115,7 @@ generate-signing-cert:
 	openssl req -x509 -newkey rsa:2048 -days 1825 -nodes \
 		-subj "/CN=$(CERT_CN)/O=$(CERT_ORG)/C=$(CERT_COUNTRY)" \
 		-addext "keyUsage=critical,digitalSignature" \
-		-addext "extendedKeyUsage=codeSigning" \
+		-addext "extendedKeyUsage=codeSigning,1.2.840.113635.100.4.13" \
 		-keyout dist/signing-cert.key -out dist/signing-cert.pem
 	openssl pkcs12 -export -legacy -out dist/signing-cert.p12 \
 		-inkey dist/signing-cert.key -in dist/signing-cert.pem \


### PR DESCRIPTION
## Problem

`productsign` requires a signing identity with Apple's installer OID (`1.2.840.113635.100.4.13`) in `extendedKeyUsage`. Our cert only had `codeSigning` (`1.3.6.1.5.5.7.3.3`), which is an *application* signing identity. `productsign` explicitly rejects these:

```
productsign: error: Could not find appropriate signing identity for "***".
An installer signing identity (not an application signing identity) is required for signing flat-style products.
```

Additionally, when `productsign` failed, the Makefile silently swallowed the error — `rm -f dist/databricks-claude-unsigned.pkg` still ran, the `if` block exited 0, make reported success, and `dist/databricks-claude.pkg` was never created.

## Changes

- **`generate-signing-cert`**: Add `1.2.840.113635.100.4.13` alongside `codeSigning` in `extendedKeyUsage` so the cert satisfies both code signing (for `codesign`) and installer signing (for `productsign`)
- **`pkg`**: Add `|| exit 1` after `productsign` so failures surface immediately instead of being swallowed

## Required action after merge

Tanner: regenerate the cert and update all four secrets:
```
cd your-local-repo
rm dist/signing-cert.key  # remove old key first
P12_PASSWORD=<your-password> CERT_CN="IceRhymers Claude Desktop Code Signing" \
  CERT_ORG="IceRhymers" make generate-signing-cert
```
Then update GitHub secrets with the new values from `dist/`.