### PR TITLE
fix: allow pkgutil --check-signature to exit non-zero for unsigned pkg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           # productsign requires an Apple-issued installer cert; self-signed certs
           # can't satisfy that requirement. The binary inside is codesigned.
-          OUT=$(pkgutil --check-signature dist/databricks-claude.pkg)
+          OUT=$(pkgutil --check-signature dist/databricks-claude.pkg || true)
           echo "$OUT"
           echo "$OUT" | grep -E "Status: no signature"
       - name: Upload pkg + trust profile to release


### PR DESCRIPTION
\`pkgutil --check-signature\` exits with a non-zero status code when a package has no signature (expected behavior for our unsigned pkg). With \`bash -e\` active in the workflow step, the command substitution on line 1 kills the step immediately — before \`echo\` or \`grep\` ever run.

Fix: add \`|| true\` so the non-zero exit is absorbed and the output can be captured and asserted against normally.