### PR TITLE
docs: fix documentation drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,19 +11,22 @@ Transparent proxy wrapper for Claude Code that auto-refreshes Databricks OAuth t
 |------|-------------|
 | `main.go` | CLI entry point: flag parsing, config resolution from `~/.claude/settings.json` and persistent config, token seeding, AI Gateway discovery, proxy startup, settings patching, child launch, and settings restore on exit |
 | `proxy.go` | Thin facade over `pkg/proxy`: defines `ProxyConfig`, wires up `NewProxyServer` and `StartProxy` |
-| `token.go` | Facade over `pkg/tokencache`: implements `databricksFetcher` (shells out to `databricks auth token`), host discovery via `databricks auth env`, workspace ID resolution via SCIM, and AI Gateway URL construction |
-| `process.go` | `SettingsManager` (wraps `pkg/settings`): full-setup and save/restore of `~/.claude/settings.json` env keys, OTEL key management, `ClearOTELKeys`, `RunChild`, `ForwardSignals` |
-| `lock.go` | Type alias forwarding `pkg/filelock.FileLock` to package main |
-| `registry.go` | Type alias forwarding `pkg/registry.SessionRegistry` to package main |
-| `desktop_config.go` | `desktop` subcommand handlers: credential-helper alias, `generate-config` (writes `.mobileconfig`, `.reg`, and `.json` artifacts for Claude Desktop), atomic file writes, output safety guard, per-OS install instructions |
+| `token.go` | Facade over `pkg/tokencache`: implements `databricksFetcher` (shells out to `databricks auth token`), host discovery via `databricks auth env`, and AI Gateway URL construction (`{host}/ai-gateway/anthropic`) |
+| `process.go` | Wraps `pkg/childproc`: `RunChild`, `ForwardSignals` |
+| `state.go` | `persistentState` struct and helpers for `~/.claude/.databricks-claude.json` (profile, port, CLI path, OTEL table names) |
+| `hooks.go` | Session hook install/uninstall: `installHooks`, `uninstallHooks` |
+| `ensureconfig.go` | Bootstrap helpers for first-run settings patching |
+| `completion_flags.go` | `flagDefs` slice shared by shell completion and flag parsing |
+| `databrickscfg.go` | Reads `~/.databrickscfg` section headers for profile completion |
+| `desktop_config.go` | `desktop` subcommand: `generate-config` writing `.mobileconfig`, `.reg`, and `.json` artifacts for Claude Desktop; credential-helper alias dispatch |
+| `desktop_trust.go` | `generate-trust-profile` subcommand for MDM trust profile generation |
 | `desktop_config_test.go` | Tests for `buildMobileconfig`, `buildRegFile`, `buildDevModeJSON`, `writeDesktopConfigByPath`, `guardDevJSONOutputPath`, `writeFileAtomic`, install-instruction routing, and model-list consistency across all three artifacts |
 | `main_test.go` | Tests for `parseArgs`, `handlePrintEnv`, persistent config, `deriveLogsTable`, full integration scenarios |
-| `process_test.go` | Tests for `SettingsManager` save/restore, atomic writes, OTEL handling, signal forwarding, exit code propagation |
+| `process_test.go` | Tests for `RunChild`, signal forwarding, exit code propagation |
 | `proxy_test.go` | Tests for inference and OTEL proxy routing, token injection, panic recovery |
 | `token_test.go` | Tests using helper binaries compiled at test time to mock the `databricks` CLI |
-| `lock_test.go` | Tests for `FileLock` acquire/release and contention |
-| `registry_test.go` | Tests for session registry register/unregister/prune |
-| `concurrent_test.go` | Concurrent session lifecycle and handoff tests |
+| `state_test.go` | Tests for persistent state load/save |
+| `hooks_test.go` | Tests for hook install/uninstall |
 | `Makefile` | Build, install, test, cross-compile, lint targets |
 | `go.mod` | Module declaration (`github.com/IceRhymers/databricks-claude`, Go 1.22, zero deps) |
 | `CLAUDE.md` | Project-level AI agent instructions |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,14 +22,19 @@ go test ./pkg/proxy/... -v       # test a single package
 
 ### Root package (`main`)
 
