### PR TITLE
fix: add missing sanitize patterns; reject bare --idle-timeout integers

### DIFF
--- a/completion_flags.go
+++ b/completion_flags.go
@@ -33,7 +33,7 @@ var flagDefs = []completion.FlagDef{
 	{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
 	{Name: "port", Description: "Proxy listen port (default: 49153)", TakesArg: true},
 	{Name: "headless", Description: "Start proxy without launching claude (for IDE extensions or hooks)"},
-	{Name: "idle-timeout", Description: "Idle timeout for headless mode (default: 30m; 0 disables)", TakesArg: true},
+	{Name: "idle-timeout", Description: "Idle timeout for headless mode (default: 30m; 0 disables; use e.g. 30s, 5m, 1h)", TakesArg: true},
 	{Name: "install-hooks", Description: "Install SessionStart/Stop hooks into ~/.claude/settings.json"},
 	{Name: "uninstall-hooks", Description: "Remove databricks-claude hooks from ~/.claude/settings.json"},
 	{Name: "headless-ensure", Description: "Start proxy if not running — called by the SessionStart hook"},

--- a/main.go
+++ b/main.go
@@ -122,7 +122,11 @@ func main() {
 	// Usage: databricks-claude [databricks-claude-flags] [--] [claude-args...]
 	// Unknown flags are forwarded to claude automatically.
 	// Tip: use "databricks-claude -- completion" to pass "completion" to claude.
-	a := parseArgs(os.Args[1:])
+	a, err := parseArgs(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "databricks-claude:", err)
+		os.Exit(1)
+	}
 
 	if a.ShowHelp {
 		handleHelp(a.Upstream)
@@ -725,7 +729,7 @@ func envBlock(doc map[string]interface{}) map[string]interface{} {
 // --no-otel-traces, --proxy-api-key, --tls-cert, --tls-key.
 // Everything else (including unknown flags like --debug) passes through to claude.
 // An explicit "--" separator is supported but not required.
-func parseArgs(args []string) *Args {
+func parseArgs(args []string) (*Args, error) {
 	a := &Args{
 		OTELMetricsTable: "main.claude_telemetry.claude_otel_metrics", // default
 		IdleTimeout:      30 * time.Minute,                            // default
@@ -741,7 +745,7 @@ func parseArgs(args []string) *Args {
 		// Explicit separator: everything after "--" goes to claude.
 		if arg == "--" {
 			a.ClaudeArgs = append(a.ClaudeArgs, args[i+1:]...)
-			return a
+			return a, nil
 		}
 
 		// Special case: -h is a short flag for --help, -v for --verbose.
@@ -885,9 +889,8 @@ func parseArgs(args []string) *Args {
 					if raw != "" {
 						if d, err := time.ParseDuration(raw); err == nil {
 							a.IdleTimeout = d
-						} else if mins, err := strconv.Atoi(raw); err == nil {
-							// Bare number: treat as minutes for convenience.
-							a.IdleTimeout = time.Duration(mins) * time.Minute
+						} else {
+							return nil, fmt.Errorf("--idle-timeout: %q is not a valid duration (use e.g. 30s, 5m, 1h)", raw)
 						}
 					}
 				}
@@ -900,7 +903,7 @@ func parseArgs(args []string) *Args {
 		a.ClaudeArgs = append(a.ClaudeArgs, arg)
 		i++
 	}
-	return a
+	return a, nil
 }
 
 // handleHelp prints the databricks-claude help message and appends claude's own --help output.
@@ -936,7 +939,7 @@ Databricks-Claude Flags:
   --headless                   Start proxy without launching claude (for IDE extensions)
   --headless-ensure            Start proxy if not running (called by SessionStart hook)
   --headless-release           Decrement proxy refcount (called by Stop hook)
-  --idle-timeout duration      Idle timeout for headless mode (default 30m, 0 disables, bare number = minutes)
+  --idle-timeout duration      Idle timeout for headless mode (default 30m, 0 disables; use e.g. 30s, 5m, 1h)
   --install-hooks              Install SessionStart/SessionEnd hooks AND perform first-run
                                env setup (idempotent). Accepts --profile and --port to
                                persist them; no prior databricks-claude invocation needed.

--- a/main_test.go
+++ b/main_test.go
@@ -27,7 +27,7 @@ type shutdownResp struct {
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	a := parseArgs([]string{"--help"})
+	a, _ := parseArgs([]string{"--help"})
 	if !a.ShowHelp {
 		t.Error("expected showHelp=true for --help")
 	}
@@ -37,77 +37,77 @@ func TestParseArgs_HelpLong(t *testing.T) {
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	a := parseArgs([]string{"-h"})
+	a, _ := parseArgs([]string{"-h"})
 	if !a.ShowHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	a := parseArgs([]string{"--print-env"})
+	a, _ := parseArgs([]string{"--print-env"})
 	if !a.PrintEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	a := parseArgs([]string{"--version"})
+	a, _ := parseArgs([]string{"--version"})
 	if !a.Version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	a := parseArgs([]string{"--verbose"})
+	a, _ := parseArgs([]string{"--verbose"})
 	if !a.Verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	a := parseArgs([]string{"-v"})
+	a, _ := parseArgs([]string{"-v"})
 	if !a.Verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	a := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	a, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
 	if a.LogFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", a.LogFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	a := parseArgs([]string{"--log-file=/tmp/test.log"})
+	a, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
 	if a.LogFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", a.LogFile)
 	}
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	a := parseArgs([]string{"--profile", "foo"})
+	a, _ := parseArgs([]string{"--profile", "foo"})
 	if a.Profile != "foo" {
 		t.Errorf("expected profile=%q, got %q", "foo", a.Profile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	a := parseArgs([]string{"--upstream", "/path/to/claude"})
+	a, _ := parseArgs([]string{"--upstream", "/path/to/claude"})
 	if a.Upstream != "/path/to/claude" {
 		t.Errorf("expected upstream=%q, got %q", "/path/to/claude", a.Upstream)
 	}
 }
 
 func TestParseArgs_Otel(t *testing.T) {
-	a := parseArgs([]string{"--otel"})
+	a, _ := parseArgs([]string{"--otel"})
 	if !a.OTEL {
 		t.Error("expected otel=true for --otel")
 	}
 }
 
 func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
-	a := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
+	a, _ := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
 	if !a.OTELMetricsTableSet {
 		t.Error("expected metricsTableSet=true when --otel-metrics-table is passed")
 	}
@@ -117,7 +117,7 @@ func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
 }
 
 func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
-	a := parseArgs([]string{"--otel"})
+	a, _ := parseArgs([]string{"--otel"})
 	if a.OTELMetricsTableSet {
 		t.Error("expected metricsTableSet=false when --otel-metrics-table is not passed")
 	}
@@ -127,7 +127,7 @@ func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
-	a := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
+	a, _ := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
 	if !a.OTELMetricsTableSet {
 		t.Error("expected metricsTableSet=true for --otel-metrics-table=value")
 	}
@@ -137,7 +137,7 @@ func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
-	a := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
+	a, _ := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
 	if !a.OTELLogsTableSet {
 		t.Error("expected logsTableSet=true when --otel-logs-table is passed")
 	}
@@ -147,7 +147,7 @@ func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	a := parseArgs([]string{"--otel"})
+	a, _ := parseArgs([]string{"--otel"})
 	if a.OTELLogsTableSet {
 		t.Error("expected logsTableSet=false when --otel-logs-table is not passed")
 	}
@@ -157,7 +157,7 @@ func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
 }
 
 func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
-	a := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
+	a, _ := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
 	if !a.OTELLogsTableSet {
 		t.Error("expected logsTableSet=true for --otel-logs-table=value")
 	}
@@ -167,7 +167,7 @@ func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
 }
 
 func TestParseArgs_BothOtelTables(t *testing.T) {
-	a := parseArgs([]string{
+	a, _ := parseArgs([]string{
 		"--otel-metrics-table", "cat.schema.metrics",
 		"--otel-logs-table", "cat.schema.logs",
 	})
@@ -183,14 +183,14 @@ func TestParseArgs_BothOtelTables(t *testing.T) {
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	a := parseArgs([]string{"--unknown"})
+	a, _ := parseArgs([]string{"--unknown"})
 	if len(a.ClaudeArgs) != 1 || a.ClaudeArgs[0] != "--unknown" {
 		t.Errorf("expected claudeArgs=[\"--unknown\"], got %v", a.ClaudeArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	a := parseArgs([]string{})
+	a, _ := parseArgs([]string{})
 	if a.Profile != "" {
 		t.Errorf("expected empty profile, got %q", a.Profile)
 	}
@@ -213,7 +213,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	a := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
+	a, _ := parseArgs([]string{"--profile", "prod", "--verbose", "--help"})
 	if !a.ShowHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -226,21 +226,21 @@ func TestParseArgs_Mixed(t *testing.T) {
 }
 
 func TestParseArgs_Headless(t *testing.T) {
-	a := parseArgs([]string{"--headless"})
+	a, _ := parseArgs([]string{"--headless"})
 	if !a.Headless {
 		t.Error("expected headless=true for --headless")
 	}
 }
 
 func TestParseArgs_NoUpdateCheck(t *testing.T) {
-	a := parseArgs([]string{"--no-update-check"})
+	a, _ := parseArgs([]string{"--no-update-check"})
 	if !a.NoUpdateCheck {
 		t.Error("expected noUpdateCheck=true for --no-update-check")
 	}
 }
 
 func TestParseArgs_HeadlessWithOtherFlags(t *testing.T) {
-	a := parseArgs([]string{"--headless", "--verbose"})
+	a, _ := parseArgs([]string{"--headless", "--verbose"})
 	if !a.Headless {
 		t.Error("expected headless=true")
 	}
@@ -250,7 +250,7 @@ func TestParseArgs_HeadlessWithOtherFlags(t *testing.T) {
 }
 
 func TestParseArgs_NoOtel(t *testing.T) {
-	a := parseArgs([]string{"--no-otel"})
+	a, _ := parseArgs([]string{"--no-otel"})
 	if !a.NoOTEL {
 		t.Error("expected noOtel=true for --no-otel")
 	}
@@ -263,7 +263,7 @@ func TestParseArgs_NoOtel(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelAndOtel(t *testing.T) {
-	a := parseArgs([]string{"--no-otel", "--otel"})
+	a, _ := parseArgs([]string{"--no-otel", "--otel"})
 	if !a.NoOTEL {
 		t.Error("expected noOtel=true")
 	}
@@ -273,7 +273,7 @@ func TestParseArgs_NoOtelAndOtel(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
-	a := parseArgs([]string{"--no-otel", "somearg"})
+	a, _ := parseArgs([]string{"--no-otel", "somearg"})
 	if !a.NoOTEL {
 		t.Error("expected noOtel=true")
 	}
@@ -283,7 +283,7 @@ func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
 }
 
 func TestParseArgs_OtelUnaffectedByNoOtel(t *testing.T) {
-	a := parseArgs([]string{"--otel"})
+	a, _ := parseArgs([]string{"--otel"})
 	if !a.OTEL {
 		t.Error("expected otel=true for --otel")
 	}
@@ -295,7 +295,7 @@ func TestParseArgs_OtelUnaffectedByNoOtel(t *testing.T) {
 // --- per-signal no-otel-* flag tests ---
 
 func TestParseArgs_NoOtelMetrics(t *testing.T) {
-	a := parseArgs([]string{"--no-otel-metrics"})
+	a, _ := parseArgs([]string{"--no-otel-metrics"})
 	if !a.NoOTELMetrics {
 		t.Error("expected noOtelMetrics=true for --no-otel-metrics")
 	}
@@ -305,7 +305,7 @@ func TestParseArgs_NoOtelMetrics(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelLogs(t *testing.T) {
-	a := parseArgs([]string{"--no-otel-logs"})
+	a, _ := parseArgs([]string{"--no-otel-logs"})
 	if !a.NoOTELLogs {
 		t.Error("expected noOtelLogs=true for --no-otel-logs")
 	}
@@ -315,7 +315,7 @@ func TestParseArgs_NoOtelLogs(t *testing.T) {
 }
 
 func TestParseArgs_NoOtelTraces(t *testing.T) {
-	a := parseArgs([]string{"--no-otel-traces"})
+	a, _ := parseArgs([]string{"--no-otel-traces"})
 	if !a.NoOTELTraces {
 		t.Error("expected noOtelTraces=true for --no-otel-traces")
 	}
@@ -327,14 +327,14 @@ func TestParseArgs_NoOtelTraces(t *testing.T) {
 // --- --otel-traces flag tests ---
 
 func TestParseArgs_OtelTraces(t *testing.T) {
-	a := parseArgs([]string{"--otel-traces"})
+	a, _ := parseArgs([]string{"--otel-traces"})
 	if !a.OTELTraces {
 		t.Error("expected otelTraces=true for --otel-traces")
 	}
 }
 
 func TestParseArgs_OtelTracesTableOverride(t *testing.T) {
-	a := parseArgs([]string{"--otel-traces-table", "main.default.traces"})
+	a, _ := parseArgs([]string{"--otel-traces-table", "main.default.traces"})
 	if !a.OTELTracesTableSet {
 		t.Error("expected tracesTableSet=true when --otel-traces-table is passed")
 	}
@@ -344,7 +344,7 @@ func TestParseArgs_OtelTracesTableOverride(t *testing.T) {
 }
 
 func TestParseArgs_OtelTracesTableEquals(t *testing.T) {
-	a := parseArgs([]string{"--otel-traces-table=my.catalog.traces"})
+	a, _ := parseArgs([]string{"--otel-traces-table=my.catalog.traces"})
 	if !a.OTELTracesTableSet {
 		t.Error("expected tracesTableSet=true for --otel-traces-table=value")
 	}
@@ -356,7 +356,7 @@ func TestParseArgs_OtelTracesTableEquals(t *testing.T) {
 func TestParseArgs_OtelTracesTableDefault(t *testing.T) {
 	// --otel-traces alone (no table) should not auto-populate a default table —
 	// traces only activate when an explicit --otel-traces-table is provided.
-	a := parseArgs([]string{"--otel-traces"})
+	a, _ := parseArgs([]string{"--otel-traces"})
 	if !a.OTELTraces {
 		t.Error("expected otelTraces=true")
 	}
@@ -371,7 +371,7 @@ func TestParseArgs_OtelTracesTableDefault(t *testing.T) {
 // TestParseArgs_TracesStandalone verifies that --otel-traces-table works
 // without --otel — traces is a standalone signal.
 func TestParseArgs_TracesStandalone(t *testing.T) {
-	a := parseArgs([]string{"--otel-traces-table", "cat.schema.traces"})
+	a, _ := parseArgs([]string{"--otel-traces-table", "cat.schema.traces"})
 	if a.OTEL {
 		t.Error("expected otel=false when only --otel-traces-table given")
 	}
@@ -478,7 +478,10 @@ func TestParseArgs_Table(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			a := parseArgs(tc.args)
+			a, err := parseArgs(tc.args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
 			if a.Profile != tc.want.profile {
 				t.Errorf("profile: got %q, want %q", a.Profile, tc.want.profile)
@@ -908,37 +911,44 @@ func TestProfileResolution_StateFileWins(t *testing.T) {
 // --- idle-timeout flag tests ---
 
 func TestParseArgs_IdleTimeoutDefault(t *testing.T) {
-	a := parseArgs([]string{})
+	a, _ := parseArgs([]string{})
 	if a.IdleTimeout != 30*time.Minute {
 		t.Errorf("expected default idleTimeout=30m, got %v", a.IdleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutCustom(t *testing.T) {
-	a := parseArgs([]string{"--idle-timeout", "10m"})
+	a, _ := parseArgs([]string{"--idle-timeout", "10m"})
 	if a.IdleTimeout != 10*time.Minute {
 		t.Errorf("expected idleTimeout=10m, got %v", a.IdleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutZero(t *testing.T) {
-	a := parseArgs([]string{"--idle-timeout", "0"})
+	a, _ := parseArgs([]string{"--idle-timeout", "0"})
 	if a.IdleTimeout != 0 {
 		t.Errorf("expected idleTimeout=0, got %v", a.IdleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutEquals(t *testing.T) {
-	a := parseArgs([]string{"--idle-timeout=5m"})
+	a, _ := parseArgs([]string{"--idle-timeout=5m"})
 	if a.IdleTimeout != 5*time.Minute {
 		t.Errorf("expected idleTimeout=5m, got %v", a.IdleTimeout)
 	}
 }
 
 func TestParseArgs_IdleTimeoutBareNumber(t *testing.T) {
-	a := parseArgs([]string{"--idle-timeout", "1"})
-	if a.IdleTimeout != 1*time.Minute {
-		t.Errorf("expected idleTimeout=1m for bare number '1', got %v", a.IdleTimeout)
+	_, err := parseArgs([]string{"--idle-timeout", "30"})
+	if err == nil {
+		t.Error("expected error for bare integer --idle-timeout value, got nil")
+	}
+}
+
+func TestParseArgs_IdleTimeoutBareNumberEquals(t *testing.T) {
+	_, err := parseArgs([]string{"--idle-timeout=30"})
+	if err == nil {
+		t.Error("expected error for bare integer --idle-timeout=value, got nil")
 	}
 }
 

--- a/pkg/proxy/sanitize.go
+++ b/pkg/proxy/sanitize.go
@@ -3,10 +3,13 @@ package proxy
 import "regexp"
 
 var sensitivePatterns = []*regexp.Regexp{
-	regexp.MustCompile(`Bearer [^\s"]+`),
+	regexp.MustCompile(`(?i)Bearer [^\s"]+`),
 	regexp.MustCompile(`dapi[a-zA-Z0-9-]+`),
 	regexp.MustCompile(`(?i)x-api-key:\s*[^\s"]+`),
 	regexp.MustCompile(`(?i)x-databricks-authorization:\s*\S+`),
+	regexp.MustCompile(`(?i)Authorization:\s*Basic\s+[A-Za-z0-9+/=]+`),
+	regexp.MustCompile(`"access_token"\s*:\s*"[^"]+"`),
+	regexp.MustCompile(`DATABRICKS_TOKEN=[^\s&"]+`),
 }
 
 // sanitizeLogOutput redacts sensitive values (Bearer tokens, PATs, API keys)

--- a/pkg/proxy/sanitize_test.go
+++ b/pkg/proxy/sanitize_test.go
@@ -63,6 +63,31 @@ func TestSanitizeLogOutput(t *testing.T) {
 			input: `x-databricks-authorization: some-pat-token`,
 			want:  `[REDACTED]`,
 		},
+		{
+			name:  "bearer token lowercase",
+			input: `bearer abc123`,
+			want:  `[REDACTED]`,
+		},
+		{
+			name:  "bearer token uppercase",
+			input: `BEARER abc123`,
+			want:  `[REDACTED]`,
+		},
+		{
+			name:  "basic auth header",
+			input: `Authorization: Basic dXNlcjpwYXNz`,
+			want:  `[REDACTED]`,
+		},
+		{
+			name:  "access_token JSON field",
+			input: `{"access_token": "eyJhbGci..."}`,
+			want:  `{[REDACTED]}`,
+		},
+		{
+			name:  "DATABRICKS_TOKEN env var",
+			input: `DATABRICKS_TOKEN=dapi1234abcd`,
+			want:  `[REDACTED]`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes remaining items from #127 (sanitize part covered by #129).

- `sanitize.go`: Bearer match is now case-insensitive; adds Basic auth, `access_token` JSON field, and `DATABRICKS_TOKEN` env-var patterns
- `--idle-timeout`: bare integers (e.g. `--idle-timeout 30`) now return a clear error instead of silently treating as minutes; duration strings (`30s`, `5m`) still work
- Tests cover all new patterns and the rejection of bare integers