### PR TITLE
fix: remove stale proxy entries from settings.json on startup

### DIFF
--- a/ensureconfig.go
+++ b/ensureconfig.go
@@ -4,8 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // bootstrapSettings persists profile + port to the state file and writes the
@@ -71,6 +77,9 @@ func ensureConfig(proxyURL string, otelEnv map[string]string) error {
 
 	// Get or create the env block.
 	env := getOrCreateEnvBlock(doc)
+
+	// Remove stale 127.0.0.1:<port> entries from dead prior instances.
+	pruneStaleProxyEntries(env, portFromURL(proxyURL))
 
 	// Check if already configured — no-op if ANTHROPIC_BASE_URL matches and
 	// there are no pending OTEL keys to write.
@@ -162,6 +171,80 @@ func getOrCreateEnvBlock(doc map[string]interface{}) map[string]interface{} {
 	env := map[string]interface{}{}
 	doc["env"] = env
 	return env
+}
+
+// portFromURL parses rawURL and returns the port as an int. Returns 0 on any
+// error (missing port, non-numeric port, invalid URL).
+func portFromURL(rawURL string) int {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return 0
+	}
+	_, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		return 0
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0
+	}
+	return port
+}
+
+// pruneStaleProxyEntries removes any 127.0.0.1:<port> proxy entries from env
+// that belong to a prior instance that is no longer listening. skipPort is the
+// port we are about to write — it is always treated as live (idempotent case).
+func pruneStaleProxyEntries(env map[string]interface{}, skipPort int) {
+	// Probe ANTHROPIC_BASE_URL.
+	if baseURL, ok := env["ANTHROPIC_BASE_URL"].(string); ok {
+		u, err := url.Parse(baseURL)
+		if err == nil && u.Hostname() == "127.0.0.1" {
+			_, portStr, splitErr := net.SplitHostPort(u.Host)
+			if splitErr == nil {
+				port, convErr := strconv.Atoi(portStr)
+				if convErr == nil && port != skipPort {
+					conn, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+					if dialErr != nil {
+						log.Printf("databricks-claude: removed stale proxy entry for port %d (prior instance not responding)", port)
+						delete(env, "ANTHROPIC_BASE_URL")
+						delete(env, "ANTHROPIC_AUTH_TOKEN")
+					} else {
+						conn.Close()
+					}
+				}
+			}
+		}
+	}
+
+	// Probe any OTEL endpoint keys containing _ENDPOINT with a 127.0.0.1 value.
+	for k, v := range env {
+		if !strings.Contains(k, "_ENDPOINT") {
+			continue
+		}
+		val, ok := v.(string)
+		if !ok {
+			continue
+		}
+		u, err := url.Parse(val)
+		if err != nil || u.Hostname() != "127.0.0.1" {
+			continue
+		}
+		_, portStr, splitErr := net.SplitHostPort(u.Host)
+		if splitErr != nil {
+			continue
+		}
+		port, convErr := strconv.Atoi(portStr)
+		if convErr != nil || port == skipPort {
+			continue
+		}
+		conn, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+		if dialErr != nil {
+			log.Printf("databricks-claude: removed stale proxy entry for port %d (prior instance not responding)", port)
+			delete(env, k)
+		} else {
+			conn.Close()
+		}
+	}
 }
 
 // clearOTELKeys removes all OTEL-related env keys from ~/.claude/settings.json.

