### PR TITLE
fix: proxy reliability — empty Bearer token and WebSocket goroutine leak

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -235,8 +235,11 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, upstream *url.URL, 
 		io.Copy(clientConn, upstreamConn) //nolint:errcheck
 	}()
 
-	// Wait for one direction to finish, then close both.
+	// Wait for first direction to finish, then close both to unblock the other goroutine.
 	<-done
+	clientConn.Close()
+	upstreamConn.Close()
+	<-done // wait for second goroutine to finish
 
 	if config.Verbose {
 		log.Printf("databricks-claude: ws connection closed")
@@ -296,8 +299,10 @@ func NewServer(config *Config) http.Handler {
 				// than crashing; the empty bearer will be rejected by the upstream.
 				log.Printf("databricks-claude: token fetch error: %v", err)
 			}
-			req.Header.Set("Authorization", "Bearer "+token)
-			req.Header.Set("x-api-key", token) // Anthropic SDK sends x-api-key; overwrite the "proxy-managed" placeholder
+			if token != "" {
+				req.Header.Set("Authorization", "Bearer "+token)
+				req.Header.Set("x-api-key", token) // Anthropic SDK sends x-api-key; overwrite the "proxy-managed" placeholder
+			}
 			req.Header.Set("x-databricks-use-coding-agent-mode", "true")
 
 			req.URL.Scheme = inferenceUpstream.Scheme
@@ -349,8 +354,10 @@ func NewServer(config *Config) http.Handler {
 			if err != nil {
 				log.Printf("databricks-claude: token fetch error (otel): %v", err)
 			}
-			req.Header.Set("Authorization", "Bearer "+token)
-			req.Header.Set("x-api-key", token)
+			if token != "" {
+				req.Header.Set("Authorization", "Bearer "+token)
+				req.Header.Set("x-api-key", token)
+			}
 
 			// Pick the correct UC table based on the OTel signal in the path.
 			// Any of UCLogsTable, UCTracesTable, or UCMetricsTable may be empty


### PR DESCRIPTION
Closes #121
Closes #122

- **Empty Bearer token (#121):** Guard `Authorization` and `x-api-key` header injection with `if token != ""` so unconfigured proxies don't send malformed headers on token fetch errors.
- **WebSocket goroutine leak (#122):** After one pipe direction closes, explicitly close both connections before waiting for the second goroutine, eliminating the linger on half-closed TCP connections.