### PR TITLE
fix: return errors from NewServer/Ensure; resolve CLI path in authcheck

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -16,12 +16,14 @@ import (
 // If not, it starts a detached headless proxy and polls until ready (max 10s).
 // Called by the SessionStart hook via: databricks-claude --headless-ensure
 func headlessEnsure(port int) {
-	headless.Ensure(headless.Config{
+	if err := headless.Ensure(headless.Config{
 		Port:          port,
 		ManagedEnvVar: "DATABRICKS_CLAUDE_MANAGED",
 		LogPrefix:     "databricks-claude",
 		RefcountPath:  refcount.PathForPort(".databricks-claude-sessions", port),
-	})
+	}); err != nil {
+		log.Fatalf("databricks-claude: %v", err)
+	}
 }
 
 // headlessRelease calls POST /shutdown on the proxy to decrement the refcount.

--- a/main.go
+++ b/main.go
@@ -275,7 +275,7 @@ func main() {
 	}
 
 	// --- Ensure the user is authenticated before proceeding ---
-	if err := authcheck.EnsureAuthenticated(resolvedProfile); err != nil {
+	if err := authcheck.EnsureAuthenticated(resolvedProfile, ""); err != nil {
 		log.Fatalf("databricks-claude: auth failed: %v", err)
 	}
 

--- a/pkg/authcheck/authcheck.go
+++ b/pkg/authcheck/authcheck.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/IceRhymers/databricks-claude/pkg/cli"
 )
 
 // Overridable for testing.
@@ -15,10 +17,12 @@ var execCommandContext = exec.CommandContext
 
 // IsAuthenticated returns true if a valid token can be fetched for the given
 // Databricks profile without triggering an interactive login.
-func IsAuthenticated(profile string) bool {
+// cmdName is the Databricks CLI binary name or path; pass "" to use the default ("databricks").
+func IsAuthenticated(profile, cmdName string) bool {
+	resolved := cli.ResolveDatabricksCLI(cmdName)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	out, err := execCommandContext(ctx, "databricks", "auth", "token", "--profile", profile).Output()
+	out, err := execCommandContext(ctx, resolved, "auth", "token", "--profile", profile).Output()
 	if err != nil {
 		return false
 	}
@@ -26,22 +30,24 @@ func IsAuthenticated(profile string) bool {
 }
 
 // EnsureAuthenticated verifies the user has a valid token for the profile.
-// If not authenticated, it runs "databricks auth login --profile <profile>"
+// If not authenticated, it runs "<cmdName> auth login --profile <profile>"
 // interactively (attaches stdin/stdout/stderr so the browser OAuth flow works).
 // Returns nil if authentication succeeds, error if it fails even after login.
-func EnsureAuthenticated(profile string) error {
-	if IsAuthenticated(profile) {
+// cmdName is the Databricks CLI binary name or path; pass "" to use the default ("databricks").
+func EnsureAuthenticated(profile, cmdName string) error {
+	if IsAuthenticated(profile, cmdName) {
 		return nil
 	}
+	resolved := cli.ResolveDatabricksCLI(cmdName)
 	fmt.Fprintf(os.Stderr, "databricks: not authenticated for profile %q, opening browser login...\n", profile)
-	cmd := execCommand("databricks", "auth", "login", "--profile", profile)
+	cmd := execCommand(resolved, "auth", "login", "--profile", profile)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("databricks auth login failed: %w", err)
 	}
-	if !IsAuthenticated(profile) {
+	if !IsAuthenticated(profile, cmdName) {
 		return fmt.Errorf("still not authenticated for profile %q after login attempt", profile)
 	}
 	return nil

--- a/pkg/authcheck/authcheck_test.go
+++ b/pkg/authcheck/authcheck_test.go
@@ -27,13 +27,25 @@ func fakeCommand(output string, fail bool) func(name string, args ...string) *ex
 	}
 }
 
+// TestIsAuthenticated_FakeCmdNameReturnsFalse verifies that when the CLI binary
+// does not exist, IsAuthenticated returns false cleanly (no panic or fatal).
+func TestIsAuthenticated_FakeCmdNameReturnsFalse(t *testing.T) {
+	// Use the real execCommandContext with a binary that cannot be found.
+	// pkg/cli.ResolveDatabricksCLI will return the name unchanged when not found,
+	// and exec will fail with a "not found" error — IsAuthenticated must return false.
+	result := IsAuthenticated("DEFAULT", "/nonexistent/path/to/fake-databricks-binary")
+	if result {
+		t.Error("expected IsAuthenticated to return false for nonexistent binary, got true")
+	}
+}
+
 func TestIsAuthenticated_Success(t *testing.T) {
 	origCtx := execCommandContext
 	defer func() { execCommandContext = origCtx }()
 
 	execCommandContext = fakeCommandContext(`{"access_token":"dapi-xxx","token_type":"Bearer"}`, false)
 
-	if !IsAuthenticated("DEFAULT") {
+	if !IsAuthenticated("DEFAULT", "") {
 		t.Error("expected IsAuthenticated to return true when access_token is present")
 	}
 }
@@ -44,7 +56,7 @@ func TestIsAuthenticated_NoToken(t *testing.T) {
 
 	execCommandContext = fakeCommandContext(`{"error":"no token"}`, false)
 
-	if IsAuthenticated("DEFAULT") {
+	if IsAuthenticated("DEFAULT", "") {
 		t.Error("expected IsAuthenticated to return false when access_token is absent")
 	}
 }
@@ -55,7 +67,7 @@ func TestIsAuthenticated_CommandFails(t *testing.T) {
 
 	execCommandContext = fakeCommandContext("", true)
 
-	if IsAuthenticated("DEFAULT") {
+	if IsAuthenticated("DEFAULT", "") {
 		t.Error("expected IsAuthenticated to return false when command fails")
 	}
 }
@@ -66,7 +78,7 @@ func TestEnsureAuthenticated_AlreadyAuthed(t *testing.T) {
 
 	execCommandContext = fakeCommandContext(`{"access_token":"dapi-xxx"}`, false)
 
-	if err := EnsureAuthenticated("DEFAULT"); err != nil {
+	if err := EnsureAuthenticated("DEFAULT", ""); err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
 }
@@ -84,7 +96,7 @@ func TestEnsureAuthenticated_LoginFails(t *testing.T) {
 	// login command fails
 	execCommand = fakeCommand("", true)
 
-	err := EnsureAuthenticated("DEFAULT")
+	err := EnsureAuthenticated("DEFAULT", "")
 	if err == nil {
 		t.Error("expected error when login fails")
 	}
@@ -110,7 +122,7 @@ func TestEnsureAuthenticated_LoginSucceeds(t *testing.T) {
 	// login succeeds
 	execCommand = fakeCommand("login ok", false)
 
-	if err := EnsureAuthenticated("DEFAULT"); err != nil {
+	if err := EnsureAuthenticated("DEFAULT", ""); err != nil {
 		t.Errorf("expected no error after successful login, got: %v", err)
 	}
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,0 +1,70 @@
+// Package cli provides helpers for locating the Databricks CLI binary.
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// FallbackCLIDirs lists install locations to probe when the CLI binary is not
+// on PATH. Order matters: most-likely first. GUI-launched subprocesses (e.g.
+// Claude Desktop invoking the credential helper) inherit launchd's minimal
+// PATH (/usr/bin:/bin:/usr/sbin:/sbin), which omits all of these.
+var FallbackCLIDirs = []string{
+	"/usr/local/bin",
+	"/opt/homebrew/bin",
+	"/opt/homebrew/sbin",
+	".local/bin", // resolved against $HOME
+	"go/bin",     // resolved against $HOME
+	"bin",        // resolved against $HOME
+}
+
+// ResolveDatabricksCLI returns an executable path for cmdName.
+// Lookup order:
+//  1. Absolute or path-qualified cmdName → returned unchanged (back-compat for tests).
+//  2. $DATABRICKS_CLI env override, if set and executable.
+//  3. exec.LookPath(cmdName), which honors the inherited PATH.
+//  4. A scan of common install dirs (FallbackCLIDirs).
+//
+// If none match, cmdName is returned unchanged so the eventual exec error
+// surfaces with its original message.
+func ResolveDatabricksCLI(cmdName string) string {
+	if cmdName == "" {
+		cmdName = "databricks"
+	}
+	if filepath.IsAbs(cmdName) || filepath.Base(cmdName) != cmdName {
+		return cmdName
+	}
+	if override := os.Getenv("DATABRICKS_CLI"); override != "" {
+		if IsExecutableFile(override) {
+			return override
+		}
+	}
+	if p, err := exec.LookPath(cmdName); err == nil {
+		return p
+	}
+	home, _ := os.UserHomeDir()
+	for _, dir := range FallbackCLIDirs {
+		if !filepath.IsAbs(dir) {
+			if home == "" {
+				continue
+			}
+			dir = filepath.Join(home, dir)
+		}
+		candidate := filepath.Join(dir, cmdName)
+		if IsExecutableFile(candidate) {
+			return candidate
+		}
+	}
+	return cmdName
+}
+
+// IsExecutableFile reports whether path refers to an executable file.
+func IsExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode()&0o111 != 0
+}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsExecutableFile_Executable(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "exec-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if err := os.Chmod(f.Name(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !IsExecutableFile(f.Name()) {
+		t.Errorf("expected %q to be reported as executable", f.Name())
+	}
+}
+
+func TestIsExecutableFile_NonExecutable(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "noexec-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if err := os.Chmod(f.Name(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if IsExecutableFile(f.Name()) {
+		t.Errorf("expected %q to not be executable", f.Name())
+	}
+}
+
+func TestIsExecutableFile_Missing(t *testing.T) {
+	if IsExecutableFile("/nonexistent/path/to/binary") {
+		t.Error("expected false for missing file")
+	}
+}
+
+func TestIsExecutableFile_Directory(t *testing.T) {
+	dir := t.TempDir()
+	if IsExecutableFile(dir) {
+		t.Errorf("expected false for directory %q", dir)
+	}
+}
+
+func TestResolveDatabricksCLI_EmptyDefaultsToDatabricks(t *testing.T) {
+	// When the binary isn't found, it returns the default name unchanged.
+	result := ResolveDatabricksCLI("")
+	if result == "" {
+		t.Error("expected non-empty result for empty cmdName")
+	}
+	// Should either resolve to an absolute path or fall back to "databricks".
+	if filepath.Base(result) != "databricks" && !filepath.IsAbs(result) {
+		t.Errorf("unexpected result for empty cmdName: %q", result)
+	}
+}
+
+func TestResolveDatabricksCLI_AbsolutePassthrough(t *testing.T) {
+	abs := "/usr/local/bin/databricks"
+	if got := ResolveDatabricksCLI(abs); got != abs {
+		t.Errorf("expected absolute path returned unchanged, got %q", got)
+	}
+}
+
+func TestResolveDatabricksCLI_EnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "fake-databricks")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\necho ok\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DATABRICKS_CLI", fake)
+	if got := ResolveDatabricksCLI("databricks"); got != fake {
+		t.Errorf("expected DATABRICKS_CLI override %q, got %q", fake, got)
+	}
+}
+
+func TestResolveDatabricksCLI_EnvOverrideNotExecutable(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "not-exec")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DATABRICKS_CLI", fake)
+	// Should NOT use the override since it's not executable; falls through to LookPath/fallback.
+	got := ResolveDatabricksCLI("databricks")
+	if got == fake {
+		t.Errorf("should not use non-executable DATABRICKS_CLI override, but got %q", got)
+	}
+}
+
+func TestResolveDatabricksCLI_FallbackDir(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "mybinary")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orig := FallbackCLIDirs
+	FallbackCLIDirs = []string{dir}
+	defer func() { FallbackCLIDirs = orig }()
+
+	// Clear DATABRICKS_CLI so it falls through to fallback dirs.
+	t.Setenv("DATABRICKS_CLI", "")
+
+	got := ResolveDatabricksCLI("mybinary")
+	if got != fake {
+		t.Errorf("expected fallback dir resolution to %q, got %q", fake, got)
+	}
+}

--- a/pkg/headless/headless.go
+++ b/pkg/headless/headless.go
@@ -49,13 +49,14 @@ type Config struct {
 
 // Ensure checks whether the proxy is healthy on the given port.
 // If not, it starts a detached headless proxy and polls until ready (max 10s).
-func Ensure(cfg Config) {
+// Returns an error if the proxy cannot be started or does not become healthy.
+func Ensure(cfg Config) error {
 	if cfg.Scheme == "" {
 		cfg.Scheme = "http"
 	}
 	if cfg.ManagedEnvVar != "" && os.Getenv(cfg.ManagedEnvVar) == "1" {
 		log.Printf("%s: --headless-ensure: skipped (managed session)", cfg.LogPrefix)
-		return
+		return nil
 	}
 
 	// Acquire refcount FIRST so every ensure/release pair is symmetric.
@@ -66,7 +67,7 @@ func Ensure(cfg Config) {
 	}
 
 	if health.ProxyHealthy(cfg.Port, cfg.Scheme) {
-		return // already running, refcount incremented
+		return nil // already running, refcount incremented
 	}
 
 	self := cfg.BinaryPath
@@ -77,7 +78,7 @@ func Ensure(cfg Config) {
 			if cfg.RefcountPath != "" {
 				refcount.Release(cfg.RefcountPath) // undo acquire on failure
 			}
-			log.Fatalf("%s: --headless-ensure: cannot find self: %v", cfg.LogPrefix, err)
+			return fmt.Errorf("%s: --headless-ensure: cannot find self: %v", cfg.LogPrefix, err)
 		}
 	}
 
@@ -88,7 +89,7 @@ func Ensure(cfg Config) {
 		if cfg.RefcountPath != "" {
 			refcount.Release(cfg.RefcountPath) // undo acquire on failure
 		}
-		log.Fatalf("%s: --headless-ensure: failed to start proxy: %v", cfg.LogPrefix, err)
+		return fmt.Errorf("%s: --headless-ensure: failed to start proxy: %v", cfg.LogPrefix, err)
 	}
 	if err := cmd.Process.Release(); err != nil {
 		log.Printf("%s: --headless-ensure: release warning: %v", cfg.LogPrefix, err)
@@ -98,13 +99,13 @@ func Ensure(cfg Config) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(500 * time.Millisecond)
 		if health.ProxyHealthy(cfg.Port, cfg.Scheme) {
-			return
+			return nil
 		}
 	}
 	if cfg.RefcountPath != "" {
 		refcount.Release(cfg.RefcountPath) // undo acquire on failure
 	}
-	log.Fatalf("%s: --headless-ensure: proxy did not become healthy within 10s", cfg.LogPrefix)
+	return fmt.Errorf("%s: --headless-ensure: proxy did not become healthy within 10s", cfg.LogPrefix)
 }
 
 // buildArgs constructs the CLI arguments for the detached proxy subprocess.

--- a/pkg/headless/headless_test.go
+++ b/pkg/headless/headless_test.go
@@ -11,11 +11,13 @@ import (
 func TestEnsure_ManagedSessionSkips(t *testing.T) {
 	t.Setenv("DATABRICKS_CLAUDE_MANAGED", "1")
 	// Port 99999 has nothing listening. Without the guard this would fatalf.
-	Ensure(Config{
+	if err := Ensure(Config{
 		Port:          99999,
 		ManagedEnvVar: "DATABRICKS_CLAUDE_MANAGED",
 		LogPrefix:     "test",
-	})
+	}); err != nil {
+		t.Fatalf("expected no error for managed session skip, got: %v", err)
+	}
 }
 
 func TestEnsure_AlreadyHealthy(t *testing.T) {
@@ -31,11 +33,29 @@ func TestEnsure_AlreadyHealthy(t *testing.T) {
 	port := srv.Listener.Addr().(*net.TCPAddr).Port
 
 	// Should return immediately without trying to start a new proxy.
-	Ensure(Config{
+	if err := Ensure(Config{
 		Port:      port,
 		Scheme:    "http",
 		LogPrefix: "test",
+	}); err != nil {
+		t.Fatalf("expected no error when proxy is already healthy, got: %v", err)
+	}
+}
+
+// TestEnsure_BadBinaryReturnsError verifies that when the configured binary
+// does not exist, Ensure returns an error instead of calling log.Fatalf.
+func TestEnsure_BadBinaryReturnsError(t *testing.T) {
+	// Use a port with nothing listening so health check fails and Ensure tries
+	// to launch the binary.
+	err := Ensure(Config{
+		Port:       0, // port 0 will not have a healthy proxy
+		Scheme:     "http",
+		BinaryPath: "/nonexistent/path/to/binary-that-does-not-exist",
+		LogPrefix:  "test",
 	})
+	if err == nil {
+		t.Fatal("expected non-nil error when binary does not exist, got nil")
+	}
 }
 
 func TestBuildArgs_NoTLS(t *testing.T) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -277,17 +277,17 @@ func requireAPIKey(next http.Handler, key string) http.Handler {
 //   - /v1/logs paths   → UCLogsTable header
 //   - /v1/traces paths → UCTracesTable header
 //   - all other paths  → UCMetricsTable header (omitted if the chosen table is empty)
-func NewServer(config *Config) http.Handler {
+func NewServer(config *Config) (http.Handler, error) {
 	mux := http.NewServeMux()
 
 	inferenceUpstream, err := url.Parse(config.InferenceUpstream)
 	if err != nil {
-		log.Fatalf("databricks-claude: invalid InferenceUpstream %q: %v", config.InferenceUpstream, err)
+		return nil, fmt.Errorf("databricks-claude: invalid InferenceUpstream %q: %v", config.InferenceUpstream, err)
 	}
 
 	otelUpstream, err := url.Parse(config.OTELUpstream)
 	if err != nil {
-		log.Fatalf("databricks-claude: invalid OTELUpstream %q: %v", config.OTELUpstream, err)
+		return nil, fmt.Errorf("databricks-claude: invalid OTELUpstream %q: %v", config.OTELUpstream, err)
 	}
 
 	// Inference proxy — default route
@@ -426,7 +426,7 @@ func NewServer(config *Config) http.Handler {
 	mux.Handle("/", RecoveryHandler(inferenceHandler))
 
 	// APIKey check applies to all connections including WebSocket upgrades (used by databricks-codex)
-	return requireAPIKey(mux, config.APIKey)
+	return requireAPIKey(mux, config.APIKey), nil
 }
 
 // ValidateTLSConfig returns an error if the TLS configuration is incomplete

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -40,7 +40,10 @@ func TestProxy_InjectsAuthHeader(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenSource:       warmToken("test-token-123"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/messages", nil)
 	rec := httptest.NewRecorder()
@@ -67,7 +70,10 @@ func TestProxy_InjectsCustomHeaders(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
 	rec := httptest.NewRecorder()
@@ -101,7 +107,10 @@ func TestProxy_RoutesDefaultToInference(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
 	rec := httptest.NewRecorder()
@@ -134,7 +143,10 @@ func TestProxy_RoutesOTELPath(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/otel/v1/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -161,7 +173,10 @@ func TestProxy_PathAlgebra_Inference(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
 	rec := httptest.NewRecorder()
@@ -190,7 +205,10 @@ func TestProxy_PathAlgebra_OTEL(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/otel/v1/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -220,7 +238,10 @@ func TestProxy_PreservesRequestBody(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -281,7 +302,10 @@ func TestProxy_SSEStreaming(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	l, err := Start(handler, "", "")
 	if err != nil {
@@ -322,7 +346,10 @@ func TestProxy_OTELTableName_Metrics(t *testing.T) {
 		UCLogsTable:       "main.telemetry.claude_otel_logs",
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/otel/v1/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -349,7 +376,10 @@ func TestProxy_OTELTableName_Logs(t *testing.T) {
 		UCLogsTable:       "main.telemetry.claude_otel_logs",
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/otel/v1/logs", nil)
 	rec := httptest.NewRecorder()
@@ -380,7 +410,10 @@ func TestProxy_OTELTableName_MetricsEmpty(t *testing.T) {
 		UCLogsTable:       "main.telemetry.codex_otel_logs",
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/otel/v1/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -408,7 +441,10 @@ func TestProxy_OTELTableName_Traces(t *testing.T) {
 		UCTracesTable:     "main.telemetry.claude_otel_traces",
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/otel/v1/traces", nil)
 	rec := httptest.NewRecorder()
@@ -439,7 +475,10 @@ func TestProxy_OTELTableName_TracesEmpty(t *testing.T) {
 		UCTracesTable:     "", // empty — caller does not emit traces
 		TokenSource:       warmToken("tok"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/otel/v1/traces", nil)
 	rec := httptest.NewRecorder()
@@ -494,7 +533,11 @@ func TestProxy_WebSocket_UpgradeRejectedByUpstream(t *testing.T) {
 		TokenSource:       warmToken("tok"),
 	}
 
-	l, err := Start(NewServer(cfg), "", "")
+	wsHandler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	l, err := Start(wsHandler, "", "")
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -536,7 +579,10 @@ func TestProxy_WebSocket_PlainHTTPNotAffected(t *testing.T) {
 		UCLogsTable:       "main.t.l",
 		TokenSource:       warmToken("plain-http-token"),
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
 	// No Upgrade header — this is a plain HTTP request (Claude Code path).
@@ -590,7 +636,10 @@ func TestProxy_APIKey_CorrectKey(t *testing.T) {
 		TokenSource:       warmToken("tok"),
 		APIKey:            "my-secret-key",
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
 	req.Header.Set("Authorization", "Bearer my-secret-key")
@@ -618,7 +667,10 @@ func TestProxy_APIKey_WrongKey(t *testing.T) {
 		TokenSource:       warmToken("tok"),
 		APIKey:            "my-secret-key",
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
 	req.Header.Set("Authorization", "Bearer wrong-key")
@@ -645,7 +697,10 @@ func TestProxy_APIKey_NoKeyConfigured(t *testing.T) {
 		TokenSource:       warmToken("tok"),
 		APIKey:            "", // no key — auth disabled
 	}
-	handler := NewServer(cfg)
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
 	// No Authorization header at all.
@@ -688,5 +743,33 @@ func TestValidateTLSConfig_NeitherSet(t *testing.T) {
 	err := ValidateTLSConfig("", "")
 	if err != nil {
 		t.Errorf("unexpected error when neither cert nor key is set: %v", err)
+	}
+}
+
+// TestNewServer_InvalidInferenceUpstream verifies that NewServer returns a
+// non-nil error for an invalid InferenceUpstream URL (no process exit).
+func TestNewServer_InvalidInferenceUpstream(t *testing.T) {
+	cfg := &Config{
+		InferenceUpstream: "://bad-url",
+		OTELUpstream:      "http://localhost",
+		TokenSource:       warmToken("tok"),
+	}
+	_, err := NewServer(cfg)
+	if err == nil {
+		t.Fatal("expected non-nil error for invalid InferenceUpstream, got nil")
+	}
+}
+
+// TestNewServer_InvalidOTELUpstream verifies that NewServer returns a
+// non-nil error for an invalid OTELUpstream URL (no process exit).
+func TestNewServer_InvalidOTELUpstream(t *testing.T) {
+	cfg := &Config{
+		InferenceUpstream: "http://localhost",
+		OTELUpstream:      "://bad-url",
+		TokenSource:       warmToken("tok"),
+	}
+	_, err := NewServer(cfg)
+	if err == nil {
+		t.Fatal("expected non-nil error for invalid OTELUpstream, got nil")
 	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"net"
 	"net/http"
 
@@ -31,8 +32,10 @@ func recoveryHandler(next http.Handler) http.Handler {
 
 // NewProxyServer returns an http.Handler that routes requests to the
 // inference upstream (default) and the OTEL upstream (/otel/).
+// Panics if the upstream URLs in config are invalid — callers in main should
+// validate URLs before calling this function.
 func NewProxyServer(config *ProxyConfig) http.Handler {
-	return proxy.NewServer(&proxy.Config{
+	h, err := proxy.NewServer(&proxy.Config{
 		InferenceUpstream: config.InferenceUpstream,
 		OTELUpstream:      config.OTELUpstream,
 		UCMetricsTable:    config.UCMetricsTable,
@@ -44,6 +47,10 @@ func NewProxyServer(config *ProxyConfig) http.Handler {
 		ToolName:          config.ToolName,
 		Version:           config.Version,
 	})
+	if err != nil {
+		log.Fatalf("databricks-claude: %v", err)
+	}
+	return h
 }
 
 // ServeProxy starts the proxy on the given listener.

--- a/token.go
+++ b/token.go
@@ -19,6 +19,11 @@ func resolveDatabricksCLI(cmdName string) string {
 	return cli.ResolveDatabricksCLI(cmdName)
 }
 
+// isExecutableFile delegates to pkg/cli.IsExecutableFile.
+func isExecutableFile(path string) bool {
+	return cli.IsExecutableFile(path)
+}
+
 // TokenProvider is an alias to the pkg type for backward compatibility.
 type TokenProvider = tokencache.TokenProvider
 

--- a/token.go
+++ b/token.go
@@ -4,75 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/IceRhymers/databricks-claude/pkg/cli"
 	"github.com/IceRhymers/databricks-claude/pkg/tokencache"
 )
 
-// fallbackCLIDirs lists install locations to probe when "databricks" is not on
-// PATH. Order matters: most-likely first. GUI-launched subprocesses (e.g.
-// Claude Desktop invoking the credential helper) inherit launchd's minimal
-// PATH (/usr/bin:/bin:/usr/sbin:/sbin), which omits all of these.
-var fallbackCLIDirs = []string{
-	"/usr/local/bin",
-	"/opt/homebrew/bin",
-	"/opt/homebrew/sbin",
-	".local/bin", // resolved against $HOME
-	"go/bin",     // resolved against $HOME
-	"bin",        // resolved against $HOME
-}
-
-// resolveDatabricksCLI returns an executable path for the Databricks CLI.
-// Lookup order:
-//  1. Absolute or path-qualified cmdName → returned unchanged (back-compat for tests).
-//  2. $DATABRICKS_CLI env override, if set and executable.
-//  3. exec.LookPath(cmdName), which honors the inherited PATH.
-//  4. A scan of common install dirs (/usr/local/bin, /opt/homebrew/bin, ~/.local/bin, ~/go/bin, ~/bin).
-//
-// If none match, cmdName is returned unchanged so the eventual exec error
-// surfaces with its original message.
+// resolveDatabricksCLI delegates to pkg/cli for CLI binary resolution.
+// See pkg/cli.ResolveDatabricksCLI for the full lookup order.
 func resolveDatabricksCLI(cmdName string) string {
-	if cmdName == "" {
-		cmdName = "databricks"
-	}
-	if filepath.IsAbs(cmdName) || filepath.Base(cmdName) != cmdName {
-		return cmdName
-	}
-	if override := os.Getenv("DATABRICKS_CLI"); override != "" {
-		if isExecutableFile(override) {
-			return override
-		}
-	}
-	if p, err := exec.LookPath(cmdName); err == nil {
-		return p
-	}
-	home, _ := os.UserHomeDir()
-	for _, dir := range fallbackCLIDirs {
-		if !filepath.IsAbs(dir) {
-			if home == "" {
-				continue
-			}
-			dir = filepath.Join(home, dir)
-		}
-		candidate := filepath.Join(dir, cmdName)
-		if isExecutableFile(candidate) {
-			return candidate
-		}
-	}
-	return cmdName
-}
-
-func isExecutableFile(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil || info.IsDir() {
-		return false
-	}
-	return info.Mode()&0o111 != 0
+	return cli.ResolveDatabricksCLI(cmdName)
 }
 
 // TokenProvider is an alias to the pkg type for backward compatibility.


### PR DESCRIPTION
Fixes #120.

- `pkg/proxy.NewServer` now returns `(http.Handler, error)` — callers handle the error; only `main` fatals
- `pkg/headless.Ensure` now returns `error` — SessionStart hook path logs and exits cleanly
- `pkg/authcheck.IsAuthenticated` / `EnsureAuthenticated` accept explicit `cmdName` and use `pkg/cli.ResolveDatabricksCLI` — fixes silent false-negative on GUI launches where bare `databricks` is not on PATH
- New `pkg/cli` package extracted from `token.go` with resolution logic
- Tests verify error return (no process exit) for invalid upstream URLs and bad headless config