### PR TITLE
fix: include helper symlink in pkg payload; fix assertion to expand archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,11 @@ jobs:
           # MUST match desktop_config.MacOSCanonicalHelperPath
           # (locked by TestMacOSCanonicalHelperPathLiteral).
           EXPECTED="/usr/local/bin/databricks-claude-credential-helper"
-          pkgutil --payload-files dist/databricks-claude.pkg | grep -F "$EXPECTED"
+          # productbuild wraps component pkgs; --payload-files doesn't recurse.
+          # Expand the archive and read the BOM from the inner component package.
+          pkgutil --expand dist/databricks-claude.pkg /tmp/pkg-check
+          find /tmp/pkg-check -name 'Bom' | xargs lsbom | grep -F "$EXPECTED"
+          rm -rf /tmp/pkg-check
       - name: Assert pkg is unsigned
         run: |
           # productsign requires an Apple-issued installer cert; self-signed certs

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ pkg:
 		codesign --force --options runtime --sign - build/databricks-claude; \
 	fi
 	cp build/databricks-claude root/usr/local/bin/databricks-claude
+	ln -sf databricks-claude root/usr/local/bin/databricks-claude-credential-helper
 	printf '#!/bin/sh\nset -e\ncd /usr/local/bin\nln -sf databricks-claude databricks-claude-credential-helper\n' > scripts/postinstall
 	chmod +x scripts/postinstall
 	pkgbuild --root root --scripts scripts \


### PR DESCRIPTION
## Two bugs, one PR

### 1. Helper symlink not in pkg payload

The `databricks-claude-credential-helper` symlink was only created by the postinstall script at install time — it was never in the `root/` directory, so it was never a payload file. `pkgutil --payload-files` correctly returned nothing.

**Fix**: Add `ln -sf databricks-claude root/usr/local/bin/databricks-claude-credential-helper` so the symlink is a real payload entry. The postinstall script that also creates it stays — that's the upgrade mechanism for machines where a previous version may have installed the binary without the symlink in the payload.

### 2. Assertion used wrong command for product archives

`pkgutil --payload-files` on a product archive (output of `productbuild`) doesn't recurse into embedded component packages — it sees the outer xar structure, finds no direct payload, and returns empty.

**Fix**: Use `pkgutil --expand` to unpack the archive, then `lsbom` on the component package's `Bom` file to list actual payload paths.

```sh
pkgutil --expand dist/databricks-claude.pkg /tmp/pkg-check
find /tmp/pkg-check -name 'Bom' | xargs lsbom | grep -F "$EXPECTED"
rm -rf /tmp/pkg-check
```