### PR TITLE
fix: correct sanitize patterns

### DIFF
--- a/pkg/proxy/sanitize.go
+++ b/pkg/proxy/sanitize.go
@@ -4,8 +4,9 @@ import "regexp"
 
 var sensitivePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`Bearer [^\s"]+`),
-	regexp.MustCompile(`dapi-[a-zA-Z0-9]+`),
+	regexp.MustCompile(`dapi[a-zA-Z0-9-]+`),
 	regexp.MustCompile(`(?i)x-api-key:\s*[^\s"]+`),
+	regexp.MustCompile(`(?i)x-databricks-authorization:\s*\S+`),
 }
 
 // sanitizeLogOutput redacts sensitive values (Bearer tokens, PATs, API keys)

--- a/pkg/proxy/sanitize_test.go
+++ b/pkg/proxy/sanitize_test.go
@@ -38,6 +38,31 @@ func TestSanitizeLogOutput(t *testing.T) {
 			input: `Bearer tok123 and dapi-xyz456`,
 			want:  `[REDACTED] and [REDACTED]`,
 		},
+		{
+			name:  "bearer header word itself is redacted",
+			input: `Bearer mysecrettoken`,
+			want:  `[REDACTED]`,
+		},
+		{
+			name:  "dapi token without leading hyphen",
+			input: `token was dapi01234567890abcdef in the request`,
+			want:  `token was [REDACTED] in the request`,
+		},
+		{
+			name:  "dapi token with internal hyphens",
+			input: `token was dapi-abc-123-xyz in the request`,
+			want:  `token was [REDACTED] in the request`,
+		},
+		{
+			name:  "x-databricks-authorization header",
+			input: `X-Databricks-Authorization: dapi01234567890abcdef`,
+			want:  `[REDACTED]`,
+		},
+		{
+			name:  "x-databricks-authorization header lowercase",
+			input: `x-databricks-authorization: some-pat-token`,
+			want:  `[REDACTED]`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Partial fix for #127 (sanitize patterns; idle-timeout to follow in Wave 2)

- Broadens `dapi` pattern to match tokens without a leading hyphen (`dapi01234567890abcdef`)
- Adds `X-Databricks-Authorization` header redaction
- Adds test coverage for new pattern variations