### PR TITLE
refactor: replace parseArgs tuple with Args struct

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,41 @@ import (
 // Version is set at build time via -ldflags.
 var Version = "dev"
 
+// Args holds all parsed command-line arguments for databricks-claude.
+type Args struct {
+	Profile             string
+	Verbose             bool
+	Version             bool
+	ShowHelp            bool
+	PrintEnv            bool
+	OTEL                bool
+	OTELMetricsTable    string
+	OTELMetricsTableSet bool
+	OTELLogsTable       string
+	OTELLogsTableSet    bool
+	OTELTraces          bool
+	OTELTracesTable     string
+	OTELTracesTableSet  bool
+	Upstream            string
+	LogFile             string
+	NoOTEL              bool
+	NoOTELMetrics       bool
+	NoOTELLogs          bool
+	NoOTELTraces        bool
+	ProxyAPIKey         string
+	TLSCert             string
+	TLSKey              string
+	Port                int
+	Headless            bool
+	IdleTimeout         time.Duration
+	InstallHooks        bool
+	UninstallHooks      bool
+	HeadlessEnsure      bool
+	HeadlessRelease     bool
+	NoUpdateCheck       bool
+	ClaudeArgs          []string
+}
+
 func main() {
 	// completion <shell> — must be the very first check, before any flag parsing,
 	// auth, or state loading. Safe to call in the Homebrew install sandbox.
@@ -87,38 +122,38 @@ func main() {
 	// Usage: databricks-claude [databricks-claude-flags] [--] [claude-args...]
 	// Unknown flags are forwarded to claude automatically.
 	// Tip: use "databricks-claude -- completion" to pass "completion" to claude.
-	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, otelMetricsTableSet, otelLogsTable, otelLogsTableSet, otelTraces, otelTracesTable, otelTracesTableSet, upstream, logFile, noOtel, noOtelMetrics, noOtelLogs, noOtelTraces, proxyAPIKey, tlsCert, tlsKey, portFlag, headless, idleTimeout, installHooksFlag, uninstallHooksFlag, headlessEnsureFlag, headlessReleaseFlag, noUpdateCheck, claudeArgs := parseArgs(os.Args[1:])
+	a := parseArgs(os.Args[1:])
 
-	if showHelp {
-		handleHelp(upstream)
+	if a.ShowHelp {
+		handleHelp(a.Upstream)
 		os.Exit(0)
 	}
 
-	if version {
+	if a.Version {
 		fmt.Printf("databricks-claude %s\n", Version)
 		os.Exit(0)
 	}
 
 	// --- Hook lifecycle commands (handled before auth/config setup) ---
-	if installHooksFlag || uninstallHooksFlag {
+	if a.InstallHooks || a.UninstallHooks {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			log.Fatalf("databricks-claude: cannot determine home dir: %v", err)
 		}
 		sp := filepath.Join(homeDir, ".claude", "settings.json")
-		if installHooksFlag {
+		if a.InstallHooks {
 			// First-run env setup: persist profile/port and write
 			// ANTHROPIC_BASE_URL placeholder so users no longer need to run
 			// `databricks-claude` once before installing hooks. The placeholder
 			// URL is overwritten by --headless-ensure at session start with
 			// the discovered gateway URL.
-			resolvedProfile := profile
+			resolvedProfile := a.Profile
 			if resolvedProfile == "" {
 				resolvedProfile = "DEFAULT"
 			}
-			port := resolvePort(portFlag, loadState())
+			port := resolvePort(a.Port, loadState())
 			placeholder := fmt.Sprintf("http://127.0.0.1:%d", port)
-			if err := bootstrapSettings(portFlag, resolvedProfile, placeholder, nil); err != nil {
+			if err := bootstrapSettings(a.Port, resolvedProfile, placeholder, nil); err != nil {
 				log.Fatalf("databricks-claude: --install-hooks bootstrap: %v", err)
 			}
 			if err := installHooks(sp); err != nil {
@@ -135,10 +170,10 @@ func main() {
 	}
 
 	// --- Headless hook commands (called by installed hooks, not by end users) ---
-	if headlessEnsureFlag || headlessReleaseFlag {
+	if a.HeadlessEnsure || a.HeadlessRelease {
 		state := loadState()
-		port := resolvePort(portFlag, state)
-		if headlessEnsureFlag {
+		port := resolvePort(a.Port, state)
+		if a.HeadlessEnsure {
 			headlessEnsure(port)
 		} else {
 			headlessRelease(port)
@@ -149,31 +184,31 @@ func main() {
 	// --no-otel and --no-otel-{metrics,logs,traces}: clear persisted OTEL keys
 	// from settings.json. Per-signal flags clear only that signal; --no-otel
 	// is the nuclear option that clears every signal plus the telemetry toggle.
-	if noOtel || noOtelMetrics || noOtelLogs || noOtelTraces {
+	if a.NoOTEL || a.NoOTELMetrics || a.NoOTELLogs || a.NoOTELTraces {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			log.Fatalf("databricks-claude: cannot determine home dir: %v", err)
 		}
 		settingsPathForClear := filepath.Join(homeDir, ".claude", "settings.json")
-		if noOtel {
+		if a.NoOTEL {
 			if err := clearOTELKeys(settingsPathForClear); err != nil {
 				log.Fatalf("databricks-claude: failed to clear OTEL keys: %v", err)
 			}
 			fmt.Fprintln(os.Stderr, "databricks-claude: OTEL keys cleared — OTEL disabled for future sessions")
 		} else {
-			if noOtelMetrics {
+			if a.NoOTELMetrics {
 				if err := clearOTELKeysSubset(settingsPathForClear, otelMetricsKeys); err != nil {
 					log.Fatalf("databricks-claude: failed to clear OTEL metrics keys: %v", err)
 				}
 				fmt.Fprintln(os.Stderr, "databricks-claude: OTEL metrics keys cleared")
 			}
-			if noOtelLogs {
+			if a.NoOTELLogs {
 				if err := clearOTELKeysSubset(settingsPathForClear, otelLogsKeys); err != nil {
 					log.Fatalf("databricks-claude: failed to clear OTEL logs keys: %v", err)
 				}
 				fmt.Fprintln(os.Stderr, "databricks-claude: OTEL logs keys cleared")
 			}
-			if noOtelTraces {
+			if a.NoOTELTraces {
 				if err := clearOTELKeysSubset(settingsPathForClear, otelTracesKeys); err != nil {
 					log.Fatalf("databricks-claude: failed to clear OTEL traces keys: %v", err)
 				}
@@ -193,17 +228,17 @@ func main() {
 	// Default: discard all logs (silent wrapper — identical to vanilla claude).
 	log.SetOutput(io.Discard)
 
-	if verbose {
+	if a.Verbose {
 		log.SetOutput(os.Stderr)
 	}
-	if logFile != "" {
-		f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if a.LogFile != "" {
+		f, err := os.OpenFile(a.LogFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 		if err != nil {
 			log.SetOutput(os.Stderr) // ensure this fatal is visible
-			log.Fatalf("databricks-claude: cannot open log file %q: %v", logFile, err)
+			log.Fatalf("databricks-claude: cannot open log file %q: %v", a.LogFile, err)
 		}
 		defer f.Close()
-		if verbose {
+		if a.Verbose {
 			// Both stderr and file.
 			log.SetOutput(io.MultiWriter(os.Stderr, f))
 		} else {
@@ -224,7 +259,7 @@ func main() {
 	// Claude's settings.json injects env vars into child processes, which
 	// would override the user's explicit --profile choice persisted in the
 	// state file.
-	resolvedProfile := profile
+	resolvedProfile := a.Profile
 	if resolvedProfile == "" {
 		if saved := loadState(); saved.Profile != "" {
 			resolvedProfile = saved.Profile
@@ -311,13 +346,13 @@ func main() {
 	// table value that the state-file fallback above may have populated —
 	// the flag wins over persisted state (but the state file is left intact
 	// so the next --otel invocation can pick the tables back up).
-	if noOtel || noOtelMetrics {
+	if a.NoOTEL || a.NoOTELMetrics {
 		ucMetricsTable = ""
 	}
-	if noOtel || noOtelLogs {
+	if a.NoOTEL || a.NoOTELLogs {
 		ucLogsTable = ""
 	}
-	if noOtel || noOtelTraces {
+	if a.NoOTEL || a.NoOTELTraces {
 		ucTracesTable = ""
 	}
 
@@ -332,8 +367,8 @@ func main() {
 	needsFullSetup := false
 
 	// --upstream flag takes highest priority for the inference endpoint.
-	if upstream != "" {
-		inferenceUpstream = upstream
+	if a.Upstream != "" {
+		inferenceUpstream = a.Upstream
 		log.Printf("databricks-claude: using explicit upstream: %s", inferenceUpstream)
 		if databricksHost == "" {
 			// Try to discover host for OTEL even when upstream is explicit.
@@ -375,38 +410,38 @@ func main() {
 	//
 	// Metrics table: --otel-metrics-table > persisted > --otel default. Without
 	// any of those, ucMetricsTable stays empty and metrics env vars are skipped.
-	if otelMetricsTableSet {
-		ucMetricsTable = otelMetricsTable
-	} else if ucMetricsTable == "" && otel {
-		ucMetricsTable = otelMetricsTable
+	if a.OTELMetricsTableSet {
+		ucMetricsTable = a.OTELMetricsTable
+	} else if ucMetricsTable == "" && a.OTEL {
+		ucMetricsTable = a.OTELMetricsTable
 	}
 
 	// Logs table: --otel-logs-table > persisted > derive-from-metrics (only
 	// when metrics is itself configured). Without any of those it stays empty.
-	if otelLogsTableSet {
-		ucLogsTable = otelLogsTable
+	if a.OTELLogsTableSet {
+		ucLogsTable = a.OTELLogsTable
 	} else if ucLogsTable == "" && ucMetricsTable != "" {
 		ucLogsTable = deriveLogsTable(ucMetricsTable)
 	}
 
 	// Traces table: --otel-traces-table > persisted. No default — traces are
 	// opt-in via --otel-traces / --otel-traces-table.
-	if otelTracesTableSet {
-		ucTracesTable = otelTracesTable
+	if a.OTELTracesTableSet {
+		ucTracesTable = a.OTELTracesTable
 	}
 	// If --otel-traces is passed but no table is configured (neither flag nor
 	// persisted), traces is silently skipped — see the env-injection block.
-	_ = otelTraces
+	_ = a.OTELTraces
 
 	// --- Resolve port for downstream binding ---
-	port := resolvePort(portFlag, loadState())
+	port := resolvePort(a.Port, loadState())
 
 	// --- Print env and exit if requested ---
 	// This exit is intentionally before any state or settings.json writes so
 	// --print-env remains a read-only diagnostic (no side effects).
-	if printEnv {
+	if a.PrintEnv {
 		otelActive := ucMetricsTable != "" || ucLogsTable != "" || ucTracesTable != ""
-		handlePrintEnv(resolvedProfile, databricksHost, inferenceUpstream, initialToken, upstream, otelActive, ucMetricsTable, ucLogsTable, ucTracesTable)
+		handlePrintEnv(resolvedProfile, databricksHost, inferenceUpstream, initialToken, a.Upstream, otelActive, ucMetricsTable, ucLogsTable, ucTracesTable)
 		os.Exit(0)
 	}
 
@@ -419,17 +454,17 @@ func main() {
 		metricsToSave := ""
 		logsToSave := ""
 		tracesToSave := ""
-		if otelMetricsTableSet {
+		if a.OTELMetricsTableSet {
 			metricsToSave = ucMetricsTable
 		} else if metricsFromSettings != "" && tableState.OtelMetricsTable == "" {
 			metricsToSave = metricsFromSettings
 		}
-		if otelLogsTableSet {
+		if a.OTELLogsTableSet {
 			logsToSave = ucLogsTable
 		} else if logsFromSettings != "" && tableState.OtelLogsTable == "" {
 			logsToSave = logsFromSettings
 		}
-		if otelTracesTableSet {
+		if a.OTELTracesTableSet {
 			tracesToSave = ucTracesTable
 		} else if tracesFromSettings != "" && tableState.OtelTracesTable == "" {
 			tracesToSave = tracesFromSettings
@@ -455,7 +490,7 @@ func main() {
 	}
 
 	// --- Validate TLS config ---
-	if err := proxy.ValidateTLSConfig(tlsCert, tlsKey); err != nil {
+	if err := proxy.ValidateTLSConfig(a.TLSCert, a.TLSKey); err != nil {
 		log.Fatalf("databricks-claude: %v", err)
 	}
 
@@ -466,7 +501,7 @@ func main() {
 	}
 
 	scheme := "http"
-	if tlsCert != "" && tlsKey != "" {
+	if a.TLSCert != "" && a.TLSKey != "" {
 		scheme = "https"
 		fmt.Fprintln(os.Stderr, "databricks-claude: TLS enabled")
 	}
@@ -480,14 +515,14 @@ func main() {
 		UCLogsTable:       ucLogsTable,
 		UCTracesTable:     ucTracesTable,
 		TokenProvider:     tp,
-		Verbose:           verbose,
-		APIKey:            proxyAPIKey,
-		TLSCertFile:       tlsCert,
-		TLSKeyFile:        tlsKey,
+		Verbose:           a.Verbose,
+		APIKey:            a.ProxyAPIKey,
+		TLSCertFile:       a.TLSCert,
+		TLSKeyFile:        a.TLSKey,
 		ToolName:          "databricks-claude",
 		Version:           Version,
 	}
-	if proxyAPIKey != "" {
+	if a.ProxyAPIKey != "" {
 		fmt.Fprintln(os.Stderr, "databricks-claude: proxy API key authentication enabled")
 	}
 	handler := NewProxyServer(proxyConfig)
@@ -498,7 +533,7 @@ func main() {
 	// so the last session's release brings the count to 0 and triggers shutdown.
 	// In wrapper mode, the parent process acquires here and releases on exit.
 	refcountPath := refcount.PathForPort(".databricks-claude-sessions", port)
-	if !headless {
+	if !a.Headless {
 		if err := refcount.Acquire(refcountPath); err != nil {
 			log.Printf("databricks-claude: refcount acquire warning: %v", err)
 		}
@@ -510,7 +545,7 @@ func main() {
 	// promote IsOwner so /shutdown correctly triggers shutdown after takeover.
 	var doneCh chan struct{}
 	var promoteCh chan struct{}
-	if headless {
+	if a.Headless {
 		doneCh = make(chan struct{})
 		if !isOwner {
 			promoteCh = make(chan struct{})
@@ -520,8 +555,8 @@ func main() {
 			RefcountPath: refcountPath,
 			IsOwner:      isOwner,
 			PromoteCh:    promoteCh,
-			IdleTimeout:  idleTimeout,
-			APIKey:       proxyAPIKey,
+			IdleTimeout:  a.IdleTimeout,
+			APIKey:       a.ProxyAPIKey,
 			DoneCh:       doneCh,
 			LogPrefix:    "databricks-claude",
 		})
@@ -531,8 +566,8 @@ func main() {
 	if isOwner {
 		go func() {
 			srv := &http.Server{Handler: handler}
-			if tlsCert != "" && tlsKey != "" {
-				if err := srv.ServeTLS(ln, tlsCert, tlsKey); err != nil && err != http.ErrServerClosed {
+			if a.TLSCert != "" && a.TLSKey != "" {
+				if err := srv.ServeTLS(ln, a.TLSCert, a.TLSKey); err != nil && err != http.ErrServerClosed {
 					log.Printf("databricks-claude: proxy serve error: %v", err)
 				}
 			} else {
@@ -550,7 +585,7 @@ func main() {
 				close(promoteCh)
 			}
 		}
-		go health.WatchProxy(port, handler, tlsCert, tlsKey, "databricks-claude", onTakeover)
+		go health.WatchProxy(port, handler, a.TLSCert, a.TLSKey, "databricks-claude", onTakeover)
 	}
 
 	// --- Write config once (idempotent) ---
@@ -604,8 +639,8 @@ func main() {
 		otelEnv["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] = "1"
 	}
 
-	if err := bootstrapSettings(portFlag, resolvedProfile, proxyURL, otelEnv); err != nil {
-		if headless {
+	if err := bootstrapSettings(a.Port, resolvedProfile, proxyURL, otelEnv); err != nil {
+		if a.Headless {
 			fmt.Fprintf(os.Stderr, "databricks-claude: warning: config write failed: %v\n", err)
 		} else {
 			log.Fatalf("databricks-claude: %v", err)
@@ -616,18 +651,18 @@ func main() {
 	log.Printf("databricks-claude: proxy on %s (owner=%v), profile=%s, upstream=%s",
 		proxyURL, isOwner, resolvedProfile, inferenceUpstream)
 
-	if headless {
+	if a.Headless {
 		runHeadless(proxyURL, ln, isOwner, refcountPath, doneCh)
 		return
 	}
 
 	// --- Synchronous update check (before child to avoid stderr interleaving) ---
-	if !noUpdateCheck && os.Getenv("DATABRICKS_NO_UPDATE_CHECK") != "1" {
+	if !a.NoUpdateCheck && os.Getenv("DATABRICKS_NO_UPDATE_CHECK") != "1" {
 		updater.PrintUpdateNotice(buildUpdaterConfig())
 	}
 
 	// --- Run child ---
-	exitCode, err := RunChild(context.Background(), claudeArgs)
+	exitCode, err := RunChild(context.Background(), a.ClaudeArgs)
 	if err != nil {
 		log.Printf("databricks-claude: child error: %v", err)
 	}
@@ -690,9 +725,11 @@ func envBlock(doc map[string]interface{}) map[string]interface{} {
 // --no-otel-traces, --proxy-api-key, --tls-cert, --tls-key.
 // Everything else (including unknown flags like --debug) passes through to claude.
 // An explicit "--" separator is supported but not required.
-func parseArgs(args []string) (profile string, verbose bool, version bool, showHelp bool, printEnv bool, otel bool, otelMetricsTable string, otelMetricsTableSet bool, otelLogsTable string, otelLogsTableSet bool, otelTraces bool, otelTracesTable string, otelTracesTableSet bool, upstream string, logFile string, noOtel bool, noOtelMetrics bool, noOtelLogs bool, noOtelTraces bool, proxyAPIKey string, tlsCert string, tlsKey string, portFlag int, headless bool, idleTimeout time.Duration, installHooksFlag bool, uninstallHooksFlag bool, headlessEnsureFlag bool, headlessReleaseFlag bool, noUpdateCheck bool, claudeArgs []string) {
-	otelMetricsTable = "main.claude_telemetry.claude_otel_metrics" // default
-	idleTimeout = 30 * time.Minute                                 // default
+func parseArgs(args []string) *Args {
+	a := &Args{
+		OTELMetricsTable: "main.claude_telemetry.claude_otel_metrics", // default
+		IdleTimeout:      30 * time.Minute,                            // default
+	}
 
 	// knownFlags is defined at package level in completion_flags.go,
 	// derived from flagDefs so completions and parsing stay in sync.
@@ -703,18 +740,18 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 
 		// Explicit separator: everything after "--" goes to claude.
 		if arg == "--" {
-			claudeArgs = append(claudeArgs, args[i+1:]...)
-			return
+			a.ClaudeArgs = append(a.ClaudeArgs, args[i+1:]...)
+			return a
 		}
 
 		// Special case: -h is a short flag for --help, -v for --verbose.
 		if arg == "-h" {
-			showHelp = true
+			a.ShowHelp = true
 			i++
 			continue
 		}
 		if arg == "-v" {
-			verbose = true
+			a.Verbose = true
 			i++
 			continue
 		}
@@ -733,112 +770,112 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 				switch name {
 				case "--profile":
 					if value != "" {
-						profile = value
+						a.Profile = value
 					} else if i+1 < len(args) {
 						i++
-						profile = args[i]
+						a.Profile = args[i]
 					}
 				case "--otel-metrics-table":
 					if value != "" {
-						otelMetricsTable = value
-						otelMetricsTableSet = true
+						a.OTELMetricsTable = value
+						a.OTELMetricsTableSet = true
 					} else if i+1 < len(args) {
 						i++
-						otelMetricsTable = args[i]
-						otelMetricsTableSet = true
+						a.OTELMetricsTable = args[i]
+						a.OTELMetricsTableSet = true
 					}
 				case "--otel-logs-table":
 					if value != "" {
-						otelLogsTable = value
-						otelLogsTableSet = true
+						a.OTELLogsTable = value
+						a.OTELLogsTableSet = true
 					} else if i+1 < len(args) {
 						i++
-						otelLogsTable = args[i]
-						otelLogsTableSet = true
+						a.OTELLogsTable = args[i]
+						a.OTELLogsTableSet = true
 					}
 				case "--upstream":
 					if value != "" {
-						upstream = value
+						a.Upstream = value
 					} else if i+1 < len(args) {
 						i++
-						upstream = args[i]
+						a.Upstream = args[i]
 					}
 				case "--log-file":
 					if value != "" {
-						logFile = value
+						a.LogFile = value
 					} else if i+1 < len(args) {
 						i++
-						logFile = args[i]
+						a.LogFile = args[i]
 					}
 				case "--verbose":
-					verbose = true
+					a.Verbose = true
 				case "--version":
-					version = true
+					a.Version = true
 				case "--help":
-					showHelp = true
+					a.ShowHelp = true
 				case "--print-env":
-					printEnv = true
+					a.PrintEnv = true
 				case "--otel":
-					otel = true
+					a.OTEL = true
 				case "--otel-traces":
-					otelTraces = true
+					a.OTELTraces = true
 				case "--otel-traces-table":
 					if value != "" {
-						otelTracesTable = value
-						otelTracesTableSet = true
+						a.OTELTracesTable = value
+						a.OTELTracesTableSet = true
 					} else if i+1 < len(args) {
 						i++
-						otelTracesTable = args[i]
-						otelTracesTableSet = true
+						a.OTELTracesTable = args[i]
+						a.OTELTracesTableSet = true
 					}
 				case "--no-otel":
-					noOtel = true
+					a.NoOTEL = true
 				case "--no-otel-metrics":
-					noOtelMetrics = true
+					a.NoOTELMetrics = true
 				case "--no-otel-logs":
-					noOtelLogs = true
+					a.NoOTELLogs = true
 				case "--no-otel-traces":
-					noOtelTraces = true
+					a.NoOTELTraces = true
 				case "--proxy-api-key":
 					if value != "" {
-						proxyAPIKey = value
+						a.ProxyAPIKey = value
 					} else if i+1 < len(args) {
 						i++
-						proxyAPIKey = args[i]
+						a.ProxyAPIKey = args[i]
 					}
 				case "--tls-cert":
 					if value != "" {
-						tlsCert = value
+						a.TLSCert = value
 					} else if i+1 < len(args) {
 						i++
-						tlsCert = args[i]
+						a.TLSCert = args[i]
 					}
 				case "--tls-key":
 					if value != "" {
-						tlsKey = value
+						a.TLSKey = value
 					} else if i+1 < len(args) {
 						i++
-						tlsKey = args[i]
+						a.TLSKey = args[i]
 					}
 				case "--port":
 					if value != "" {
-						portFlag, _ = strconv.Atoi(value)
+						a.Port, _ = strconv.Atoi(value)
 					} else if i+1 < len(args) {
 						i++
-						portFlag, _ = strconv.Atoi(args[i])
+						a.Port, _ = strconv.Atoi(args[i])
 					}
 				case "--headless":
-					headless = true
+					a.Headless = true
 				case "--install-hooks":
-					installHooksFlag = true
+					a.InstallHooks = true
 				case "--uninstall-hooks":
-					uninstallHooksFlag = true
+					a.UninstallHooks = true
 				case "--headless-ensure":
-					headlessEnsureFlag = true
+					a.HeadlessEnsure = true
 				case "--headless-release":
-					headlessReleaseFlag = true
+					a.HeadlessRelease = true
 				case "--no-update-check":
-					noUpdateCheck = true
+					a.NoUpdateCheck = true
 				case "--idle-timeout":
 					raw := value
 					if raw == "" && i+1 < len(args) {
@@ -847,10 +884,10 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 					}
 					if raw != "" {
 						if d, err := time.ParseDuration(raw); err == nil {
-							idleTimeout = d
+							a.IdleTimeout = d
 						} else if mins, err := strconv.Atoi(raw); err == nil {
 							// Bare number: treat as minutes for convenience.
-							idleTimeout = time.Duration(mins) * time.Minute
+							a.IdleTimeout = time.Duration(mins) * time.Minute
 						}
 					}
 				}
@@ -860,10 +897,10 @@ func parseArgs(args []string) (profile string, verbose bool, version bool, showH
 		}
 
 		// Not a known databricks-claude flag — pass through to claude.
-		claudeArgs = append(claudeArgs, arg)
+		a.ClaudeArgs = append(a.ClaudeArgs, arg)
 		i++
 	}
-	return
+	return a
 }
 
 // handleHelp prints the databricks-claude help message and appends claude's own --help output.

--- a/main_test.go
+++ b/main_test.go
@@ -27,267 +27,267 @@ type shutdownResp struct {
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--help"})
-	if !showHelp {
+	a := parseArgs([]string{"--help"})
+	if !a.ShowHelp {
 		t.Error("expected showHelp=true for --help")
 	}
-	if profile != "" || verbose || version || printEnv || otel || upstream != "" || logFile != "" || noOtel || len(claudeArgs) != 0 {
+	if a.Profile != "" || a.Verbose || a.Version || a.PrintEnv || a.OTEL || a.Upstream != "" || a.LogFile != "" || a.NoOTEL || len(a.ClaudeArgs) != 0 {
 		t.Error("unexpected non-default values alongside --help")
 	}
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
-	if !showHelp {
+	a := parseArgs([]string{"-h"})
+	if !a.ShowHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
-	if !printEnv {
+	a := parseArgs([]string{"--print-env"})
+	if !a.PrintEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, _, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
-	if !version {
+	a := parseArgs([]string{"--version"})
+	if !a.Version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
-	if !verbose {
+	a := parseArgs([]string{"--verbose"})
+	if !a.Verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
-	if !verbose {
+	a := parseArgs([]string{"-v"})
+	if !a.Verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
-	if logFile != "/tmp/test.log" {
-		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
+	a := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	if a.LogFile != "/tmp/test.log" {
+		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", a.LogFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
-	if logFile != "/tmp/test.log" {
-		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
+	a := parseArgs([]string{"--log-file=/tmp/test.log"})
+	if a.LogFile != "/tmp/test.log" {
+		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", a.LogFile)
 	}
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	profile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "foo"})
-	if profile != "foo" {
-		t.Errorf("expected profile=%q, got %q", "foo", profile)
+	a := parseArgs([]string{"--profile", "foo"})
+	if a.Profile != "foo" {
+		t.Errorf("expected profile=%q, got %q", "foo", a.Profile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
-	if upstream != "/path/to/claude" {
-		t.Errorf("expected upstream=%q, got %q", "/path/to/claude", upstream)
+	a := parseArgs([]string{"--upstream", "/path/to/claude"})
+	if a.Upstream != "/path/to/claude" {
+		t.Errorf("expected upstream=%q, got %q", "/path/to/claude", a.Upstream)
 	}
 }
 
 func TestParseArgs_Otel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
-	if !otel {
+	a := parseArgs([]string{"--otel"})
+	if !a.OTEL {
 		t.Error("expected otel=true for --otel")
 	}
 }
 
 func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
-	if !metricsTableSet {
+	a := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
+	if !a.OTELMetricsTableSet {
 		t.Error("expected metricsTableSet=true when --otel-metrics-table is passed")
 	}
-	if metricsTable != "main.default.otel" {
-		t.Errorf("expected metricsTable=%q, got %q", "main.default.otel", metricsTable)
+	if a.OTELMetricsTable != "main.default.otel" {
+		t.Errorf("expected metricsTable=%q, got %q", "main.default.otel", a.OTELMetricsTable)
 	}
 }
 
 func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
-	if metricsTableSet {
+	a := parseArgs([]string{"--otel"})
+	if a.OTELMetricsTableSet {
 		t.Error("expected metricsTableSet=false when --otel-metrics-table is not passed")
 	}
-	if metricsTable != "main.claude_telemetry.claude_otel_metrics" {
-		t.Errorf("expected default metricsTable, got %q", metricsTable)
+	if a.OTELMetricsTable != "main.claude_telemetry.claude_otel_metrics" {
+		t.Errorf("expected default metricsTable, got %q", a.OTELMetricsTable)
 	}
 }
 
 func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
-	if !metricsTableSet {
+	a := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
+	if !a.OTELMetricsTableSet {
 		t.Error("expected metricsTableSet=true for --otel-metrics-table=value")
 	}
-	if metricsTable != "my.catalog.table" {
-		t.Errorf("expected metricsTable=%q, got %q", "my.catalog.table", metricsTable)
+	if a.OTELMetricsTable != "my.catalog.table" {
+		t.Errorf("expected metricsTable=%q, got %q", "my.catalog.table", a.OTELMetricsTable)
 	}
 }
 
 func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
-	if !logsTableSet {
+	a := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
+	if !a.OTELLogsTableSet {
 		t.Error("expected logsTableSet=true when --otel-logs-table is passed")
 	}
-	if logsTable != "main.default.my_logs" {
-		t.Errorf("expected logsTable=%q, got %q", "main.default.my_logs", logsTable)
+	if a.OTELLogsTable != "main.default.my_logs" {
+		t.Errorf("expected logsTable=%q, got %q", "main.default.my_logs", a.OTELLogsTable)
 	}
 }
 
 func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
-	if logsTableSet {
+	a := parseArgs([]string{"--otel"})
+	if a.OTELLogsTableSet {
 		t.Error("expected logsTableSet=false when --otel-logs-table is not passed")
 	}
-	if logsTable != "" {
-		t.Errorf("expected empty logsTable default, got %q", logsTable)
+	if a.OTELLogsTable != "" {
+		t.Errorf("expected empty logsTable default, got %q", a.OTELLogsTable)
 	}
 }
 
 func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, logsTable, logsTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
-	if !logsTableSet {
+	a := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
+	if !a.OTELLogsTableSet {
 		t.Error("expected logsTableSet=true for --otel-logs-table=value")
 	}
-	if logsTable != "my.catalog.logs" {
-		t.Errorf("expected logsTable=%q, got %q", "my.catalog.logs", logsTable)
+	if a.OTELLogsTable != "my.catalog.logs" {
+		t.Errorf("expected logsTable=%q, got %q", "my.catalog.logs", a.OTELLogsTable)
 	}
 }
 
 func TestParseArgs_BothOtelTables(t *testing.T) {
-	_, _, _, _, _, _, metricsTable, metricsSet, logsTable, logsSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{
+	a := parseArgs([]string{
 		"--otel-metrics-table", "cat.schema.metrics",
 		"--otel-logs-table", "cat.schema.logs",
 	})
-	if !metricsSet || !logsSet {
+	if !a.OTELMetricsTableSet || !a.OTELLogsTableSet {
 		t.Error("expected both table flags to be set")
 	}
-	if metricsTable != "cat.schema.metrics" {
-		t.Errorf("metricsTable=%q, want cat.schema.metrics", metricsTable)
+	if a.OTELMetricsTable != "cat.schema.metrics" {
+		t.Errorf("metricsTable=%q, want cat.schema.metrics", a.OTELMetricsTable)
 	}
-	if logsTable != "cat.schema.logs" {
-		t.Errorf("logsTable=%q, want cat.schema.logs", logsTable)
+	if a.OTELLogsTable != "cat.schema.logs" {
+		t.Errorf("logsTable=%q, want cat.schema.logs", a.OTELLogsTable)
 	}
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--unknown"})
-	if len(claudeArgs) != 1 || claudeArgs[0] != "--unknown" {
-		t.Errorf("expected claudeArgs=[\"--unknown\"], got %v", claudeArgs)
+	a := parseArgs([]string{"--unknown"})
+	if len(a.ClaudeArgs) != 1 || a.ClaudeArgs[0] != "--unknown" {
+		t.Errorf("expected claudeArgs=[\"--unknown\"], got %v", a.ClaudeArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	profile, verbose, version, showHelp, printEnv, otel, otelMetricsTable, _, _, _, _, _, _, upstream, logFile, noOtel, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{})
-	if profile != "" {
-		t.Errorf("expected empty profile, got %q", profile)
+	a := parseArgs([]string{})
+	if a.Profile != "" {
+		t.Errorf("expected empty profile, got %q", a.Profile)
 	}
-	if verbose || version || showHelp || printEnv || otel || noOtel {
+	if a.Verbose || a.Version || a.ShowHelp || a.PrintEnv || a.OTEL || a.NoOTEL {
 		t.Error("expected all bool flags false for empty args")
 	}
-	if upstream != "" {
-		t.Errorf("expected empty upstream, got %q", upstream)
+	if a.Upstream != "" {
+		t.Errorf("expected empty upstream, got %q", a.Upstream)
 	}
-	if logFile != "" {
-		t.Errorf("expected empty logFile, got %q", logFile)
+	if a.LogFile != "" {
+		t.Errorf("expected empty logFile, got %q", a.LogFile)
 	}
-	if len(claudeArgs) != 0 {
-		t.Errorf("expected no claudeArgs, got %v", claudeArgs)
+	if len(a.ClaudeArgs) != 0 {
+		t.Errorf("expected no claudeArgs, got %v", a.ClaudeArgs)
 	}
-	// otelMetricsTable should have the default value
-	if otelMetricsTable == "" {
+	// OTELMetricsTable should have the default value
+	if a.OTELMetricsTable == "" {
 		t.Error("expected non-empty default otelMetricsTable")
 	}
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	profile, verbose, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
-	if !showHelp {
+	a := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
+	if !a.ShowHelp {
 		t.Error("expected showHelp=true")
 	}
-	if profile != "prod" {
-		t.Errorf("expected profile=%q, got %q", "prod", profile)
+	if a.Profile != "prod" {
+		t.Errorf("expected profile=%q, got %q", "prod", a.Profile)
 	}
-	if !verbose {
+	if !a.Verbose {
 		t.Error("expected verbose=true")
 	}
 }
 
 func TestParseArgs_Headless(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _, _, _ := parseArgs([]string{"--headless"})
-	if !headless {
+	a := parseArgs([]string{"--headless"})
+	if !a.Headless {
 		t.Error("expected headless=true for --headless")
 	}
 }
 
 func TestParseArgs_NoUpdateCheck(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, noUpdateCheck, _ := parseArgs([]string{"--no-update-check"})
-	if !noUpdateCheck {
+	a := parseArgs([]string{"--no-update-check"})
+	if !a.NoUpdateCheck {
 		t.Error("expected noUpdateCheck=true for --no-update-check")
 	}
 }
 
 func TestParseArgs_HeadlessWithOtherFlags(t *testing.T) {
-	_, verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _, _, _ := parseArgs([]string{"--headless", "--verbose"})
-	if !headless {
+	a := parseArgs([]string{"--headless", "--verbose"})
+	if !a.Headless {
 		t.Error("expected headless=true")
 	}
-	if !verbose {
+	if !a.Verbose {
 		t.Error("expected verbose=true")
 	}
 }
 
 func TestParseArgs_NoOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel"})
-	if !noOtel {
+	a := parseArgs([]string{"--no-otel"})
+	if !a.NoOTEL {
 		t.Error("expected noOtel=true for --no-otel")
 	}
-	if otel {
+	if a.OTEL {
 		t.Error("expected otel=false when only --no-otel given")
 	}
-	if len(claudeArgs) != 0 {
-		t.Errorf("expected no claudeArgs, got %v", claudeArgs)
+	if len(a.ClaudeArgs) != 0 {
+		t.Errorf("expected no claudeArgs, got %v", a.ClaudeArgs)
 	}
 }
 
 func TestParseArgs_NoOtelAndOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--no-otel", "--otel"})
-	if !noOtel {
+	a := parseArgs([]string{"--no-otel", "--otel"})
+	if !a.NoOTEL {
 		t.Error("expected noOtel=true")
 	}
-	if !otel {
+	if !a.OTEL {
 		t.Error("expected otel=true (both flags can coexist; main() handles precedence)")
 	}
 }
 
 func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs([]string{"--no-otel", "somearg"})
-	if !noOtel {
+	a := parseArgs([]string{"--no-otel", "somearg"})
+	if !a.NoOTEL {
 		t.Error("expected noOtel=true")
 	}
-	if len(claudeArgs) != 1 || claudeArgs[0] != "somearg" {
-		t.Errorf("expected claudeArgs=[\"somearg\"], got %v", claudeArgs)
+	if len(a.ClaudeArgs) != 1 || a.ClaudeArgs[0] != "somearg" {
+		t.Errorf("expected claudeArgs=[\"somearg\"], got %v", a.ClaudeArgs)
 	}
 }
 
 func TestParseArgs_OtelUnaffectedByNoOtel(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, _, _, _, _, noOtel, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel"})
-	if !otel {
+	a := parseArgs([]string{"--otel"})
+	if !a.OTEL {
 		t.Error("expected otel=true for --otel")
 	}
-	if noOtel {
+	if a.NoOTEL {
 		t.Error("expected noOtel=false when only --otel given")
 	}
 }
@@ -295,31 +295,31 @@ func TestParseArgs_OtelUnaffectedByNoOtel(t *testing.T) {
 // --- per-signal no-otel-* flag tests ---
 
 func TestParseArgs_NoOtelMetrics(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, noOtelMetrics, noOtelLogs, noOtelTraces, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--no-otel-metrics"})
-	if !noOtelMetrics {
+	a := parseArgs([]string{"--no-otel-metrics"})
+	if !a.NoOTELMetrics {
 		t.Error("expected noOtelMetrics=true for --no-otel-metrics")
 	}
-	if noOtelLogs || noOtelTraces {
+	if a.NoOTELLogs || a.NoOTELTraces {
 		t.Error("expected noOtelLogs/noOtelTraces=false when only --no-otel-metrics given")
 	}
 }
 
 func TestParseArgs_NoOtelLogs(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, noOtelMetrics, noOtelLogs, noOtelTraces, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--no-otel-logs"})
-	if !noOtelLogs {
+	a := parseArgs([]string{"--no-otel-logs"})
+	if !a.NoOTELLogs {
 		t.Error("expected noOtelLogs=true for --no-otel-logs")
 	}
-	if noOtelMetrics || noOtelTraces {
+	if a.NoOTELMetrics || a.NoOTELTraces {
 		t.Error("expected noOtelMetrics/noOtelTraces=false when only --no-otel-logs given")
 	}
 }
 
 func TestParseArgs_NoOtelTraces(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, noOtelMetrics, noOtelLogs, noOtelTraces, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--no-otel-traces"})
-	if !noOtelTraces {
+	a := parseArgs([]string{"--no-otel-traces"})
+	if !a.NoOTELTraces {
 		t.Error("expected noOtelTraces=true for --no-otel-traces")
 	}
-	if noOtelMetrics || noOtelLogs {
+	if a.NoOTELMetrics || a.NoOTELLogs {
 		t.Error("expected noOtelMetrics/noOtelLogs=false when only --no-otel-traces given")
 	}
 }
@@ -327,56 +327,56 @@ func TestParseArgs_NoOtelTraces(t *testing.T) {
 // --- --otel-traces flag tests ---
 
 func TestParseArgs_OtelTraces(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, otelTraces, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-traces"})
-	if !otelTraces {
+	a := parseArgs([]string{"--otel-traces"})
+	if !a.OTELTraces {
 		t.Error("expected otelTraces=true for --otel-traces")
 	}
 }
 
 func TestParseArgs_OtelTracesTableOverride(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, tracesTable, tracesTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-traces-table", "main.default.traces"})
-	if !tracesTableSet {
+	a := parseArgs([]string{"--otel-traces-table", "main.default.traces"})
+	if !a.OTELTracesTableSet {
 		t.Error("expected tracesTableSet=true when --otel-traces-table is passed")
 	}
-	if tracesTable != "main.default.traces" {
-		t.Errorf("expected tracesTable=%q, got %q", "main.default.traces", tracesTable)
+	if a.OTELTracesTable != "main.default.traces" {
+		t.Errorf("expected tracesTable=%q, got %q", "main.default.traces", a.OTELTracesTable)
 	}
 }
 
 func TestParseArgs_OtelTracesTableEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, tracesTable, tracesTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-traces-table=my.catalog.traces"})
-	if !tracesTableSet {
+	a := parseArgs([]string{"--otel-traces-table=my.catalog.traces"})
+	if !a.OTELTracesTableSet {
 		t.Error("expected tracesTableSet=true for --otel-traces-table=value")
 	}
-	if tracesTable != "my.catalog.traces" {
-		t.Errorf("expected tracesTable=%q, got %q", "my.catalog.traces", tracesTable)
+	if a.OTELTracesTable != "my.catalog.traces" {
+		t.Errorf("expected tracesTable=%q, got %q", "my.catalog.traces", a.OTELTracesTable)
 	}
 }
 
 func TestParseArgs_OtelTracesTableDefault(t *testing.T) {
 	// --otel-traces alone (no table) should not auto-populate a default table —
 	// traces only activate when an explicit --otel-traces-table is provided.
-	_, _, _, _, _, _, _, _, _, _, otelTraces, tracesTable, tracesTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-traces"})
-	if !otelTraces {
+	a := parseArgs([]string{"--otel-traces"})
+	if !a.OTELTraces {
 		t.Error("expected otelTraces=true")
 	}
-	if tracesTableSet {
+	if a.OTELTracesTableSet {
 		t.Error("expected tracesTableSet=false without --otel-traces-table")
 	}
-	if tracesTable != "" {
-		t.Errorf("expected empty tracesTable default, got %q", tracesTable)
+	if a.OTELTracesTable != "" {
+		t.Errorf("expected empty tracesTable default, got %q", a.OTELTracesTable)
 	}
 }
 
 // TestParseArgs_TracesStandalone verifies that --otel-traces-table works
 // without --otel — traces is a standalone signal.
 func TestParseArgs_TracesStandalone(t *testing.T) {
-	_, _, _, _, _, otel, _, _, _, _, _, tracesTable, tracesTableSet, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--otel-traces-table", "cat.schema.traces"})
-	if otel {
+	a := parseArgs([]string{"--otel-traces-table", "cat.schema.traces"})
+	if a.OTEL {
 		t.Error("expected otel=false when only --otel-traces-table given")
 	}
-	if !tracesTableSet || tracesTable != "cat.schema.traces" {
-		t.Errorf("expected tracesTable=cat.schema.traces (set), got %q (set=%v)", tracesTable, tracesTableSet)
+	if !a.OTELTracesTableSet || a.OTELTracesTable != "cat.schema.traces" {
+		t.Errorf("expected tracesTable=cat.schema.traces (set), got %q (set=%v)", a.OTELTracesTable, a.OTELTracesTableSet)
 	}
 }
 
@@ -478,34 +478,34 @@ func TestParseArgs_Table(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			profile, verbose, version, showHelp, printEnv, otel, _, _, _, _, _, _, _, upstream, logFile, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, claudeArgs := parseArgs(tc.args)
+			a := parseArgs(tc.args)
 
-			if profile != tc.want.profile {
-				t.Errorf("profile: got %q, want %q", profile, tc.want.profile)
+			if a.Profile != tc.want.profile {
+				t.Errorf("profile: got %q, want %q", a.Profile, tc.want.profile)
 			}
-			if verbose != tc.want.verbose {
-				t.Errorf("verbose: got %v, want %v", verbose, tc.want.verbose)
+			if a.Verbose != tc.want.verbose {
+				t.Errorf("verbose: got %v, want %v", a.Verbose, tc.want.verbose)
 			}
-			if version != tc.want.version {
-				t.Errorf("version: got %v, want %v", version, tc.want.version)
+			if a.Version != tc.want.version {
+				t.Errorf("version: got %v, want %v", a.Version, tc.want.version)
 			}
-			if showHelp != tc.want.showHelp {
-				t.Errorf("showHelp: got %v, want %v", showHelp, tc.want.showHelp)
+			if a.ShowHelp != tc.want.showHelp {
+				t.Errorf("showHelp: got %v, want %v", a.ShowHelp, tc.want.showHelp)
 			}
-			if printEnv != tc.want.printEnv {
-				t.Errorf("printEnv: got %v, want %v", printEnv, tc.want.printEnv)
+			if a.PrintEnv != tc.want.printEnv {
+				t.Errorf("printEnv: got %v, want %v", a.PrintEnv, tc.want.printEnv)
 			}
-			if otel != tc.want.otel {
-				t.Errorf("otel: got %v, want %v", otel, tc.want.otel)
+			if a.OTEL != tc.want.otel {
+				t.Errorf("otel: got %v, want %v", a.OTEL, tc.want.otel)
 			}
-			if upstream != tc.want.upstream {
-				t.Errorf("upstream: got %q, want %q", upstream, tc.want.upstream)
+			if a.Upstream != tc.want.upstream {
+				t.Errorf("upstream: got %q, want %q", a.Upstream, tc.want.upstream)
 			}
-			if logFile != tc.want.logFile {
-				t.Errorf("logFile: got %q, want %q", logFile, tc.want.logFile)
+			if a.LogFile != tc.want.logFile {
+				t.Errorf("logFile: got %q, want %q", a.LogFile, tc.want.logFile)
 			}
-			if len(claudeArgs) != tc.want.claudeLen {
-				t.Errorf("claudeArgs length: got %d, want %d (args: %v)", len(claudeArgs), tc.want.claudeLen, claudeArgs)
+			if len(a.ClaudeArgs) != tc.want.claudeLen {
+				t.Errorf("claudeArgs length: got %d, want %d (args: %v)", len(a.ClaudeArgs), tc.want.claudeLen, a.ClaudeArgs)
 			}
 		})
 	}
@@ -908,37 +908,37 @@ func TestProfileResolution_StateFileWins(t *testing.T) {
 // --- idle-timeout flag tests ---
 
 func TestParseArgs_IdleTimeoutDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _, _ := parseArgs([]string{})
-	if idleTimeout != 30*time.Minute {
-		t.Errorf("expected default idleTimeout=30m, got %v", idleTimeout)
+	a := parseArgs([]string{})
+	if a.IdleTimeout != 30*time.Minute {
+		t.Errorf("expected default idleTimeout=30m, got %v", a.IdleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutCustom(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _, _ := parseArgs([]string{"--idle-timeout", "10m"})
-	if idleTimeout != 10*time.Minute {
-		t.Errorf("expected idleTimeout=10m, got %v", idleTimeout)
+	a := parseArgs([]string{"--idle-timeout", "10m"})
+	if a.IdleTimeout != 10*time.Minute {
+		t.Errorf("expected idleTimeout=10m, got %v", a.IdleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutZero(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _, _ := parseArgs([]string{"--idle-timeout", "0"})
-	if idleTimeout != 0 {
-		t.Errorf("expected idleTimeout=0, got %v", idleTimeout)
+	a := parseArgs([]string{"--idle-timeout", "0"})
+	if a.IdleTimeout != 0 {
+		t.Errorf("expected idleTimeout=0, got %v", a.IdleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _, _ := parseArgs([]string{"--idle-timeout=5m"})
-	if idleTimeout != 5*time.Minute {
-		t.Errorf("expected idleTimeout=5m, got %v", idleTimeout)
+	a := parseArgs([]string{"--idle-timeout=5m"})
+	if a.IdleTimeout != 5*time.Minute {
+		t.Errorf("expected idleTimeout=5m, got %v", a.IdleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutBareNumber(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idleTimeout, _, _, _, _, _, _ := parseArgs([]string{"--idle-timeout", "1"})
-	if idleTimeout != 1*time.Minute {
-		t.Errorf("expected idleTimeout=1m for bare number '1', got %v", idleTimeout)
+	a := parseArgs([]string{"--idle-timeout", "1"})
+	if a.IdleTimeout != 1*time.Minute {
+		t.Errorf("expected idleTimeout=1m for bare number '1', got %v", a.IdleTimeout)
 	}
 }
 


### PR DESCRIPTION
Closes #124

Replaces the 31-value named-return tuple from parseArgs with a named Args struct. No behavior changes — purely structural refactor improving safety, readability, and extensibility.