### PR TITLE
fix: ship unsigned .pkg — productsign requires Apple-issued installer cert

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,15 +85,7 @@ jobs:
         run: |
           mkdir -p dist
           printf '%s\n' "$CERT_PEM" > dist/signing-cert.pem
-      - name: Trust self-signed cert as installer signing root
-        # productsign evaluates the cert chain against the installer policy.
-        # Self-signed certs are not trusted by default, so the chain check
-        # fails even with the right OIDs. Adding the cert as a trusted root
-        # in the system keychain makes the chain evaluation pass for this runner.
-        run: |
-          sudo security add-trusted-cert -d -r trustRoot \
-            -k /Library/Keychains/System.keychain dist/signing-cert.pem
-      - name: Build signed .pkg
+      - name: Build pkg
         env:
           APPLE_INTERNAL_SIGNING_IDENTITY: ${{ secrets.APPLE_INTERNAL_SIGNING_IDENTITY }}
         run: make pkg
@@ -109,16 +101,13 @@ jobs:
           # (locked by TestMacOSCanonicalHelperPathLiteral).
           EXPECTED="/usr/local/bin/databricks-claude-credential-helper"
           pkgutil --payload-files dist/databricks-claude.pkg | grep -F "$EXPECTED"
-      - name: Assert pkg signature
-        env:
-          APPLE_INTERNAL_SIGNING_IDENTITY: ${{ secrets.APPLE_INTERNAL_SIGNING_IDENTITY }}
+      - name: Assert pkg is unsigned
         run: |
-          # Self-signed certs report 'signed by untrusted identifier' on
-          # runners without the trust profile installed; that's expected.
+          # productsign requires an Apple-issued installer cert; self-signed certs
+          # can't satisfy that requirement. The binary inside is codesigned.
           OUT=$(pkgutil --check-signature dist/databricks-claude.pkg)
           echo "$OUT"
-          echo "$OUT" | grep -E "Status: (signed|signed by untrusted identifier)"
-          echo "$OUT" | grep -F "$APPLE_INTERNAL_SIGNING_IDENTITY"
+          echo "$OUT" | grep -E "Status: no signature"
       - name: Upload pkg + trust profile to release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ dist:
 	GOOS=windows GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-claude-windows-arm64.exe .
 
 ## Build a universal2 macOS .pkg installer. Set APPLE_INTERNAL_SIGNING_IDENTITY
-## (and run inside `apple-actions/import-codesign-certs` keychain) to produce a
-## signed .pkg; otherwise the binary is ad-hoc signed and the .pkg is unsigned
-## (good enough for local dev).
+## to codesign the binary inside the pkg with hardened-runtime flags; otherwise
+## the binary is ad-hoc signed. The .pkg itself is always unsigned — productsign
+## requires an Apple-issued installer cert, which a self-signed cert can't satisfy.
 pkg:
 	rm -rf build root scripts/postinstall dist/databricks-claude*.pkg
 	mkdir -p build dist scripts root/usr/local/bin
@@ -68,14 +68,7 @@ pkg:
 	productbuild --package dist/databricks-claude-component.pkg \
 		--identifier com.databricks.databricks-claude.dist \
 		--version "$(VERSION)" \
-		dist/databricks-claude-unsigned.pkg
-	@if [ -n "$$APPLE_INTERNAL_SIGNING_IDENTITY" ]; then \
-		echo "Signing .pkg with identity: $$APPLE_INTERNAL_SIGNING_IDENTITY"; \
-		productsign --sign "$$APPLE_INTERNAL_SIGNING_IDENTITY" dist/databricks-claude-unsigned.pkg dist/databricks-claude.pkg || exit 1; \
-		rm -f dist/databricks-claude-unsigned.pkg; \
-	else \
-		mv dist/databricks-claude-unsigned.pkg dist/databricks-claude.pkg; \
-	fi
+		dist/databricks-claude.pkg
 	rm -f dist/databricks-claude-component.pkg
 	@echo "Built dist/databricks-claude.pkg"
 


### PR DESCRIPTION
## Root cause

`productsign` uses macOS's `kSecPolicyAppleInstaller` trust policy, which requires the signing cert to chain back to **Apple's Developer ID CA** (or a trusted enterprise CA hierarchy). A self-signed cert — even with:
- `keyUsage=digitalSignature` ✅
- `extendedKeyUsage=codeSigning` ✅  
- `extendedKeyUsage=1.2.840.113635.100.4.13` (Apple installer OID) ✅
- Trusted as system root via `security add-trusted-cert` ✅

...still fails chain validation because the cert is both the root and the leaf. Apple's installer policy evaluates a *chain*, not a self-signed certificate.

## What this PR does

- **Makefile**: Remove the `productsign` block. `productbuild` writes directly to `dist/databricks-claude.pkg`. The binary inside is still codesigned with hardened runtime.
- **Workflow**: Remove the now-unnecessary `security add-trusted-cert` step. Change "Assert pkg signature" → "Assert pkg is unsigned" (verifies `pkgutil` reports `Status: no signature`).

## Why this is fine

The binary codesigning is what Gatekeeper and hardened runtime enforcement care about. The `.pkg` wrapper's signature would only add tamper detection on the installer itself — useful, but not achievable without an Apple Developer ID Installer cert. MDM deployment bypasses Gatekeeper anyway.

**No cert regen needed.** No secrets changes needed.