-Six `.go` files act as thin facades wiring together `pkg/` sub-packages:
+The root package is a set of `.go` files that act as thin facades wiring together `pkg/` sub-packages:
 
-- **main.go** — CLI entry point: flag parsing, config resolution (`~/.claude/settings.json` + `~/.claude/.databricks-claude.json`), token seeding, AI Gateway auto-discovery, proxy startup, settings patching, child launch, headless lifecycle management (`wrapWithLifecycle` for `/shutdown` endpoint and idle timeout), and explicit settings restore before `os.Exit`.
+- **main.go** — CLI entry point: flag parsing, config resolution (`~/.claude/settings.json` + `~/.claude/.databricks-claude.json`), token seeding, AI Gateway auto-discovery, proxy startup, settings patching, child launch, headless lifecycle management, and explicit settings restore before `os.Exit`.
 - **proxy.go** — Facade over `pkg/proxy`: defines `ProxyConfig`, wires `NewProxyServer` and `StartProxy`.
-- **token.go** — Facade over `pkg/tokencache`: implements `databricksFetcher` (shells out to `databricks auth token`), host discovery, workspace ID resolution via SCIM, AI Gateway URL construction.
-- **process.go** — `SettingsManager` wrapping `pkg/settings`: full-setup and save/restore of settings.json env keys, OTEL key management, `RunChild`, `ForwardSignals`.
-- **lock.go** — Type alias forwarding `pkg/filelock.FileLock`.
-- **registry.go** — Type alias forwarding `pkg/registry.SessionRegistry`.
+- **token.go** — Facade over `pkg/tokencache`: implements `databricksFetcher` (shells out to `databricks auth token`), host discovery via `databricks auth env`, AI Gateway URL construction (`{host}/ai-gateway/anthropic`).
+- **process.go** — Wraps `pkg/childproc`: `RunChild`, `ForwardSignals`.
+- **state.go** — `persistentState` struct: JSON schema for `~/.claude/.databricks-claude.json` (profile, port, CLI path, OTEL table names).
+- **hooks.go** — Session hook install/uninstall (`installHooks`, `uninstallHooks`).
+- **ensureconfig.go** — Bootstrap helpers for first-run settings setup.
+- **completion_flags.go** — `flagDefs` slice driving shell completion and flag parsing.
+- **databrickscfg.go** — Reads `~/.databrickscfg` section headers for profile name resolution.
+- **desktop_config.go** — `desktop` subcommand: `generate-config` writing `.mobileconfig`, `.reg`, and `.json` artifacts for Claude Desktop.
+- **desktop_trust.go** — `generate-trust-profile` subcommand for MDM trust profile generation.
 
 ### Library packages (`pkg/`)
 
@@ -39,25 +44,30 @@ Each package is independently importable with no cross-dependencies:
 |---------|---------|
 | `pkg/authcheck` | Pre-flight Databricks auth check + interactive browser login fallback |
 | `pkg/childproc` | Child process start, SIGINT/SIGTERM forwarding, exit code propagation |
-| `pkg/filelock` | Exclusive file locking via `syscall.Flock` (graceful degradation) |
+| `pkg/completion` | Shell completion script generation (bash, zsh, fish) from `FlagDef` slices |
+| `pkg/headless` | Headless mode helpers: `Ensure` (start-if-absent) and `Release` (refcount decrement) |
+| `pkg/health` | `/health` endpoint handler returning JSON with tool name, version, and PID |
+| `pkg/lifecycle` | HTTP handler wrapper adding `/shutdown` refcount endpoint and idle timeout |
+| `pkg/portbind` | Port binding helpers: bind to a configured port with fallback |
 | `pkg/proxy` | HTTP/WebSocket reverse proxy, OTEL routing, API key auth, TLS, panic recovery, log sanitization |
