### PR TITLE
Simplify ConstructGatewayURL: drop SCIM call, use host-relative AI Gateway path

### DIFF
--- a/desktop_config.go
+++ b/desktop_config.go
@@ -287,13 +287,7 @@ func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride, databrick
 		os.Exit(1)
 	}
 
-	tp := NewTokenProvider(resolved, "")
-	tok, err := tp.Token(context.Background())
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "databricks-claude: failed to fetch token for profile %q: %v\n", resolved, err)
-		os.Exit(1)
-	}
-	gatewayURL := ConstructGatewayURL(host, tok)
+	gatewayURL := ConstructGatewayURL(host)
 
 	helperPath, err := resolveHelperPath(binaryPathOverride, forPkg)
 	if err != nil {

--- a/desktop_config_test.go
+++ b/desktop_config_test.go
@@ -36,7 +36,7 @@ func TestNewUUID_FormatAndUniqueness(t *testing.T) {
 }
 
 func TestBuildMobileconfig_ContainsRequiredKeys(t *testing.T) {
-	gateway := "https://abc-123.ai-gateway.cloud.databricks.com/anthropic"
+	gateway := "https://adb-abc-123.azuredatabricks.net/ai-gateway/anthropic"
 	helper := "/usr/local/bin/databricks-claude"
 	out, err := buildMobileconfig(gateway, helper)
 	if err != nil {
@@ -104,7 +104,7 @@ func TestBuildMobileconfig_UniqueUUIDs(t *testing.T) {
 }
 
 func TestBuildRegFile_ContainsRequiredKeys(t *testing.T) {
-	gateway := "https://abc-123.ai-gateway.cloud.databricks.com/anthropic"
+	gateway := "https://adb-abc-123.azuredatabricks.net/ai-gateway/anthropic"
 	helper := `C:\Program Files\databricks-claude\databricks-claude.exe`
 	out := buildRegFile(gateway, helper)
 
@@ -417,7 +417,7 @@ func TestExtractForPkgFlag(t *testing.T) {
 // ---- buildDevModeJSON ------------------------------------------------------
 
 const (
-	devTestGateway = "https://abc-123.ai-gateway.cloud.databricks.com/anthropic"
+	devTestGateway = "https://adb-abc-123.azuredatabricks.net/ai-gateway/anthropic"
 	devTestHelper  = "/usr/local/bin/databricks-claude-credential-helper"
 )
 

--- a/main.go
+++ b/main.go
@@ -353,7 +353,7 @@ func main() {
 		log.Printf("databricks-claude: discovered host: %s", host)
 		databricksHost = host
 
-		inferenceUpstream = ConstructGatewayURL(host, initialToken)
+		inferenceUpstream = ConstructGatewayURL(host)
 		log.Printf("databricks-claude: upstream: %s", inferenceUpstream)
 
 		needsFullSetup = true

--- a/token.go
+++ b/token.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/tokencache"
@@ -180,42 +179,8 @@ func DiscoverHost(profile, cmdName string) (string, error) {
 	return host, nil
 }
 
-// ResolveWorkspaceID calls the SCIM /Me endpoint and extracts x-databricks-org-id from response headers.
-func ResolveWorkspaceID(host, token string) (string, error) {
-	client := &http.Client{Timeout: 10 * time.Second}
-
-	req, err := http.NewRequest(http.MethodGet, host+"/api/2.0/preview/scim/v2/Me", nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to build SCIM request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("SCIM request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("SCIM request returned status %d", resp.StatusCode)
-	}
-
-	orgID := resp.Header.Get("x-databricks-org-id")
-	if orgID == "" {
-		return "", fmt.Errorf("x-databricks-org-id header not present in SCIM response")
-	}
-	return orgID, nil
-}
-
-// ConstructGatewayURL builds the AI Gateway URL using the workspace ID, falling back
-// to the serving-endpoints path if workspace ID resolution fails.
-func ConstructGatewayURL(host, token string) string {
-	workspaceID, err := ResolveWorkspaceID(host, token)
-	if err != nil {
-		log.Printf("workspace ID resolution failed, falling back to serving-endpoints: %v", err)
-		return host + "/serving-endpoints/anthropic"
-	}
-	gatewayURL := "https://" + workspaceID + ".ai-gateway.cloud.databricks.com/anthropic"
-	log.Printf("resolved workspace ID %s, using AI Gateway URL: %s", workspaceID, gatewayURL)
-	return gatewayURL
+// ConstructGatewayURL returns the AI Gateway base URL for the given Databricks host.
+func ConstructGatewayURL(host string) string {
+	host = strings.TrimRight(host, "/")
+	return host + "/ai-gateway/anthropic"
 }

--- a/token_test.go
+++ b/token_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -322,75 +320,19 @@ func TestDiscoverHost_CommandFails(t *testing.T) {
 	}
 }
 
-// TestResolveWorkspaceID_Success: mock server returns org-id header → extracted.
-func TestResolveWorkspaceID_Success(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("x-databricks-org-id", "1234567890")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	orgID, err := ResolveWorkspaceID(srv.URL, "test-token")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestConstructGatewayURL(t *testing.T) {
+	tests := []struct {
+		host string
+		want string
+	}{
+		{"https://adb-123.azuredatabricks.net", "https://adb-123.azuredatabricks.net/ai-gateway/anthropic"},
+		{"https://adb-123.azuredatabricks.net/", "https://adb-123.azuredatabricks.net/ai-gateway/anthropic"},
 	}
-	if orgID != "1234567890" {
-		t.Errorf("got %q, want %q", orgID, "1234567890")
-	}
-}
-
-// TestResolveWorkspaceID_MissingHeader: server returns 200 but no org-id header → error.
-func TestResolveWorkspaceID_MissingHeader(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	_, err := ResolveWorkspaceID(srv.URL, "test-token")
-	if err == nil {
-		t.Fatal("expected error when org-id header missing, got nil")
-	}
-}
-
-// TestResolveWorkspaceID_Non200: server returns 401 → error.
-func TestResolveWorkspaceID_Non200(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-
-	_, err := ResolveWorkspaceID(srv.URL, "bad-token")
-	if err == nil {
-		t.Fatal("expected error on non-200 status, got nil")
-	}
-}
-
-// TestConstructGatewayURL_WithWorkspaceID: resolves workspace ID → AI Gateway URL.
-func TestConstructGatewayURL_WithWorkspaceID(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("x-databricks-org-id", "9876543210")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	got := ConstructGatewayURL(srv.URL, "test-token")
-	want := "https://9876543210.ai-gateway.cloud.databricks.com/anthropic"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-}
-
-// TestConstructGatewayURL_Fallback: resolution fails → falls back to serving-endpoints URL.
-func TestConstructGatewayURL_Fallback(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-
-	got := ConstructGatewayURL(srv.URL, "bad-token")
-	want := srv.URL + "/serving-endpoints/anthropic"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
+	for _, tc := range tests {
+		got := ConstructGatewayURL(tc.host)
+		if got != tc.want {
+			t.Errorf("ConstructGatewayURL(%q) = %q, want %q", tc.host, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #115

## Changes
- Delete `ResolveWorkspaceID` (SCIM call to resolve workspace ID)
- Rewrite `ConstructGatewayURL(host string) string` — no token param, returns `{host}/ai-gateway/anthropic`
- Remove token fetch in `desktop_config.go` (was only used for URL construction)
- Update tests and test fixtures to new URL format

## Why
The AI Gateway URL format no longer requires a workspace ID. The new format `{host}/ai-gateway/{provider}` is confirmed in databricks/databricks-ai-bridge (official SDK).