### PR TITLE
fix: trust self-signed cert as system root so productsign accepts it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,14 @@ jobs:
         run: |
           mkdir -p dist
           printf '%s\n' "$CERT_PEM" > dist/signing-cert.pem
+      - name: Trust self-signed cert as installer signing root
+        # productsign evaluates the cert chain against the installer policy.
+        # Self-signed certs are not trusted by default, so the chain check
+        # fails even with the right OIDs. Adding the cert as a trusted root
+        # in the system keychain makes the chain evaluation pass for this runner.
+        run: |
+          sudo security add-trusted-cert -d -r trustRoot \
+            -k /Library/Keychains/System.keychain dist/signing-cert.pem
       - name: Build signed .pkg
         env:
           APPLE_INTERNAL_SIGNING_IDENTITY: ${{ secrets.APPLE_INTERNAL_SIGNING_IDENTITY }}


### PR DESCRIPTION
## Root cause

`productsign` evaluates the signing identity's certificate chain against macOS's **installer signing policy** (`kSecPolicyAppleInstaller`). This policy requires:

1. The cert has the Apple installer OID `1.2.840.113635.100.4.13` in `extendedKeyUsage` ✅ (added in #109)
2. The cert chain is trusted — i.e., the root is in the system trust store ❌

For Developer ID certs this is automatic (they chain to Apple's CA). For self-signed certs there's no chain, so the cert itself needs to be explicitly trusted as a root. Without that, `productsign` reports "Could not find appropriate signing identity" even if the OID is present.

## Fix

Add one step between writing the PEM and running `make pkg`:

```sh
sudo security add-trusted-cert -d -r trustRoot \
  -k /Library/Keychains/System.keychain dist/signing-cert.pem
```

This is the same operation the MDM trust profile (mobileconfig) performs on end-user machines — it makes the runner treat our self-signed cert as a trusted root for the duration of the job.

## No cert regen needed

This is a CI-only change. The cert itself is fine (it already has the installer OID from #109).