-| `pkg/registry` | JSON-file session registry for multi-process coordination and handoff |
-| `pkg/settings` | Settings.json read/write/restore engine with session-aware handoff |
+| `pkg/refcount` | Atomic session reference counter with conditional-exit support |
+| `pkg/state` | JSON-file state persistence helpers (atomic temp-file + rename) |
 | `pkg/tokencache` | Mutex-guarded token cache with 5-min refresh buffer and fallback-on-error |
+| `pkg/updater` | GitHub release checker with 24-hour cache and numeric semver comparison |
 
 ### Key data flow
 
-1. `main.go` seeds token cache → starts proxy on `127.0.0.1:0` → patches `settings.json` to point `ANTHROPIC_BASE_URL` at proxy → launches `claude` as child (or enters headless mode)
-2. In headless mode, the handler is wrapped with `wrapWithLifecycle` which adds `POST /shutdown` (refcount decrement + conditional exit) and idle timeout (default 30m, resets on each proxied request)
-3. Proxy intercepts every request, injects fresh OAuth token via `pkg/tokencache` → forwards to AI Gateway (inference) or Databricks OTEL endpoint
-4. On exit, `SettingsManager.Restore()` is called **explicitly before `os.Exit`** (not via defer — `os.Exit` skips defers). Smart handoff points `ANTHROPIC_BASE_URL` to a surviving session if one exists.
+1. `main.go` seeds token cache → binds proxy on the configured port (default `49153`) → patches `settings.json` to point `ANTHROPIC_BASE_URL` at proxy → launches `claude` as child (or enters headless mode)
+2. In headless mode, the handler is wrapped with `pkg/lifecycle` which adds `POST /shutdown` (refcount decrement + conditional exit) and idle timeout (default 30m, resets on each proxied request)
+3. Proxy intercepts every request, injects fresh OAuth token via `pkg/tokencache` → forwards to AI Gateway (`{host}/ai-gateway/anthropic`) or Databricks OTEL endpoint
+4. On exit, settings are restored **explicitly before `os.Exit`** (not via defer — `os.Exit` skips defers). `ANTHROPIC_BASE_URL` is handed off to a surviving session if one exists.
 
 ## Key Design Constraints
 
 - **Zero external dependencies** — do not add third-party imports. Pure Go stdlib only.
 - **No breaking changes to settings.json** — a botched restore leaves the user's Claude config pointing at a dead proxy. Any change to key names, restore logic, or the save/restore lifecycle requires extreme care.
 - **Atomic file writes everywhere** — all JSON writes (settings, registry, persistent config) use temp-file + `os.Rename` in the same directory.
-- **Session handoff** — when multiple `databricks-claude` instances run concurrently, the exiting one hands `ANTHROPIC_BASE_URL` to the most recent survivor via `pkg/registry`.
+- **Session handoff** — when multiple `databricks-claude` instances run concurrently, the exiting one hands `ANTHROPIC_BASE_URL` to the most recent survivor.
 - **OTEL key persistence** — when `--otel` is active, OTEL keys survive settings restore (controlled by `otelKeysPersistent` flag).
 
 ## Testing Patterns

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ databricks-claude --headless
 
 `databricks-claude` wraps the `claude` binary. It:
 
-1. Binds a local HTTP proxy on `127.0.0.1:49153` (fixed port — shared across concurrent sessions)
+1. Binds a local HTTP proxy on a configured port (default `49153`, stored in `~/.claude/.databricks-claude.json`)
 2. Writes `~/.claude/settings.json` once to point `ANTHROPIC_BASE_URL` at the proxy (idempotent — no restore on exit)
 3. Launches `claude` with your args — fully transparent
 4. Injects fresh Databricks OAuth tokens on every request (auto-refreshed from `databricks auth token`)
