### PR TITLE
feat: require conventional commit prefix in agent instructions

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -43,3 +43,8 @@ Releases are automated via [release-please](https://github.com/googleapis/releas
 - Squash-merge is fine — the squash commit message is what release-please reads.
 - `chore:` is safe for housekeeping (formatting, test updates, doc-only changes) but will not produce a release.
 - If a release PR is unexpectedly missing after a merge, check the release workflow logs: the most common cause is a non-conventional commit message.
+
+### Commit message requirements (release-please)
+
+- **All implementation commits MUST start with `feat:` or `fix:`.** release-please reads commit messages on master — the branch name prefix (`feat/`) does NOT trigger a version bump. Without a conventional prefix the release PR is never opened.
+- `chore:`, `docs:`, `refactor:`, `test:` prefixes will NOT trigger a release PR.


### PR DESCRIPTION
Adds an explicit rule to `.github/workflows/AGENTS.md` requiring all implementation commits to start with `feat:` or `fix:`. This fixes the root cause of missing release-please PRs — the branch name prefix does not count, only the commit message prefix does.

This `feat:` commit itself will trigger release-please to open a version bump PR for the gateway URL simplification already merged to master.