--- a/ensureconfig_test.go
+++ b/ensureconfig_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"sync"
@@ -312,6 +314,159 @@ func TestWritePersistentConfig_ConcurrentWrites(t *testing.T) {
 	for _, e := range entries {
 		if e.Name() != ".databricks-claude.json" {
 			t.Errorf("unexpected leftover file in dir: %s", e.Name())
+		}
+	}
+}
+
+// TestPruneStaleProxyEntries_DeadPort verifies that a stale ANTHROPIC_BASE_URL
+// pointing at a port that is no longer listening is removed by ensureConfig.
+func TestPruneStaleProxyEntries_DeadPort(t *testing.T) {
+	home := withTempHome(t)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+
+	// Bind then immediately close a listener to obtain a dead port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	deadPort := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	// Write settings.json with the stale URL.
+	initial := map[string]interface{}{
+		"env": map[string]interface{}{
+			"ANTHROPIC_BASE_URL":   fmt.Sprintf("http://127.0.0.1:%d", deadPort),
+			"ANTHROPIC_AUTH_TOKEN": "proxy-managed",
+		},
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(settingsPath, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("write initial settings.json: %v", err)
+	}
+
+	newURL := "http://127.0.0.1:49200"
+	if err := ensureConfig(newURL, nil); err != nil {
+		t.Fatalf("ensureConfig: %v", err)
+	}
+
+	doc, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	env, ok := doc["env"].(map[string]interface{})
+	if !ok {
+		t.Fatal("env block missing")
+	}
+	if got, _ := env["ANTHROPIC_BASE_URL"].(string); got != newURL {
+		t.Errorf("ANTHROPIC_BASE_URL: got %q, want %q", got, newURL)
+	}
+}
+
+// TestPruneStaleProxyEntries_LivePort verifies that an ANTHROPIC_BASE_URL
+// pointing at a still-listening port is preserved (idempotent case).
+func TestPruneStaleProxyEntries_LivePort(t *testing.T) {
+	home := withTempHome(t)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+
+	// Bind a listener and keep it open.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer ln.Close()
+	livePort := ln.Addr().(*net.TCPAddr).Port
+	liveURL := fmt.Sprintf("http://127.0.0.1:%d", livePort)
+
+	// Write settings.json with the live URL.
+	initial := map[string]interface{}{
+		"env": map[string]interface{}{
+			"ANTHROPIC_BASE_URL":   liveURL,
+			"ANTHROPIC_AUTH_TOKEN": "proxy-managed",
+		},
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(settingsPath, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("write initial settings.json: %v", err)
+	}
+
+	// Call ensureConfig with the same URL — should be idempotent.
+	if err := ensureConfig(liveURL, nil); err != nil {
+		t.Fatalf("ensureConfig: %v", err)
+	}
+
+	doc, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	env, ok := doc["env"].(map[string]interface{})
+	if !ok {
+		t.Fatal("env block missing")
+	}
+	if got, _ := env["ANTHROPIC_BASE_URL"].(string); got != liveURL {
+		t.Errorf("ANTHROPIC_BASE_URL: got %q, want %q (live entry should be preserved)", got, liveURL)
+	}
+}
+
+// TestPruneStaleProxyEntries_OTELEndpoint verifies that a stale OTEL
+// *_ENDPOINT key pointing at a dead port is removed, while non-endpoint sibling
+// keys are left intact.
+func TestPruneStaleProxyEntries_OTELEndpoint(t *testing.T) {
+	home := withTempHome(t)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+
+	// Bind then immediately close a listener to obtain a dead port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	deadPort := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	// Write settings.json with a dead OTEL endpoint plus non-endpoint siblings.
+	initial := map[string]interface{}{
+		"env": map[string]interface{}{
+			"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": fmt.Sprintf("http://127.0.0.1:%d", deadPort),
+			"CLAUDE_OTEL_UC_METRICS_TABLE":         "catalog.schema.metrics",
+			"OTEL_METRICS_EXPORTER":                "otlp",
+			"OTEL_METRIC_EXPORT_INTERVAL":          "60000",
+		},
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(settingsPath, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("write initial settings.json: %v", err)
+	}
+
+	if err := ensureConfig("http://127.0.0.1:49200", nil); err != nil {
+		t.Fatalf("ensureConfig: %v", err)
+	}
+
+	doc, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	env, ok := doc["env"].(map[string]interface{})
+	if !ok {
+		t.Fatal("env block missing")
+	}
+
+	// Dead endpoint key must be gone.
+	if _, exists := env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"]; exists {
+		t.Error("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT should have been removed (dead port)")
+	}
+
+	// Non-endpoint sibling keys must still be present.
+	for _, k := range []string{"CLAUDE_OTEL_UC_METRICS_TABLE", "OTEL_METRICS_EXPORTER", "OTEL_METRIC_EXPORT_INTERVAL"} {
+		if _, exists := env[k]; !exists {
+			t.Errorf("key %q should still be present but was removed", k)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #123.

On startup, before writing the new proxy URL, `ensureConfig` now calls `pruneStaleProxyEntries` which:
- Parses any existing `http://127.0.0.1:<port>` entry from `ANTHROPIC_BASE_URL` and OTEL endpoint keys
- Probes each port with a 200ms TCP dial
- Removes dead entries and logs a warning (`databricks-claude: removed stale proxy entry for port N (prior instance not responding)`)
- Skips the probe when the port matches the port we are about to write (idempotent case)

The existing "stale localhost" suppression in `main.go` (lines ~255-273) is left in place — it guards the discovery path; this PR guards the `settings.json` write path.

Tests cover: dead port pruned, live port preserved, OTEL endpoint pruning with sibling key preservation.