@@ -346,10 +346,7 @@ Unity Catalog table schemas (Delta Lake DDL) for all three OTel signals are in [
 On first run (when `ANTHROPIC_BASE_URL` is not set), `databricks-claude` auto-discovers:
 
 - Your workspace host from `databricks auth env`
-- Your workspace ID via the SCIM API (`x-databricks-org-id` header)
-- Constructs the AI Gateway URL: `https://<workspace-id>.ai-gateway.cloud.databricks.com/anthropic`
-
-If workspace ID resolution fails, it falls back to `<host>/serving-endpoints/anthropic`.
+- Constructs the AI Gateway URL: `<host>/ai-gateway/anthropic`
 
 ### Profile Resolution Order
 
@@ -392,9 +389,8 @@ Example output:
 databricks-claude configuration:
   Profile:              DEFAULT
   DATABRICKS_HOST:      https://adb-1234567890123456.7.azuredatabricks.net
-  ANTHROPIC_BASE_URL:   https://1234567890123456.ai-gateway.cloud.databricks.com/anthropic
+  ANTHROPIC_BASE_URL:   https://adb-1234567890123456.7.azuredatabricks.net/ai-gateway/anthropic
   ANTHROPIC_AUTH_TOKEN: dapi-***
-  ANTHROPIC_MODEL: databricks-claude-opus-4-7
   Upstream binary:      /usr/local/bin/claude
   OTEL enabled:         false
 ```

--- a/pkg/AGENTS.md
+++ b/pkg/AGENTS.md
@@ -12,11 +12,16 @@ Reusable library packages extracted from the root `main` package. Each sub-packa
 |-----------|---------|
 | `authcheck/` | Pre-flight Databricks authentication verification and interactive login (see `authcheck/AGENTS.md`) |
 | `childproc/` | Child process lifecycle: start, signal forwarding, exit code propagation (see `childproc/AGENTS.md`) |
-| `filelock/` | File-based exclusive locking via `syscall.Flock` (see `filelock/AGENTS.md`) |
+| `completion/` | Shell completion script generation (bash, zsh, fish) from `FlagDef` slices |
+| `headless/` | Headless mode helpers: `Ensure` (start-if-absent) and `Release` (refcount decrement) |
+| `health/` | `/health` endpoint handler returning JSON liveness data |
+| `lifecycle/` | HTTP handler wrapper adding `/shutdown` and idle timeout |
+| `portbind/` | Port binding helpers with configured-port support |
 | `proxy/` | HTTP/WebSocket reverse proxy, security checks, log sanitization (see `proxy/AGENTS.md`) |
-| `registry/` | JSON-file-backed session registry for multi-process coordination (see `registry/AGENTS.md`) |
-| `settings/` | Generic settings.json read/write/restore engine with session-aware handoff (see `settings/AGENTS.md`) |
+| `refcount/` | Atomic session reference counter |
+| `state/` | JSON-file state persistence helpers (atomic writes) |
 | `tokencache/` | Generic mutex-guarded token cache with configurable fetcher (see `tokencache/AGENTS.md`) |
+| `updater/` | GitHub release checker with 24-hour cache and numeric semver comparison |
 
 ## For AI Agents
 
@@ -27,7 +32,7 @@ Reusable library packages extracted from the root `main` package. Each sub-packa
 
 ### Testing Requirements
 - Each package has co-located `*_test.go` files. Run `go test ./pkg/...` to test all packages.
-- `proxy/` has the most extensive tests; `settings/` has no separate test file (tested via `process_test.go` in root).
+- `proxy/` has the most extensive tests.
 
 ### Common Patterns
 - Packages that do I/O use **atomic temp-file + rename** for safe writes.


### PR DESCRIPTION
Closes #119

Audited README, CLAUDE.md, AGENTS.md, and pkg/AGENTS.md against current source:
- Updated CLI flags and gateway URL format (removed stale SCIM/workspace-ID path)
- Fixed architecture description: correct file lists, removed deleted packages (filelock, registry, settings), added current packages
- Fixed --print-env example output
- Removed stale lock_test.go/registry references from AGENTS.md