### PR TITLE
feat: --with-websearch — local fulfillment of web_search/web_fetch (workaround)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ databricks-claude --with-websearch --profile <name>
 
 How it works:
 
-- The proxy detects `web_search_*` and `web_fetch_*` entries in outgoing `/v1/messages` requests and rewrites them to standard client-tool definitions named `web_search` and `web_fetch`.
-- When the model emits a `tool_use` block targeting one of those names, Claude Code's own tool loop sees an unknown tool and returns an error `tool_result` on the next turn. The proxy intercepts that `tool_result` and substitutes its own locally-fulfilled output before forwarding upstream.
+- The proxy detects `web_search_*` and `web_fetch_*` entries in outgoing `/v1/messages` requests and rewrites them to standard client-tool definitions named `web_search` and `web_fetch`. This is required because the AI Gateway rejects unknown server-tool types.
+- On the response side, the proxy parses the SSE stream from the AI Gateway. When the model emits a `tool_use` block for the rewritten `web_search`/`web_fetch` tool, the proxy: (a) rewrites the on-the-wire block type to `server_tool_use`, (b) accumulates the streaming `input_json_delta` fragments to assemble the tool's input, (c) executes the local backend (`Search` or `Fetch`), and (d) injects a synthetic `web_search_tool_result` content block per Anthropic's documented shape so Claude Code's helper sees results inline.
+- For non-streaming (`stream=false`) responses, the proxy applies the same transformation to the JSON body before forwarding.
+- A legacy fallback path also handles generic Anthropic API clients that do a client-tool loop: if the client returns an `is_error` `tool_result` for the rewritten tool, the proxy substitutes locally-fulfilled output on the next turn.
 - All fulfillment is **headless** — pure stdlib HTTP, no browser process. JavaScript-rendered pages are not supported.
 - `robots.txt` is enforced per host with a session cache.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,42 @@ There are three ways to use `databricks-claude`. Most people want **session hook
 
 The two automated modes are independent — neither requires the other — and the binary supports either or both.
 
+## Web Search & Fetch (Workaround, opt-in)
+
+> ⚠️ **This is a workaround, not a permanent feature.** Databricks AI Gateway's Anthropic compatibility layer doesn't yet support Anthropic's native `web_search` and `web_fetch` server-side tools. Until that ships, this proxy can locally fulfill those tool calls so Claude Code's research workflows work against Databricks-served models.
+>
+> When Databricks ships native server-side tool support, this flag will print a deprecation warning for one minor release before being removed.
+
+Enable with:
+
+```bash
+databricks-claude --with-websearch --profile <name>
+```
+
+How it works:
+
+- The proxy detects `web_search_*` and `web_fetch_*` entries in outgoing `/v1/messages` requests and rewrites them to standard client-tool definitions named `web_search` and `web_fetch`.
+- When the model emits a `tool_use` block targeting one of those names, Claude Code's own tool loop sees an unknown tool and returns an error `tool_result` on the next turn. The proxy intercepts that `tool_result` and substitutes its own locally-fulfilled output before forwarding upstream.
+- All fulfillment is **headless** — pure stdlib HTTP, no browser process. JavaScript-rendered pages are not supported.
+- `robots.txt` is enforced per host with a session cache.
+
+Flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--with-websearch` | `false` | Enable the workaround. Persists to `~/.claude/.databricks-claude.json`. |
+| `--websearch-backend` | `duckduckgo` | Search backend. Values: `duckduckgo` (zero config, HTML scrape), `none` (disable search but keep fetch). |
+| `--websearch-fetch-budget` | `102400` (100KB) | Max bytes returned per `web_fetch` call. Larger pages are truncated. |
+
+Limitations:
+
+- No JavaScript rendering — fetched pages are static HTML only.
+- `robots.txt` blocks return an error `tool_result`; the model is told why.
+- Per-fetch byte cap defaults to 100KB to protect the context window.
+- Search backends `brave` and `searxng` are deferred to follow-up work; only `duckduckgo` and `none` are wired today.
+
+When `--with-websearch=false` (the default), the proxy forwards request bytes unchanged — there is no behavior change for users who don't opt in.
+
 ## Session Hooks (recommended)
 
 Install hooks so every Claude Code session auto-starts the proxy on startup and releases it cleanly on exit — no manual `--headless` needed. The hooks keep the proxy running for all Claude clients — including ones that don't use the `databricks-claude` wrapper directly, such as the [Claude VS Code extension](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude-code) and JetBrains/IntelliJ plugin.

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -39,6 +39,9 @@ var flagDefs = []completion.FlagDef{
 	{Name: "headless-ensure", Description: "Start proxy if not running — called by the SessionStart hook"},
 	{Name: "headless-release", Description: "Decrement proxy refcount — called by the Stop hook"},
 	{Name: "no-update-check", Description: "Skip the automatic update check on startup"},
+	{Name: "with-websearch", Description: "Locally fulfill Anthropic web_search/web_fetch tools (workaround for FMAPI gap)"},
+	{Name: "websearch-backend", Description: "Web search backend (duckduckgo|none)", TakesArg: true},
+	{Name: "websearch-fetch-budget", Description: "Per-fetch byte budget for --with-websearch (default 102400)", TakesArg: true},
 }
 
 // knownFlags is the set of flag names (with "--" prefix) that databricks-claude

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/IceRhymers/databricks-claude/pkg/proxy"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
 	"github.com/IceRhymers/databricks-claude/pkg/updater"
+	"github.com/IceRhymers/databricks-claude/pkg/websearch"
 )
 
 // Version is set at build time via -ldflags.
@@ -63,6 +64,12 @@ type Args struct {
 	HeadlessEnsure      bool
 	HeadlessRelease     bool
 	NoUpdateCheck       bool
+	WithWebSearch          bool
+	WithWebSearchSet       bool
+	WebSearchBackend       string
+	WebSearchBackendSet    bool
+	WebSearchFetchBudget   int
+	WebSearchFetchBudgetSet bool
 	ClaudeArgs          []string
 }
 
@@ -497,6 +504,68 @@ func main() {
 		log.Fatalf("databricks-claude: %v", err)
 	}
 
+	// --- Resolve --with-websearch (workaround) settings ---
+	// Resolution chain: flag (if set) > saved state > default. Persist any
+	// flag value back to state so users only opt in once. Mirrors the
+	// OTEL-table persistence pattern.
+	wsState := loadState()
+	withWebSearch := wsState.WithWebSearch
+	wsBackend := wsState.WebSearchBackend
+	wsBudget := wsState.WebSearchFetchBudget
+	if a.WithWebSearchSet {
+		withWebSearch = a.WithWebSearch
+	}
+	if a.WebSearchBackendSet {
+		wsBackend = a.WebSearchBackend
+	}
+	if a.WebSearchFetchBudgetSet {
+		wsBudget = a.WebSearchFetchBudget
+	}
+	if wsBackend == "" {
+		wsBackend = "duckduckgo"
+	}
+	if wsBudget <= 0 {
+		wsBudget = 100 * 1024
+	}
+	{
+		mutated := false
+		if a.WithWebSearchSet && wsState.WithWebSearch != withWebSearch {
+			wsState.WithWebSearch = withWebSearch
+			mutated = true
+		}
+		if a.WebSearchBackendSet && wsState.WebSearchBackend != wsBackend {
+			wsState.WebSearchBackend = wsBackend
+			mutated = true
+		}
+		if a.WebSearchFetchBudgetSet && wsState.WebSearchFetchBudget != wsBudget {
+			wsState.WebSearchFetchBudget = wsBudget
+			mutated = true
+		}
+		if mutated {
+			if err := saveState(wsState); err != nil {
+				log.Printf("databricks-claude: warning: could not persist websearch state: %v", err)
+			}
+		}
+	}
+
+	// Build the websearch backend (if enabled) and print the workaround warning.
+	var wsBackendImpl websearch.Backend
+	var wsRobots websearch.RobotsChecker
+	if withWebSearch {
+		fmt.Fprintln(os.Stderr, "databricks-claude: --with-websearch is a workaround. Anthropic's native")
+		fmt.Fprintln(os.Stderr, "  web_search and web_fetch tools are not yet supported by Databricks FMAPI.")
+		fmt.Fprintf(os.Stderr, "  This proxy fulfills them locally via backend=%q (per-fetch budget=%d bytes).\n", wsBackend, wsBudget)
+		fmt.Fprintln(os.Stderr, "  Limitations: no JavaScript rendering; robots.txt enforced; headless only.")
+		fmt.Fprintln(os.Stderr, "  This flag will be removed (with one release of deprecation warning) when")
+		fmt.Fprintln(os.Stderr, "  Databricks ships native server-side tool support.")
+		b, err := buildWebSearchBackend(wsBackend)
+		if err != nil {
+			log.Fatalf("databricks-claude: %v", err)
+		}
+		wsBackendImpl = b
+		wsRobots = &websearch.Robots{}
+	}
+
 	// --- Bind proxy port ---
 	ln, isOwner, err := portbind.Bind("databricks-claude", port)
 	if err != nil {
@@ -524,6 +593,12 @@ func main() {
 		TLSKeyFile:        a.TLSKey,
 		ToolName:          "databricks-claude",
 		Version:           Version,
+		WebSearch: proxy.WebSearchSettings{
+			Enabled:     withWebSearch,
+			Backend:     wsBackendImpl,
+			Robots:      wsRobots,
+			FetchBudget: wsBudget,
+		},
 	}
 	if a.ProxyAPIKey != "" {
 		fmt.Fprintln(os.Stderr, "databricks-claude: proxy API key authentication enabled")
@@ -879,6 +954,36 @@ func parseArgs(args []string) (*Args, error) {
 					a.HeadlessRelease = true
 				case "--no-update-check":
 					a.NoUpdateCheck = true
+				case "--with-websearch":
+					a.WithWebSearch = true
+					a.WithWebSearchSet = true
+					// Allow optional explicit value: --with-websearch=true|false
+					if value != "" {
+						a.WithWebSearch = (value == "1" || strings.EqualFold(value, "true") || strings.EqualFold(value, "yes"))
+					}
+				case "--websearch-backend":
+					if value != "" {
+						a.WebSearchBackend = value
+						a.WebSearchBackendSet = true
+					} else if i+1 < len(args) {
+						i++
+						a.WebSearchBackend = args[i]
+						a.WebSearchBackendSet = true
+					}
+				case "--websearch-fetch-budget":
+					raw := value
+					if raw == "" && i+1 < len(args) {
+						i++
+						raw = args[i]
+					}
+					if raw != "" {
+						if n, err := strconv.Atoi(raw); err == nil {
+							a.WebSearchFetchBudget = n
+							a.WebSearchFetchBudgetSet = true
+						} else {
+							return nil, fmt.Errorf("--websearch-fetch-budget: %q is not an integer", raw)
+						}
+					}
 				case "--idle-timeout":
 					raw := value
 					if raw == "" && i+1 < len(args) {

--- a/main.go
+++ b/main.go
@@ -1049,6 +1049,12 @@ Databricks-Claude Flags:
                                persist them; no prior databricks-claude invocation needed.
   --uninstall-hooks            Remove databricks-claude hooks from ~/.claude/settings.json
   --no-update-check            Skip the automatic update check on startup
+  --with-websearch             Enable local fulfillment of Anthropic web_search/web_fetch
+                               tools (workaround until Databricks FMAPI ships native
+                               support; saved to state). Default: disabled.
+  --websearch-backend string   Search backend when --with-websearch is enabled.
+                               Values: duckduckgo (default, zero config), none
+  --websearch-fetch-budget int Max bytes returned per web_fetch call (default 102400)
   --version                    Print version and exit
   --help, -h                   Show this help message
 

--- a/main_test.go
+++ b/main_test.go
@@ -189,6 +189,85 @@ func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
 	}
 }
 
+func TestParseArgs_WithWebSearch(t *testing.T) {
+	a, err := parseArgs([]string{"--with-websearch"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !a.WithWebSearch {
+		t.Errorf("expected WithWebSearch=true")
+	}
+	if !a.WithWebSearchSet {
+		t.Errorf("expected WithWebSearchSet=true when --with-websearch is passed")
+	}
+}
+
+func TestParseArgs_WithWebSearchDefault(t *testing.T) {
+	a, _ := parseArgs([]string{})
+	if a.WithWebSearch {
+		t.Errorf("expected WithWebSearch=false by default")
+	}
+	if a.WithWebSearchSet {
+		t.Errorf("expected WithWebSearchSet=false when --with-websearch is not passed")
+	}
+}
+
+func TestParseArgs_WebSearchBackend(t *testing.T) {
+	a, err := parseArgs([]string{"--websearch-backend", "duckduckgo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.WebSearchBackend != "duckduckgo" {
+		t.Errorf("expected WebSearchBackend=duckduckgo, got %q", a.WebSearchBackend)
+	}
+	if !a.WebSearchBackendSet {
+		t.Errorf("expected WebSearchBackendSet=true")
+	}
+}
+
+func TestParseArgs_WebSearchBackendEquals(t *testing.T) {
+	a, _ := parseArgs([]string{"--websearch-backend=none"})
+	if a.WebSearchBackend != "none" {
+		t.Errorf("expected WebSearchBackend=none, got %q", a.WebSearchBackend)
+	}
+	if !a.WebSearchBackendSet {
+		t.Errorf("expected WebSearchBackendSet=true")
+	}
+}
+
+func TestParseArgs_WebSearchFetchBudget(t *testing.T) {
+	a, err := parseArgs([]string{"--websearch-fetch-budget", "204800"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.WebSearchFetchBudget != 204800 {
+		t.Errorf("expected WebSearchFetchBudget=204800, got %d", a.WebSearchFetchBudget)
+	}
+	if !a.WebSearchFetchBudgetSet {
+		t.Errorf("expected WebSearchFetchBudgetSet=true")
+	}
+}
+
+func TestParseArgs_WebSearchFetchBudgetEquals(t *testing.T) {
+	a, _ := parseArgs([]string{"--websearch-fetch-budget=51200"})
+	if a.WebSearchFetchBudget != 51200 {
+		t.Errorf("expected WebSearchFetchBudget=51200, got %d", a.WebSearchFetchBudget)
+	}
+}
+
+func TestParseArgs_AllWebSearchFlagsTogether(t *testing.T) {
+	a, _ := parseArgs([]string{"--with-websearch", "--websearch-backend", "duckduckgo", "--websearch-fetch-budget", "65536"})
+	if !a.WithWebSearch {
+		t.Errorf("expected WithWebSearch=true")
+	}
+	if a.WebSearchBackend != "duckduckgo" {
+		t.Errorf("expected WebSearchBackend=duckduckgo, got %q", a.WebSearchBackend)
+	}
+	if a.WebSearchFetchBudget != 65536 {
+		t.Errorf("expected WebSearchFetchBudget=65536, got %d", a.WebSearchFetchBudget)
+	}
+}
+
 func TestParseArgs_EmptyArgs(t *testing.T) {
 	a, _ := parseArgs([]string{})
 	if a.Profile != "" {

--- a/pkg/proxy/anthropic/AGENTS.md
+++ b/pkg/proxy/anthropic/AGENTS.md
@@ -1,0 +1,44 @@
+<!-- Parent: ../AGENTS.md -->
+
+# anthropic
+
+## Purpose
+
+Minimal pass-through types for Anthropic's Messages API request body, plus the helpers used by `pkg/proxy/websearch_handler.go` to detect and rewrite Anthropic's server-side `web_search` and `web_fetch` tool entries.
+
+This package is intentionally thin: we decode just enough to mutate `tools[]` and `messages[]`, and pass everything else through `json.RawMessage` / `Extras map[string]json.RawMessage` so unknown fields round-trip byte-equivalently. We are NOT building a full Anthropic API client.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `types.go` | `Request` struct with custom `UnmarshalJSON`/`MarshalJSON` for Extras-preserving roundtrip; helpers `IsWebSearchTool`, `IsWebFetchTool`, `IsAnnotatedTool`, `RewriteWebSearchTool`, `RewriteWebFetchTool` |
+| `types_test.go` | Roundtrip-preservation tests, tool-detection tests, rewrite-output snapshot tests |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **Roundtrip preservation is load-bearing.** When `--with-websearch=false`, the proxy must forward a request whose bytes (modulo Authorization header) are identical to what `httputil.ReverseProxy` would have sent. The `Request.MarshalJSON` / `UnmarshalJSON` Extras pattern guarantees this. If you add a typed field, you MUST also remove it from the Extras map on Marshal — failing to do so will double-emit the field and break `httputil.ReverseProxy` parity.
+- **Annotation prefix is `[databricks-claude:websearch]`** — included in the `description` field of rewritten client tools. This is how `IsAnnotatedTool` distinguishes our injected tools from user-supplied tools that happen to share the names `web_search` / `web_fetch`. Do NOT match on name alone.
+- The detection helpers match on `type` PREFIX (`web_search_` and `web_fetch_`) so future Anthropic versions like `web_search_20251201` continue to be detected without code changes.
+- We deliberately do not validate `model`, `max_tokens`, etc. — we only touch what we have to. Anthropic adds fields constantly; the Extras map is our forward-compat shield.
+
+### Testing Requirements
+
+- Run: `go test ./pkg/proxy/anthropic/...`
+- Roundtrip tests use canonicalized JSON comparison (decode → re-encode → semantic compare) to avoid false negatives on key ordering.
+
+### Out of scope
+
+- Response-body parsing. The proxy streams responses verbatim; only requests are mutated.
+- Validation of message/content-block shapes beyond what's needed to find tool_use / tool_result blocks.
+- General-purpose Anthropic SDK functionality. If you find yourself adding a fully-typed `Message` struct, stop and reconsider — `json.RawMessage` is doing the right job here.
+
+## Dependencies
+
+### Internal
+- None
+
+### External
+- None (pure Go stdlib: `encoding/json`, `bytes`, `strings`)

--- a/pkg/proxy/anthropic/types.go
+++ b/pkg/proxy/anthropic/types.go
@@ -172,3 +172,178 @@ func ToolDescription(toolJSON []byte) string {
 	_ = json.Unmarshal(toolJSON, &probe)
 	return probe.Description
 }
+
+// Response is the minimal-but-roundtrip-safe shape of an Anthropic
+// /v1/messages response body for the non-streaming path. Mirrors Request:
+// any unknown top-level fields end up in Extras and re-emit verbatim.
+type Response struct {
+	ID         string            `json:"-"`
+	Type       string            `json:"-"`
+	Role       string            `json:"-"`
+	Model      string            `json:"-"`
+	Content    []json.RawMessage `json:"-"`
+	StopReason string            `json:"-"`
+	Extras     map[string]json.RawMessage
+}
+
+// UnmarshalJSON implements custom decoding that preserves unknown fields.
+func (r *Response) UnmarshalJSON(data []byte) error {
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	r.Extras = map[string]json.RawMessage{}
+	for k, v := range raw {
+		switch k {
+		case "id":
+			_ = json.Unmarshal(v, &r.ID)
+		case "type":
+			_ = json.Unmarshal(v, &r.Type)
+		case "role":
+			_ = json.Unmarshal(v, &r.Role)
+		case "model":
+			_ = json.Unmarshal(v, &r.Model)
+		case "content":
+			_ = json.Unmarshal(v, &r.Content)
+		case "stop_reason":
+			_ = json.Unmarshal(v, &r.StopReason)
+		default:
+			r.Extras[k] = v
+		}
+	}
+	return nil
+}
+
+// MarshalJSON re-emits canonical fields plus Extras.
+func (r *Response) MarshalJSON() ([]byte, error) {
+	out := map[string]json.RawMessage{}
+	for k, v := range r.Extras {
+		out[k] = v
+	}
+	if r.ID != "" {
+		b, _ := json.Marshal(r.ID)
+		out["id"] = b
+	}
+	if r.Type != "" {
+		b, _ := json.Marshal(r.Type)
+		out["type"] = b
+	}
+	if r.Role != "" {
+		b, _ := json.Marshal(r.Role)
+		out["role"] = b
+	}
+	if r.Model != "" {
+		b, _ := json.Marshal(r.Model)
+		out["model"] = b
+	}
+	if r.Content != nil {
+		b, err := json.Marshal(r.Content)
+		if err != nil {
+			return nil, err
+		}
+		out["content"] = b
+	}
+	if r.StopReason != "" {
+		b, _ := json.Marshal(r.StopReason)
+		out["stop_reason"] = b
+	}
+	return json.Marshal(out)
+}
+
+// WebSearchResult mirrors a single entry inside a web_search_tool_result
+// content block's content array. Shape verified from
+// https://platform.claude.com/docs/en/docs/agents-and-tools/tool-use/web-search-tool
+// (2026-05-07): {type: "web_search_result", url, title, encrypted_content,
+// page_age}. EncryptedContent is required for multi-turn citations but can
+// be empty for one-shot consumers like Claude Code's WebSearch helper.
+type WebSearchResult struct {
+	URL              string `json:"url"`
+	Title            string `json:"title"`
+	EncryptedContent string `json:"encrypted_content"`
+	PageAge          string `json:"page_age,omitempty"`
+}
+
+// BuildWebSearchSuccessBlock returns a JSON-encoded web_search_tool_result
+// success block. The provided results are wrapped in {type:"web_search_result"}
+// envelopes per the Anthropic spec.
+func BuildWebSearchSuccessBlock(toolUseID string, results []WebSearchResult) ([]byte, error) {
+	wrapped := make([]map[string]string, 0, len(results))
+	for _, r := range results {
+		entry := map[string]string{
+			"type":              "web_search_result",
+			"url":               r.URL,
+			"title":             r.Title,
+			"encrypted_content": r.EncryptedContent,
+		}
+		if r.PageAge != "" {
+			entry["page_age"] = r.PageAge
+		}
+		wrapped = append(wrapped, entry)
+	}
+	out := map[string]any{
+		"type":        "web_search_tool_result",
+		"tool_use_id": toolUseID,
+		"content":     wrapped,
+	}
+	return json.Marshal(out)
+}
+
+// BuildWebSearchErrorBlock returns a JSON-encoded web_search_tool_result
+// error block. errorCode must be one of: too_many_requests, invalid_input,
+// max_uses_exceeded, query_too_long, unavailable.
+func BuildWebSearchErrorBlock(toolUseID, errorCode string) ([]byte, error) {
+	out := map[string]any{
+		"type":        "web_search_tool_result",
+		"tool_use_id": toolUseID,
+		"content": map[string]string{
+			"type":       "web_search_tool_result_error",
+			"error_code": errorCode,
+		},
+	}
+	return json.Marshal(out)
+}
+
+// BuildWebFetchSuccessBlock folds a fetched URL+text pair into the
+// web_search_tool_result envelope. Anthropic's spec does not yet define a
+// dedicated web_fetch_tool_result type; we reuse the search result envelope
+// with a single entry. The `text` is appended to the title since the spec
+// has no dedicated text/snippet field.
+func BuildWebFetchSuccessBlock(toolUseID, fetchURL, text string, truncated bool) ([]byte, error) {
+	title := fetchURL
+	if text != "" {
+		// Truncate text fold in title to a reasonable size. Claude Code's
+		// renderer trims long titles but the field accepts arbitrary length.
+		const maxFold = 4000
+		if len(text) > maxFold {
+			text = text[:maxFold] + "…"
+		}
+		if truncated {
+			text += " [truncated]"
+		}
+		title = fetchURL + " — " + text
+	}
+	results := []WebSearchResult{{URL: fetchURL, Title: title}}
+	return BuildWebSearchSuccessBlock(toolUseID, results)
+}
+
+// ParseWebSearchInput extracts {query} from a tool_use input JSON blob.
+func ParseWebSearchInput(jsonBytes []byte) (string, error) {
+	var in struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal(jsonBytes, &in); err != nil {
+		return "", err
+	}
+	return in.Query, nil
+}
+
+// ParseWebFetchInput extracts {url} from a tool_use input JSON blob.
+func ParseWebFetchInput(jsonBytes []byte) (string, error) {
+	var in struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(jsonBytes, &in); err != nil {
+		return "", err
+	}
+	return in.URL, nil
+}

--- a/pkg/proxy/anthropic/types.go
+++ b/pkg/proxy/anthropic/types.go
@@ -1,0 +1,174 @@
+// Package anthropic models just enough of Anthropic's Messages API to
+// safely rewrite tools[] and intercept tool_result blocks for the
+// --with-websearch workaround. Unknown fields pass through unmolested.
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// AnnotationPrefix tags the Description of a tool we injected on the request
+// path, so we recognise it on the response/next-request path.
+const AnnotationPrefix = "[databricks-claude:websearch] "
+
+// ClientToolName_WebSearch is the canonical client-tool name we rewrite
+// web_search_* server tools to.
+const ClientToolName_WebSearch = "web_search"
+
+// ClientToolName_WebFetch is the canonical client-tool name for web_fetch_*.
+const ClientToolName_WebFetch = "web_fetch"
+
+// Request is the minimal-but-roundtrip-safe shape of an Anthropic
+// /v1/messages request body. All fields not explicitly named end up in
+// Extras and are re-serialised verbatim, preserving forward-compatibility
+// with future Anthropic API additions.
+type Request struct {
+	Model    string            `json:"-"`
+	Messages []json.RawMessage `json:"-"`
+	Tools    []json.RawMessage `json:"-"`
+	System   json.RawMessage   `json:"-"`
+	Extras   map[string]json.RawMessage
+}
+
+// UnmarshalJSON implements custom JSON decoding that captures unknown fields
+// in Extras so MarshalJSON can re-emit them.
+func (r *Request) UnmarshalJSON(data []byte) error {
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	r.Extras = map[string]json.RawMessage{}
+	for k, v := range raw {
+		switch k {
+		case "model":
+			_ = json.Unmarshal(v, &r.Model)
+		case "messages":
+			_ = json.Unmarshal(v, &r.Messages)
+		case "tools":
+			_ = json.Unmarshal(v, &r.Tools)
+		case "system":
+			r.System = v
+		default:
+			r.Extras[k] = v
+		}
+	}
+	return nil
+}
+
+// MarshalJSON re-emits the canonical fields plus any preserved Extras.
+func (r *Request) MarshalJSON() ([]byte, error) {
+	out := map[string]json.RawMessage{}
+	for k, v := range r.Extras {
+		out[k] = v
+	}
+	if r.Model != "" {
+		b, err := json.Marshal(r.Model)
+		if err != nil {
+			return nil, err
+		}
+		out["model"] = b
+	}
+	if r.Messages != nil {
+		b, err := json.Marshal(r.Messages)
+		if err != nil {
+			return nil, err
+		}
+		out["messages"] = b
+	}
+	if r.Tools != nil {
+		b, err := json.Marshal(r.Tools)
+		if err != nil {
+			return nil, err
+		}
+		out["tools"] = b
+	}
+	if len(r.System) > 0 {
+		out["system"] = r.System
+	}
+	return json.Marshal(out)
+}
+
+// IsWebSearchTool returns true if the given tool JSON object's "type" field
+// has the prefix "web_search_".
+func IsWebSearchTool(toolJSON []byte) bool { return hasTypePrefix(toolJSON, "web_search_") }
+
+// IsWebFetchTool returns true if the type field has the prefix "web_fetch_".
+func IsWebFetchTool(toolJSON []byte) bool { return hasTypePrefix(toolJSON, "web_fetch_") }
+
+func hasTypePrefix(toolJSON []byte, prefix string) bool {
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(toolJSON, &probe); err != nil {
+		return false
+	}
+	return strings.HasPrefix(probe.Type, prefix)
+}
+
+// IsAnnotatedTool returns true if a tool's description starts with our
+// annotation prefix, indicating we (the proxy) injected it.
+func IsAnnotatedTool(description string) bool {
+	return strings.HasPrefix(description, AnnotationPrefix)
+}
+
+// RewriteWebSearchTool returns the canonical client-tool replacement for any
+// web_search_* server tool.
+func RewriteWebSearchTool() []byte {
+	const tmpl = `{
+  "name": "web_search",
+  "description": "[databricks-claude:websearch] Search the web. Returns a JSON list of {title, url, snippet} results. Use sparingly; prefer specific queries.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "query": {"type": "string", "description": "search query"}
+    },
+    "required": ["query"]
+  }
+}`
+	return compactJSON([]byte(tmpl))
+}
+
+// RewriteWebFetchTool returns the canonical client-tool replacement for any
+// web_fetch_* server tool.
+func RewriteWebFetchTool() []byte {
+	const tmpl = `{
+  "name": "web_fetch",
+  "description": "[databricks-claude:websearch] Fetch a URL and return its readable text content. Honours robots.txt; capped at a configurable byte budget.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "url": {"type": "string", "description": "absolute http(s) URL to fetch"}
+    },
+    "required": ["url"]
+  }
+}`
+	return compactJSON([]byte(tmpl))
+}
+
+func compactJSON(b []byte) []byte {
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, b); err != nil {
+		return b
+	}
+	return buf.Bytes()
+}
+
+// ToolName extracts the "name" field from a tool JSON object.
+func ToolName(toolJSON []byte) string {
+	var probe struct {
+		Name string `json:"name"`
+	}
+	_ = json.Unmarshal(toolJSON, &probe)
+	return probe.Name
+}
+
+// ToolDescription extracts the "description" field from a tool JSON object.
+func ToolDescription(toolJSON []byte) string {
+	var probe struct {
+		Description string `json:"description"`
+	}
+	_ = json.Unmarshal(toolJSON, &probe)
+	return probe.Description
+}

--- a/pkg/proxy/anthropic/types_test.go
+++ b/pkg/proxy/anthropic/types_test.go
@@ -1,0 +1,90 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRequest_RoundtripPreservesUnknownFields(t *testing.T) {
+	in := []byte(`{
+  "model": "claude-opus-4-7",
+  "messages": [{"role":"user","content":"hi"}],
+  "max_tokens": 1024,
+  "temperature": 0.5,
+  "metadata": {"user_id": "u123"},
+  "stream": true
+}`)
+	var r Request
+	if err := json.Unmarshal(in, &r); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if r.Model != "claude-opus-4-7" {
+		t.Errorf("Model=%q", r.Model)
+	}
+	if len(r.Messages) != 1 {
+		t.Errorf("Messages len=%d", len(r.Messages))
+	}
+	out, err := json.Marshal(&r)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// Canonicalise both for comparison.
+	var ain, aout map[string]any
+	json.Unmarshal(in, &ain)
+	json.Unmarshal(out, &aout)
+	canIn, _ := json.Marshal(ain)
+	canOut, _ := json.Marshal(aout)
+	if !bytes.Equal(canIn, canOut) {
+		t.Errorf("roundtrip lost data:\n in=%s\nout=%s", canIn, canOut)
+	}
+}
+
+func TestIsWebSearchTool(t *testing.T) {
+	cases := map[string]bool{
+		`{"type":"web_search_20250305","name":"web_search"}`: true,
+		`{"type":"web_search_99999999","name":"web_search"}`: true,
+		`{"type":"web_fetch_20250910","name":"web_fetch"}`:   false,
+		`{"type":"custom","name":"x"}`:                       false,
+		`{}`: false,
+	}
+	for in, want := range cases {
+		if got := IsWebSearchTool([]byte(in)); got != want {
+			t.Errorf("IsWebSearchTool(%s)=%v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestIsWebFetchTool(t *testing.T) {
+	if !IsWebFetchTool([]byte(`{"type":"web_fetch_20250910"}`)) {
+		t.Error("expected true")
+	}
+	if IsWebFetchTool([]byte(`{"type":"web_search_20250305"}`)) {
+		t.Error("expected false")
+	}
+}
+
+func TestRewriteWebSearchTool_Annotated(t *testing.T) {
+	b := RewriteWebSearchTool()
+	desc := ToolDescription(b)
+	if !IsAnnotatedTool(desc) {
+		t.Errorf("rewritten tool description not annotated: %q", desc)
+	}
+	if ToolName(b) != "web_search" {
+		t.Errorf("ToolName=%q", ToolName(b))
+	}
+	if !strings.Contains(string(b), "query") {
+		t.Errorf("rewritten tool missing query schema: %s", b)
+	}
+}
+
+func TestRewriteWebFetchTool_Annotated(t *testing.T) {
+	b := RewriteWebFetchTool()
+	if ToolName(b) != "web_fetch" {
+		t.Errorf("ToolName=%q", ToolName(b))
+	}
+	if !IsAnnotatedTool(ToolDescription(b)) {
+		t.Errorf("not annotated")
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -11,9 +11,9 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"os"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -44,7 +44,7 @@ type Config struct {
 	// header is omitted for /v1/traces requests.
 	UCTracesTable string
 	TokenSource   TokenSource
-	Verbose        bool
+	Verbose       bool
 	// ToolName identifies this proxy in /health responses (e.g. "databricks-claude").
 	ToolName string
 	// Version is the build version reported by /health.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -55,6 +55,12 @@ type Config struct {
 	// TLSCertFile and TLSKeyFile enable TLS on the listener when both are set.
 	TLSCertFile string
 	TLSKeyFile  string
+	// WebSearch (--with-websearch) bundles the optional local-fulfillment
+	// settings for Anthropic's web_search/web_fetch server-side tools when
+	// Databricks FMAPI doesn't yet support them. When Enabled is false,
+	// inference requests are forwarded byte-identically and this struct
+	// has no effect — see pkg/proxy/websearch_handler.go.
+	WebSearch WebSearchSettings
 }
 
 // RecoveryHandler wraps h with panic recovery, returning 502 on panic.
@@ -290,62 +296,13 @@ func NewServer(config *Config) (http.Handler, error) {
 		return nil, fmt.Errorf("databricks-claude: invalid OTELUpstream %q: %v", config.OTELUpstream, err)
 	}
 
-	// Inference proxy — default route
-	inferenceProxy := &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			token, err := config.TokenSource.Token(req.Context())
-			if err != nil {
-				// Log the error but let the upstream return an auth failure rather
-				// than crashing; the empty bearer will be rejected by the upstream.
-				log.Printf("databricks-claude: token fetch error: %v", err)
-			}
-			if token != "" {
-				req.Header.Set("Authorization", "Bearer "+token)
-				req.Header.Set("x-api-key", token) // Anthropic SDK sends x-api-key; overwrite the "proxy-managed" placeholder
-			}
-			req.Header.Set("x-databricks-use-coding-agent-mode", "true")
-
-			req.URL.Scheme = inferenceUpstream.Scheme
-			req.URL.Host = inferenceUpstream.Host
-			req.Host = inferenceUpstream.Host // Override Host header — upstream rejects localhost
-			// Prepend the upstream base path to the incoming request path.
-			basePath := strings.TrimRight(inferenceUpstream.Path, "/")
-			req.URL.Path = basePath + req.URL.Path
-			req.URL.RawPath = ""
-
-			if config.Verbose {
-				log.Printf("databricks-claude: inference → %s %s%s", req.Method, req.URL.Host, req.URL.Path)
-			}
-		},
-		ModifyResponse: func(resp *http.Response) error {
-			if config.Verbose && resp.StatusCode >= 400 {
-				body, err := io.ReadAll(resp.Body)
-				if err == nil {
-					// Log first 500 chars of error response
-					snippet := string(body)
-					if len(snippet) > 500 {
-						snippet = snippet[:500] + "..."
-					}
-					log.Printf("databricks-claude: upstream error %d: %s", resp.StatusCode, sanitizeLogOutput(snippet))
-					// Put the body back so the caller still gets it
-					resp.Body = io.NopCloser(bytes.NewReader(body))
-				}
-			}
-			return nil
-		},
-		FlushInterval: -1,
-	}
-
-	// Wrap inference proxy with WebSocket upgrade detection.
-	// Claude Code never sends WebSocket upgrades; this branch exists for
-	// databricks-codex (Codex CLI), which uses WebSocket for inference.
-	inferenceHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if isWebSocketUpgrade(r) {
-			handleWebSocket(w, r, inferenceUpstream, config)
-			return
-		}
-		inferenceProxy.ServeHTTP(w, r)
-	})
+	// Inference handler — when WebSearch.Enabled is false this is a thin
+	// custom replacement for httputil.ReverseProxy that forwards bytes
+	// verbatim (regression-tested for byte-identity); when true, it
+	// inspects /v1/messages bodies to fulfill web_search/web_fetch locally.
+	// WebSocket upgrades (used by databricks-codex) are detected inside
+	// the handler and routed through handleWebSocket.
+	inferenceHandlerHTTP := inferenceHandler(inferenceUpstream, config, config.WebSearch)
 
 	// OTEL proxy — /otel/ route
 	otelProxy := &httputil.ReverseProxy{
@@ -423,7 +380,7 @@ func NewServer(config *Config) (http.Handler, error) {
 	})
 
 	mux.Handle("/otel/", RecoveryHandler(otelProxy))
-	mux.Handle("/", RecoveryHandler(inferenceHandler))
+	mux.Handle("/", RecoveryHandler(inferenceHandlerHTTP))
 
 	// APIKey check applies to all connections including WebSocket upgrades (used by databricks-codex)
 	return requireAPIKey(mux, config.APIKey), nil

--- a/pkg/proxy/sse_rewriter.go
+++ b/pkg/proxy/sse_rewriter.go
@@ -1,0 +1,587 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/IceRhymers/databricks-claude/pkg/proxy/anthropic"
+	"github.com/IceRhymers/databricks-claude/pkg/websearch"
+)
+
+// rewrittenTools records which tool kinds the request-side rewrite touched.
+// Used as the per-request signal that flows from tryRewriteRequest into the
+// response forwarding path so the response handler knows whether to inspect
+// the SSE stream / JSON body.
+type rewrittenTools struct {
+	HasWebSearch bool
+	HasWebFetch  bool
+}
+
+// Any reports whether any web_search_*/web_fetch_* server tool was rewritten.
+// Hot-path gate: when false, the response handler skips all SSE/JSON
+// inspection and falls through to the byte-identical passthrough.
+func (rt rewrittenTools) Any() bool { return rt.HasWebSearch || rt.HasWebFetch }
+
+// maxInputJSONBytes caps the total accumulated partial_json bytes per
+// content block. 64 KiB is far above any reasonable web_search query or
+// web_fetch URL; on overflow we degrade to passthrough for the affected
+// block.
+const maxInputJSONBytes = 64 * 1024
+
+// sseFrame is a parsed Server-Sent-Events frame (one event boundary).
+type sseFrame struct {
+	EventType string // from "event: TYPE" line; "" if absent
+	Data      []byte // from "data: JSON" line; nil if absent
+}
+
+// rewriteState holds per-stream mutable state for the SSE rewriter.
+type rewriteState struct {
+	indexShift   int                // # of synthetic blocks injected so far; added to every subsequent block index
+	activeBlocks map[int]*blockInfo // index → info for blocks of interest (only annotated tool_uses)
+	injectedAny  bool               // true once at least one synthetic web_search_tool_result was emitted
+}
+
+// blockInfo tracks an in-flight tool_use content block we may rewrite.
+type blockInfo struct {
+	toolName     string // "web_search" or "web_fetch"
+	toolUseID    string // original id from content_block_start
+	inputJSON    bytes.Buffer
+	overflowed   bool
+	originalIdx  int // upstream's original index for this block
+	rewrittenIdx int // our outbound index = originalIdx + indexShift at the time the block opened
+}
+
+// pumpSSE reads SSE frames from src, rewrites web_search/web_fetch
+// tool_use blocks into server_tool_use + web_search_tool_result pairs,
+// renumbers indices, rewrites stop_reason, and writes the transformed
+// stream to w with flushing. Caller owns src.Close.
+//
+// Returns nil on clean EOF, otherwise the underlying error.
+func pumpSSE(ctx context.Context, w http.ResponseWriter, src io.Reader, ws WebSearchSettings, rt rewrittenTools, verbose bool) error {
+	flusher, _ := w.(http.Flusher)
+	state := &rewriteState{activeBlocks: map[int]*blockInfo{}}
+
+	scanner := bufio.NewScanner(src)
+	// SSE frames are delimited by "\n\n". Allow up to 1 MiB per frame.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	scanner.Split(splitSSEFrames)
+
+	emit := func(b []byte) error {
+		if _, err := w.Write(b); err != nil {
+			return err
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return nil
+	}
+
+	for scanner.Scan() {
+		raw := scanner.Bytes()
+		// Make a copy — bufio.Scanner reuses its buffer on the next Scan.
+		frame := append([]byte(nil), raw...)
+
+		ev := parseSSEFrame(frame)
+		if len(ev.Data) == 0 {
+			// Comment-only or malformed frame; pass through verbatim.
+			if err := emit(frame); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Branch on event type. We only care about content_block_* and
+		// message_delta; everything else passes through (with index bump
+		// where applicable).
+		switch ev.EventType {
+		case "content_block_start":
+			if err := handleContentBlockStart(emit, frame, ev, state, ws, rt, verbose); err != nil {
+				return err
+			}
+		case "content_block_delta":
+			if err := handleContentBlockDelta(emit, frame, ev, state, verbose); err != nil {
+				return err
+			}
+		case "content_block_stop":
+			if err := handleContentBlockStop(ctx, emit, frame, ev, state, ws, verbose); err != nil {
+				return err
+			}
+		case "message_delta":
+			if err := handleMessageDelta(emit, frame, ev, state, verbose); err != nil {
+				return err
+			}
+		default:
+			// message_start, message_stop, ping, error, unknown: forward
+			// verbatim (no index field to rewrite at top level).
+			if err := emit(frame); err != nil {
+				return err
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		if verbose {
+			log.Printf("databricks-claude: websearch: SSE scanner error: %v", err)
+		}
+		return err
+	}
+	return nil
+}
+
+// splitSSEFrames is a bufio.SplitFunc that yields one "\n\n"-terminated
+// frame at a time. Includes the trailing "\n\n" in the returned token so
+// the rewriter can pass through verbatim when desired.
+func splitSSEFrames(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.Index(data, []byte("\n\n")); i >= 0 {
+		end := i + 2
+		return end, data[:end], nil
+	}
+	if atEOF {
+		// Trailing partial frame at EOF — emit as-is.
+		return len(data), data, nil
+	}
+	return 0, nil, nil // need more data
+}
+
+// parseSSEFrame extracts the event type and data payload from a frame.
+// Frame format: "event: TYPE\ndata: JSON\n\n" with either line optional.
+// Comment lines starting with ":" are skipped.
+func parseSSEFrame(frame []byte) sseFrame {
+	var out sseFrame
+	for _, line := range bytes.Split(frame, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		if line[0] == ':' {
+			continue // SSE comment
+		}
+		if bytes.HasPrefix(line, []byte("event:")) {
+			out.EventType = strings.TrimSpace(string(line[len("event:"):]))
+		} else if bytes.HasPrefix(line, []byte("data:")) {
+			val := bytes.TrimSpace(line[len("data:"):])
+			if out.Data == nil {
+				out.Data = append([]byte(nil), val...)
+			} else {
+				// Multi-line data: concatenate with newline per SSE spec.
+				out.Data = append(out.Data, '\n')
+				out.Data = append(out.Data, val...)
+			}
+		}
+	}
+	return out
+}
+
+// handleContentBlockStart inspects a content_block_start data payload.
+// If the block is a tool_use targeting our annotated client tools
+// (web_search/web_fetch), we rewrite its content_block.type to
+// server_tool_use on the wire (preserves Anthropic shape) and remember
+// the block so we can synthesize a web_search_tool_result on stop.
+// Other block types pass through verbatim with their index bumped.
+func handleContentBlockStart(emit func([]byte) error, frame []byte, ev sseFrame, state *rewriteState, ws WebSearchSettings, rt rewrittenTools, verbose bool) error {
+	var probe struct {
+		Type         string          `json:"type"`
+		Index        int             `json:"index"`
+		ContentBlock json.RawMessage `json:"content_block"`
+	}
+	if err := json.Unmarshal(ev.Data, &probe); err != nil {
+		return emit(frame)
+	}
+
+	var cb struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	_ = json.Unmarshal(probe.ContentBlock, &cb)
+
+	// Is this an annotated tool_use we want to rewrite?
+	annotated := cb.Type == "tool_use" && (cb.Name == anthropic.ClientToolName_WebSearch || cb.Name == anthropic.ClientToolName_WebFetch)
+
+	if !annotated {
+		// Not interesting — forward with possible index shift.
+		out, err := bumpIndexInData(ev.Data, state.indexShift)
+		if err != nil {
+			return emit(frame)
+		}
+		return emitFrame(emit, "content_block_start", out)
+	}
+
+	// Track this block for input accumulation + later synthesis.
+	bi := &blockInfo{
+		toolName:     cb.Name,
+		toolUseID:    cb.ID,
+		originalIdx:  probe.Index,
+		rewrittenIdx: probe.Index + state.indexShift,
+	}
+	state.activeBlocks[probe.Index] = bi
+
+	if verbose {
+		log.Printf("databricks-claude: websearch: SSE intercept tool_use(name=%s, id=%s, index=%d→%d)", cb.Name, cb.ID, bi.originalIdx, bi.rewrittenIdx)
+	}
+
+	// Rewrite content_block.type from "tool_use" to "server_tool_use" so
+	// downstream Anthropic SDK consumers correlate the result block we'll
+	// inject. Mint a server-tool id by prefixing with "srvtoolu_" if the
+	// upstream id doesn't already match that prefix.
+	serverID := cb.ID
+	if !strings.HasPrefix(serverID, "srvtoolu_") {
+		serverID = "srvtoolu_" + cb.ID
+	}
+	bi.toolUseID = serverID
+
+	rewrittenCB := map[string]string{
+		"type": "server_tool_use",
+		"id":   serverID,
+		"name": cb.Name,
+	}
+	rewrittenCBBytes, _ := json.Marshal(rewrittenCB)
+
+	// Re-emit the start event with the rewritten content_block and shifted index.
+	outData, err := rewriteContentBlockStartData(ev.Data, bi.rewrittenIdx, rewrittenCBBytes)
+	if err != nil {
+		return emit(frame)
+	}
+	return emitFrame(emit, "content_block_start", outData)
+}
+
+// handleContentBlockDelta forwards delta events with bumped index.
+// If the delta belongs to one of our tracked tool_use blocks, we also
+// accumulate its partial_json fragment for later input parsing.
+func handleContentBlockDelta(emit func([]byte) error, frame []byte, ev sseFrame, state *rewriteState, verbose bool) error {
+	var probe struct {
+		Type  string `json:"type"`
+		Index int    `json:"index"`
+		Delta struct {
+			Type        string `json:"type"`
+			PartialJSON string `json:"partial_json"`
+		} `json:"delta"`
+	}
+	if err := json.Unmarshal(ev.Data, &probe); err != nil {
+		return emit(frame)
+	}
+
+	if bi, ok := state.activeBlocks[probe.Index]; ok && probe.Delta.Type == "input_json_delta" && !bi.overflowed {
+		if bi.inputJSON.Len()+len(probe.Delta.PartialJSON) > maxInputJSONBytes {
+			bi.overflowed = true
+			if verbose {
+				log.Printf("databricks-claude: websearch: SSE input_json overflow on block index=%d (cap=%d); degrading to passthrough", probe.Index, maxInputJSONBytes)
+			}
+		} else {
+			bi.inputJSON.WriteString(probe.Delta.PartialJSON)
+		}
+	}
+
+	out, err := bumpIndexInData(ev.Data, state.indexShift)
+	if err != nil {
+		return emit(frame)
+	}
+	return emitFrame(emit, "content_block_delta", out)
+}
+
+// handleContentBlockStop forwards the stop event for the original block,
+// then — if the block was one of ours — synthesizes a new
+// content_block_start (web_search_tool_result, full content baked in)
+// and content_block_stop pair, and increments indexShift.
+func handleContentBlockStop(ctx context.Context, emit func([]byte) error, frame []byte, ev sseFrame, state *rewriteState, ws WebSearchSettings, verbose bool) error {
+	var probe struct {
+		Type  string `json:"type"`
+		Index int    `json:"index"`
+	}
+	if err := json.Unmarshal(ev.Data, &probe); err != nil {
+		return emit(frame)
+	}
+
+	// Forward the stop for the original block (with index shift).
+	stopOut, err := bumpIndexInData(ev.Data, state.indexShift)
+	if err != nil {
+		stopOut = ev.Data
+	}
+	if err := emitFrame(emit, "content_block_stop", stopOut); err != nil {
+		return err
+	}
+
+	bi, tracked := state.activeBlocks[probe.Index]
+	if !tracked {
+		return nil
+	}
+	delete(state.activeBlocks, probe.Index)
+
+	if bi.overflowed {
+		// Skip injection; degraded to passthrough.
+		return nil
+	}
+
+	// Execute local fulfillment with a 15s budget.
+	fulfillCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	resultBlock, fulErr := fulfillBlock(fulfillCtx, bi, ws)
+	if fulErr != nil {
+		// fulfillBlock already returns an error-variant block on backend
+		// failure; only nil-block + non-nil err is a true bug.
+		if verbose {
+			log.Printf("databricks-claude: websearch: SSE fulfillment internal error for tool_use_id=%s: %v", bi.toolUseID, fulErr)
+		}
+		return nil
+	}
+
+	// Inject content_block_start for the synthetic web_search_tool_result.
+	injectIdx := bi.rewrittenIdx + 1
+	startEvent := map[string]any{
+		"type":          "content_block_start",
+		"index":         injectIdx,
+		"content_block": json.RawMessage(resultBlock),
+	}
+	startBytes, _ := json.Marshal(startEvent)
+	if err := emitFrame(emit, "content_block_start", startBytes); err != nil {
+		return err
+	}
+
+	stopEvent := map[string]any{
+		"type":  "content_block_stop",
+		"index": injectIdx,
+	}
+	stopBytes, _ := json.Marshal(stopEvent)
+	if err := emitFrame(emit, "content_block_stop", stopBytes); err != nil {
+		return err
+	}
+
+	state.indexShift++
+	state.injectedAny = true
+
+	if verbose {
+		log.Printf("databricks-claude: websearch: SSE injected web_search_tool_result for tool_use_id=%s at index=%d (shift now %d)", bi.toolUseID, injectIdx, state.indexShift)
+	}
+	return nil
+}
+
+// handleMessageDelta forwards message_delta with stop_reason rewriting:
+// if we injected at least one synthetic block AND the upstream said
+// stop_reason="tool_use", rewrite to "end_turn". usage fields preserved.
+func handleMessageDelta(emit func([]byte) error, frame []byte, ev sseFrame, state *rewriteState, verbose bool) error {
+	if !state.injectedAny {
+		return emitFrame(emit, "message_delta", ev.Data)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(ev.Data, &raw); err != nil {
+		return emit(frame)
+	}
+	delta, ok := raw["delta"]
+	if !ok {
+		return emitFrame(emit, "message_delta", ev.Data)
+	}
+	var deltaMap map[string]json.RawMessage
+	if err := json.Unmarshal(delta, &deltaMap); err != nil {
+		return emitFrame(emit, "message_delta", ev.Data)
+	}
+	if sr, ok := deltaMap["stop_reason"]; ok {
+		var s string
+		_ = json.Unmarshal(sr, &s)
+		if s == "tool_use" {
+			deltaMap["stop_reason"] = json.RawMessage(`"end_turn"`)
+			newDelta, _ := json.Marshal(deltaMap)
+			raw["delta"] = newDelta
+			out, _ := json.Marshal(raw)
+			if verbose {
+				log.Printf("databricks-claude: websearch: SSE rewrote message_delta.stop_reason tool_use→end_turn")
+			}
+			return emitFrame(emit, "message_delta", out)
+		}
+	}
+	return emitFrame(emit, "message_delta", ev.Data)
+}
+
+// fulfillBlock executes the local search/fetch and returns the JSON-encoded
+// web_search_tool_result content block.
+func fulfillBlock(ctx context.Context, bi *blockInfo, ws WebSearchSettings) ([]byte, error) {
+	switch bi.toolName {
+	case anthropic.ClientToolName_WebSearch:
+		query, err := anthropic.ParseWebSearchInput(bi.inputJSON.Bytes())
+		if err != nil {
+			return anthropic.BuildWebSearchErrorBlock(bi.toolUseID, "invalid_input")
+		}
+		if ws.Backend == nil {
+			return anthropic.BuildWebSearchErrorBlock(bi.toolUseID, "unavailable")
+		}
+		results, err := ws.Backend.Search(ctx, query, 5)
+		if err != nil {
+			return anthropic.BuildWebSearchErrorBlock(bi.toolUseID, "unavailable")
+		}
+		out := make([]anthropic.WebSearchResult, 0, len(results))
+		for _, r := range results {
+			title := r.Title
+			if r.Snippet != "" {
+				title = r.Title + " — " + r.Snippet
+			}
+			out = append(out, anthropic.WebSearchResult{
+				URL:              r.URL,
+				Title:            title,
+				EncryptedContent: "",
+			})
+		}
+		return anthropic.BuildWebSearchSuccessBlock(bi.toolUseID, out)
+
+	case anthropic.ClientToolName_WebFetch:
+		fetchURL, err := anthropic.ParseWebFetchInput(bi.inputJSON.Bytes())
+		if err != nil {
+			return anthropic.BuildWebSearchErrorBlock(bi.toolUseID, "invalid_input")
+		}
+		fr, err := websearch.Fetch(ctx, fetchURL, ws.FetchBudget, ws.Robots)
+		if err != nil {
+			return anthropic.BuildWebSearchErrorBlock(bi.toolUseID, "unavailable")
+		}
+		return anthropic.BuildWebFetchSuccessBlock(bi.toolUseID, fr.URL, fr.Text, fr.Truncated)
+	}
+	return anthropic.BuildWebSearchErrorBlock(bi.toolUseID, "unavailable")
+}
+
+// emitFrame serializes an event as `event: TYPE\ndata: <JSON>\n\n` and
+// writes it via the emit callback.
+func emitFrame(emit func([]byte) error, eventType string, data []byte) error {
+	var buf bytes.Buffer
+	buf.WriteString("event: ")
+	buf.WriteString(eventType)
+	buf.WriteByte('\n')
+	buf.WriteString("data: ")
+	buf.Write(data)
+	buf.WriteString("\n\n")
+	return emit(buf.Bytes())
+}
+
+// bumpIndexInData rewrites the top-level "index" field in a content_block_*
+// data payload, adding shift to its value. If shift == 0 returns data as-is.
+func bumpIndexInData(data []byte, shift int) ([]byte, error) {
+	if shift == 0 {
+		return data, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return data, err
+	}
+	idxRaw, ok := raw["index"]
+	if !ok {
+		return data, nil
+	}
+	var idx int
+	if err := json.Unmarshal(idxRaw, &idx); err != nil {
+		return data, err
+	}
+	newIdx, _ := json.Marshal(idx + shift)
+	raw["index"] = newIdx
+	return json.Marshal(raw)
+}
+
+// rewriteContentBlockStartData replaces the index and content_block fields
+// in a content_block_start data payload while preserving any other fields.
+func rewriteContentBlockStartData(data []byte, newIndex int, newContentBlock []byte) ([]byte, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return data, err
+	}
+	idxBytes, _ := json.Marshal(newIndex)
+	raw["index"] = idxBytes
+	raw["content_block"] = newContentBlock
+	return json.Marshal(raw)
+}
+
+// rewriteJSONResponse handles the non-streaming /v1/messages JSON body
+// path. It walks content[] looking for tool_use(web_search|web_fetch),
+// rewrites each to server_tool_use + a synthetic web_search_tool_result
+// pair, and rewrites stop_reason "tool_use" → "end_turn" if any injection
+// happened.
+func rewriteJSONResponse(ctx context.Context, body []byte, ws WebSearchSettings, verbose bool) ([]byte, error) {
+	var resp anthropic.Response
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return body, err
+	}
+	if len(resp.Content) == 0 {
+		return body, nil
+	}
+
+	newContent := make([]json.RawMessage, 0, len(resp.Content)+2)
+	injected := false
+	for _, block := range resp.Content {
+		var probe struct {
+			Type  string          `json:"type"`
+			ID    string          `json:"id"`
+			Name  string          `json:"name"`
+			Input json.RawMessage `json:"input"`
+		}
+		if err := json.Unmarshal(block, &probe); err != nil {
+			newContent = append(newContent, block)
+			continue
+		}
+		if probe.Type != "tool_use" || (probe.Name != anthropic.ClientToolName_WebSearch && probe.Name != anthropic.ClientToolName_WebFetch) {
+			newContent = append(newContent, block)
+			continue
+		}
+
+		// Mint server tool id and rewrite the block to server_tool_use.
+		serverID := probe.ID
+		if !strings.HasPrefix(serverID, "srvtoolu_") {
+			serverID = "srvtoolu_" + probe.ID
+		}
+		var inputMap map[string]json.RawMessage
+		_ = json.Unmarshal(probe.Input, &inputMap)
+		stuRewritten, _ := json.Marshal(map[string]any{
+			"type":  "server_tool_use",
+			"id":    serverID,
+			"name":  probe.Name,
+			"input": inputMap,
+		})
+		newContent = append(newContent, stuRewritten)
+
+		bi := &blockInfo{toolName: probe.Name, toolUseID: serverID}
+		if probe.Input != nil {
+			bi.inputJSON.Write(probe.Input)
+		}
+		fulfillCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		resultBlock, err := fulfillBlock(fulfillCtx, bi, ws)
+		cancel()
+		if err != nil {
+			if verbose {
+				log.Printf("databricks-claude: websearch: JSON fulfillment error for tool_use_id=%s: %v", serverID, err)
+			}
+			continue
+		}
+		newContent = append(newContent, resultBlock)
+		injected = true
+	}
+	resp.Content = newContent
+
+	if injected && resp.StopReason == "tool_use" {
+		resp.StopReason = "end_turn"
+	}
+
+	out, err := json.Marshal(&resp)
+	if err != nil {
+		return body, err
+	}
+	if verbose && injected {
+		log.Printf("databricks-claude: websearch: JSON-rewrote response with injected web_search_tool_result blocks")
+	}
+	return out, nil
+}
+
+// isSSEResponse reports whether the response Content-Type indicates SSE.
+func isSSEResponse(resp *http.Response) bool {
+	ct := resp.Header.Get("Content-Type")
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(strings.SplitN(ct, ";", 2)[0])), "text/event-stream")
+}
+
+// isJSONResponse reports whether the response Content-Type indicates JSON.
+func isJSONResponse(resp *http.Response) bool {
+	ct := resp.Header.Get("Content-Type")
+	first := strings.ToLower(strings.TrimSpace(strings.SplitN(ct, ";", 2)[0]))
+	return first == "application/json" || strings.HasSuffix(first, "+json")
+}
+

--- a/pkg/proxy/sse_rewriter.go
+++ b/pkg/proxy/sse_rewriter.go
@@ -238,10 +238,15 @@ func handleContentBlockStart(emit func([]byte) error, frame []byte, ev sseFrame,
 	}
 	bi.toolUseID = serverID
 
-	rewrittenCB := map[string]string{
-		"type": "server_tool_use",
-		"id":   serverID,
-		"name": cb.Name,
+	// Emit server_tool_use with an empty input object — input_json_delta
+	// frames will populate it client-side, mirroring how Anthropic's native
+	// server_tool_use blocks arrive over the wire. Without "input": {} some
+	// SDK consumers reject the start event.
+	rewrittenCB := map[string]any{
+		"type":  "server_tool_use",
+		"id":    serverID,
+		"name":  cb.Name,
+		"input": map[string]any{},
 	}
 	rewrittenCBBytes, _ := json.Marshal(rewrittenCB)
 
@@ -316,7 +321,34 @@ func handleContentBlockStop(ctx context.Context, emit func([]byte) error, frame 
 	delete(state.activeBlocks, probe.Index)
 
 	if bi.overflowed {
-		// Skip injection; degraded to passthrough.
+		// Inject an error result so the SDK doesn't see an orphan
+		// server_tool_use block. Without a paired web_search_tool_result
+		// the conversation state is inconsistent and follow-up turns
+		// fail to correlate.
+		errBlock, _ := anthropic.BuildWebSearchErrorBlock(bi.toolUseID, "invalid_input")
+		injectIdx := bi.rewrittenIdx + 1
+		startEvent := map[string]any{
+			"type":          "content_block_start",
+			"index":         injectIdx,
+			"content_block": json.RawMessage(errBlock),
+		}
+		startBytes, _ := json.Marshal(startEvent)
+		if err := emitFrame(emit, "content_block_start", startBytes); err != nil {
+			return err
+		}
+		stopEvent := map[string]any{
+			"type":  "content_block_stop",
+			"index": injectIdx,
+		}
+		stopBytes, _ := json.Marshal(stopEvent)
+		if err := emitFrame(emit, "content_block_stop", stopBytes); err != nil {
+			return err
+		}
+		state.indexShift++
+		state.injectedAny = true
+		if verbose {
+			log.Printf("databricks-claude: websearch: SSE injected invalid_input error block for overflowed tool_use_id=%s", bi.toolUseID)
+		}
 		return nil
 	}
 

--- a/pkg/proxy/sse_rewriter_test.go
+++ b/pkg/proxy/sse_rewriter_test.go
@@ -1,0 +1,492 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/IceRhymers/databricks-claude/pkg/websearch"
+)
+
+// erroringBackend is a Backend that returns a fixed error from Search.
+type erroringBackend struct{}
+
+func (erroringBackend) Name() string { return "erroring" }
+func (erroringBackend) Search(_ context.Context, _ string, _ int) ([]websearch.Result, error) {
+	return nil, errors.New("simulated backend failure")
+}
+
+// frame builds a single SSE frame from event type and JSON data.
+func frame(event string, data string) string {
+	return "event: " + event + "\ndata: " + data + "\n\n"
+}
+
+// runPump runs pumpSSE on the given input string and returns the output as
+// a string for assertions. fakeRW provides http.ResponseWriter +
+// http.Flusher so the rewriter exercises the flushing path.
+func runPump(t *testing.T, input string, ws WebSearchSettings, rt rewrittenTools) string {
+	t.Helper()
+	rec := newFlushRecorder()
+	if err := pumpSSE(context.Background(), rec, strings.NewReader(input), ws, rt, false); err != nil {
+		t.Fatalf("pumpSSE: %v", err)
+	}
+	return rec.body.String()
+}
+
+// flushRecorder is an http.ResponseWriter that satisfies http.Flusher.
+type flushRecorder struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+}
+
+func newFlushRecorder() *flushRecorder { return &flushRecorder{header: http.Header{}, status: 200} }
+func (f *flushRecorder) Header() http.Header { return f.header }
+func (f *flushRecorder) Write(b []byte) (int, error) {
+	return f.body.Write(b)
+}
+func (f *flushRecorder) WriteHeader(s int) { f.status = s }
+func (f *flushRecorder) Flush()            {}
+
+// extractDataPayloads returns the JSON payload bytes of each `data:` line
+// in an SSE byte stream, in order. Useful for asserting on parsed events.
+func extractDataPayloads(t *testing.T, sse string) []map[string]any {
+	t.Helper()
+	out := []map[string]any{}
+	for _, frame := range strings.Split(sse, "\n\n") {
+		if frame == "" {
+			continue
+		}
+		for _, line := range strings.Split(frame, "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := strings.TrimPrefix(line, "data: ")
+			var m map[string]any
+			if err := json.Unmarshal([]byte(payload), &m); err != nil {
+				t.Fatalf("data not JSON: %q (err=%v)", payload, err)
+			}
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// TestSSERewriter_StreamingWebSearch_HappyPath: tool_use(web_search) with
+// split input_json_delta fragments → rewritten to server_tool_use +
+// synthesized web_search_tool_result.
+func TestSSERewriter_StreamingWebSearch_HappyPath(t *testing.T) {
+	input := strings.Join([]string{
+		frame("message_start", `{"type":"message_start","message":{"id":"msg_1"}}`),
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		frame("content_block_start", `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_abc","name":"web_search"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"que"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"ry\":\"go"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"lang\"}"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":1}`),
+		frame("message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":10}}`),
+		frame("message_stop", `{"type":"message_stop"}`),
+	}, "")
+
+	ws := WebSearchSettings{
+		Enabled: true,
+		Backend: &fakeBackend{results: []websearch.Result{
+			{Title: "Go", URL: "https://go.dev", Snippet: "An open source language"},
+		}},
+	}
+	out := runPump(t, input, ws, rewrittenTools{HasWebSearch: true})
+
+	// Original tool_use must have been rewritten on the wire to server_tool_use.
+	if !strings.Contains(out, `"type":"server_tool_use"`) {
+		t.Errorf("missing rewritten server_tool_use in output:\n%s", out)
+	}
+	if strings.Contains(out, `"type":"tool_use"`) {
+		t.Errorf("output still contains client tool_use type:\n%s", out)
+	}
+	// Synthetic result must be present with the URL from the fake backend.
+	if !strings.Contains(out, "https://go.dev") {
+		t.Errorf("missing search result URL in output:\n%s", out)
+	}
+	if !strings.Contains(out, `"type":"web_search_tool_result"`) {
+		t.Errorf("missing web_search_tool_result block:\n%s", out)
+	}
+	// Snippet should be folded into title.
+	if !strings.Contains(out, "An open source language") {
+		t.Errorf("snippet not folded into title:\n%s", out)
+	}
+	// Server tool id minted from original toolu_abc.
+	if !strings.Contains(out, `srvtoolu_toolu_abc`) {
+		t.Errorf("server tool id not minted from toolu_abc:\n%s", out)
+	}
+}
+
+// TestSSERewriter_StreamingWebSearch_BackendError: backend returns error →
+// emit error variant block.
+func TestSSERewriter_StreamingWebSearch_BackendError(t *testing.T) {
+	input := strings.Join([]string{
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_x","name":"web_search"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"x\"}"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		frame("message_stop", `{"type":"message_stop"}`),
+	}, "")
+
+	ws := WebSearchSettings{Enabled: true, Backend: erroringBackend{}}
+	out := runPump(t, input, ws, rewrittenTools{HasWebSearch: true})
+
+	if !strings.Contains(out, `"type":"web_search_tool_result_error"`) {
+		t.Errorf("expected error variant in output:\n%s", out)
+	}
+	if !strings.Contains(out, `"error_code":"unavailable"`) {
+		t.Errorf("expected unavailable error_code:\n%s", out)
+	}
+}
+
+// TestSSERewriter_StreamingWebSearch_InputOverflow: simulated huge
+// partial_json → overflow → no synthetic block injected.
+func TestSSERewriter_StreamingWebSearch_InputOverflow(t *testing.T) {
+	bigChunk := strings.Repeat("a", 32*1024) // 32 KiB per delta; two will overflow 64 KiB cap
+	jsonDelta := func(s string) string {
+		// Embed the chunk safely — escape would be heavy; we only need to
+		// trigger the byte counter, content can be invalid JSON.
+		return fmt.Sprintf(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":%q}}`, s)
+	}
+	input := strings.Join([]string{
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_y","name":"web_search"}}`),
+		frame("content_block_delta", jsonDelta(bigChunk)),
+		frame("content_block_delta", jsonDelta(bigChunk)),
+		frame("content_block_delta", jsonDelta(bigChunk)),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+	}, "")
+
+	ws := WebSearchSettings{Enabled: true, Backend: &fakeBackend{results: nil}}
+	out := runPump(t, input, ws, rewrittenTools{HasWebSearch: true})
+
+	if strings.Contains(out, `"type":"web_search_tool_result"`) {
+		t.Errorf("expected no synthetic block on overflow:\n%s", out[:min(500, len(out))])
+	}
+}
+
+// TestSSERewriter_StreamingWebSearch_InvalidJSON: malformed accumulated
+// input → emit invalid_input error block.
+func TestSSERewriter_StreamingWebSearch_InvalidJSON(t *testing.T) {
+	input := strings.Join([]string{
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_z","name":"web_search"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"not-json"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+	}, "")
+
+	ws := WebSearchSettings{Enabled: true, Backend: &fakeBackend{}}
+	out := runPump(t, input, ws, rewrittenTools{HasWebSearch: true})
+
+	if !strings.Contains(out, `"error_code":"invalid_input"`) {
+		t.Errorf("expected invalid_input error code on malformed JSON:\n%s", out)
+	}
+}
+
+// TestSSERewriter_StreamingNoToolUse_Passthrough: text-only stream is
+// effectively unchanged (events forwarded; no synthesis fires).
+func TestSSERewriter_StreamingNoToolUse_Passthrough(t *testing.T) {
+	input := strings.Join([]string{
+		frame("message_start", `{"type":"message_start","message":{"id":"msg_x"}}`),
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		frame("message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`),
+		frame("message_stop", `{"type":"message_stop"}`),
+	}, "")
+
+	ws := WebSearchSettings{Enabled: true, Backend: &fakeBackend{}}
+	out := runPump(t, input, ws, rewrittenTools{HasWebSearch: true})
+
+	// All content preserved; no injected blocks.
+	if strings.Contains(out, "web_search_tool_result") {
+		t.Errorf("unexpected synthetic block injected:\n%s", out)
+	}
+	if !strings.Contains(out, `"text":"hello"`) {
+		t.Errorf("text delta missing from output:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Errorf("end_turn stop_reason should be preserved unchanged:\n%s", out)
+	}
+}
+
+// TestSSERewriter_NonStreaming_BodyJSON_Rewrite: the non-streaming JSON
+// branch correctly rewrites tool_use → server_tool_use + injects
+// web_search_tool_result.
+func TestSSERewriter_NonStreaming_BodyJSON_Rewrite(t *testing.T) {
+	body := []byte(`{
+	  "id": "msg_a",
+	  "type": "message",
+	  "role": "assistant",
+	  "model": "claude-opus-4-7",
+	  "content": [
+	    {"type": "text", "text": "Searching..."},
+	    {"type": "tool_use", "id": "toolu_q", "name": "web_search", "input": {"query": "golang"}}
+	  ],
+	  "stop_reason": "tool_use",
+	  "usage": {"input_tokens": 10, "output_tokens": 20}
+	}`)
+
+	ws := WebSearchSettings{
+		Enabled: true,
+		Backend: &fakeBackend{results: []websearch.Result{{Title: "Go", URL: "https://go.dev"}}},
+	}
+	out, err := rewriteJSONResponse(context.Background(), body, ws, false)
+	if err != nil {
+		t.Fatalf("rewriteJSONResponse: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `"type":"server_tool_use"`) {
+		t.Errorf("missing server_tool_use:\n%s", s)
+	}
+	if !strings.Contains(s, `"type":"web_search_tool_result"`) {
+		t.Errorf("missing web_search_tool_result:\n%s", s)
+	}
+	if !strings.Contains(s, "https://go.dev") {
+		t.Errorf("missing URL from results:\n%s", s)
+	}
+	if !strings.Contains(s, `"stop_reason":"end_turn"`) {
+		t.Errorf("stop_reason should have been rewritten to end_turn:\n%s", s)
+	}
+	if !strings.Contains(s, `"input_tokens":10`) {
+		t.Errorf("usage.input_tokens should be preserved verbatim:\n%s", s)
+	}
+}
+
+// TestSSERewriter_IndexRenumbering: tool_use at index 1 followed by text
+// at index 2; injected block goes at index 2; original text renumbered to 3.
+func TestSSERewriter_IndexRenumbering(t *testing.T) {
+	input := strings.Join([]string{
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		frame("content_block_start", `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_a","name":"web_search"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"q\"}"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":1}`),
+		frame("content_block_start", `{"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"hello"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":2}`),
+	}, "")
+
+	ws := WebSearchSettings{Enabled: true, Backend: &fakeBackend{results: []websearch.Result{{URL: "https://x", Title: "X"}}}}
+	out := runPump(t, input, ws, rewrittenTools{HasWebSearch: true})
+
+	payloads := extractDataPayloads(t, out)
+	// Expected sequence (events on the wire):
+	//   block_start(idx=0,text), block_stop(idx=0),
+	//   block_start(idx=1,server_tool_use), block_delta(idx=1), block_stop(idx=1),
+	//   block_start(idx=2,web_search_tool_result) [INJECTED],
+	//   block_stop(idx=2) [INJECTED],
+	//   block_start(idx=3,text) [shifted +1], block_delta(idx=3), block_stop(idx=3).
+	wantIndices := []int{0, 0, 1, 1, 1, 2, 2, 3, 3, 3}
+	if len(payloads) != len(wantIndices) {
+		t.Fatalf("payload count = %d, want %d:\n%s", len(payloads), len(wantIndices), out)
+	}
+	for i, p := range payloads {
+		idx, ok := p["index"].(float64)
+		if !ok {
+			continue // some events lack index (e.g. message_start) — none expected here
+		}
+		if int(idx) != wantIndices[i] {
+			t.Errorf("payload[%d] index=%d want %d (type=%v):\n%s", i, int(idx), wantIndices[i], p["type"], out)
+		}
+	}
+	// And the injected block at index 5 (0-indexed payload position) is the
+	// web_search_tool_result with index=2.
+	injected := payloads[5]
+	if cb, ok := injected["content_block"].(map[string]any); !ok {
+		t.Errorf("payload[5] missing content_block: %v", injected)
+	} else if cb["type"] != "web_search_tool_result" {
+		t.Errorf("injected block type=%v want web_search_tool_result; payload[5]=%v", cb["type"], injected)
+	}
+	if int(injected["index"].(float64)) != 2 {
+		t.Errorf("injected block at wrong index: %v want 2", injected["index"])
+	}
+}
+
+// TestSSERewriter_TwoSearches: two tool_use(web_search) blocks in one
+// response → two synthetic results injected.
+func TestSSERewriter_TwoSearches(t *testing.T) {
+	input := strings.Join([]string{
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_a","name":"web_search"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"a\"}"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		frame("content_block_start", `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_b","name":"web_search"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"b\"}"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":1}`),
+		frame("message_stop", `{"type":"message_stop"}`),
+	}, "")
+
+	ws := WebSearchSettings{Enabled: true, Backend: &fakeBackend{results: []websearch.Result{{URL: "https://r", Title: "R"}}}}
+	out := runPump(t, input, ws, rewrittenTools{HasWebSearch: true})
+
+	// Two injected web_search_tool_result blocks expected.
+	count := strings.Count(out, `"type":"web_search_tool_result"`)
+	if count != 2 {
+		t.Errorf("expected 2 injected blocks, got %d:\n%s", count, out)
+	}
+	// Two server_tool_use blocks expected on the wire.
+	count = strings.Count(out, `"type":"server_tool_use"`)
+	if count != 2 {
+		t.Errorf("expected 2 server_tool_use blocks, got %d:\n%s", count, out)
+	}
+}
+
+// TestSSERewriter_StopReasonRewrite: stop_reason "tool_use" rewritten to
+// "end_turn" after injection; usage preserved verbatim.
+func TestSSERewriter_StopReasonRewrite(t *testing.T) {
+	input := strings.Join([]string{
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_q","name":"web_search"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"q\"}"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		frame("message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":12,"output_tokens":34}}`),
+	}, "")
+
+	ws := WebSearchSettings{Enabled: true, Backend: &fakeBackend{results: []websearch.Result{{URL: "https://r", Title: "R"}}}}
+	out := runPump(t, input, ws, rewrittenTools{HasWebSearch: true})
+
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Errorf("expected stop_reason rewritten to end_turn:\n%s", out)
+	}
+	if strings.Contains(out, `"stop_reason":"tool_use"`) {
+		t.Errorf("original stop_reason still present:\n%s", out)
+	}
+	if !strings.Contains(out, `"input_tokens":12`) || !strings.Contains(out, `"output_tokens":34`) {
+		t.Errorf("usage fields should be preserved verbatim:\n%s", out)
+	}
+}
+
+// TestSSERewriter_NoToolUse_StopReasonUntouched: stop_reason untouched
+// when no synthetic blocks were injected.
+func TestSSERewriter_NoToolUse_StopReasonUntouched(t *testing.T) {
+	input := strings.Join([]string{
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		frame("message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`),
+	}, "")
+
+	ws := WebSearchSettings{Enabled: true, Backend: &fakeBackend{}}
+	out := runPump(t, input, ws, rewrittenTools{HasWebSearch: true})
+
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Errorf("end_turn stop_reason should be preserved verbatim:\n%s", out)
+	}
+}
+
+// TestSSERewriter_ContentLengthStripped: integration test against a fake
+// upstream that sets Content-Length on the SSE response. Assert the
+// outbound response to the proxy client does NOT carry Content-Length.
+func TestSSERewriter_ContentLengthStripped(t *testing.T) {
+	upstreamSSE := strings.Join([]string{
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_q","name":"web_search"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"q\"}"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		frame("message_stop", `{"type":"message_stop"}`),
+	}, "")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(upstreamSSE)))
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, upstreamSSE)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		TokenSource:       warmToken("tok"),
+		WebSearch: WebSearchSettings{
+			Enabled: true,
+			Backend: &fakeBackend{results: []websearch.Result{{URL: "https://x", Title: "X"}}},
+		},
+	}
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	body := `{"model":"claude-opus-4-7","messages":[],"tools":[{"type":"web_search_20250305","name":"web_search"}],"max_tokens":1024,"stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Content-Length") != "" {
+		t.Errorf("Content-Length should be stripped on SSE rewrite path; got %q", rec.Header().Get("Content-Length"))
+	}
+	if !strings.Contains(rec.Body.String(), "web_search_tool_result") {
+		t.Errorf("integration test: expected injected web_search_tool_result in response:\n%s", rec.Body.String())
+	}
+}
+
+// TestProxy_WebSearchEnabled_StreamingResponse_RewritesToWebSearchToolResult:
+// integration test verifying a full request → upstream SSE → rewritten
+// response flow.
+func TestProxy_WebSearchEnabled_StreamingResponse_RewritesToWebSearchToolResult(t *testing.T) {
+	upstreamSSE := strings.Join([]string{
+		frame("message_start", `{"type":"message_start","message":{"id":"msg_int"}}`),
+		frame("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_int","name":"web_search"}}`),
+		frame("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"golang\"}"}}`),
+		frame("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		frame("message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}`),
+		frame("message_stop", `{"type":"message_stop"}`),
+	}, "")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, upstreamSSE)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		TokenSource:       warmToken("tok"),
+		WebSearch: WebSearchSettings{
+			Enabled: true,
+			Backend: &fakeBackend{results: []websearch.Result{
+				{URL: "https://go.dev", Title: "Go", Snippet: "An open source language"},
+			}},
+		},
+	}
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	body := `{"model":"claude-opus-4-7","messages":[],"tools":[{"type":"web_search_20250305","name":"web_search"}],"max_tokens":1024,"stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	out := rec.Body.String()
+	if !strings.Contains(out, `"type":"web_search_tool_result"`) {
+		t.Errorf("integration: missing web_search_tool_result block:\n%s", out)
+	}
+	if !strings.Contains(out, "https://go.dev") {
+		t.Errorf("integration: missing URL:\n%s", out)
+	}
+	if !strings.Contains(out, `"stop_reason":"end_turn"`) {
+		t.Errorf("integration: stop_reason should have been rewritten to end_turn:\n%s", out)
+	}
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Errorf("integration: Content-Type should be preserved as text/event-stream, got %q", rec.Header().Get("Content-Type"))
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/proxy/sse_rewriter_test.go
+++ b/pkg/proxy/sse_rewriter_test.go
@@ -47,7 +47,7 @@ type flushRecorder struct {
 	status int
 }
 
-func newFlushRecorder() *flushRecorder { return &flushRecorder{header: http.Header{}, status: 200} }
+func newFlushRecorder() *flushRecorder       { return &flushRecorder{header: http.Header{}, status: 200} }
 func (f *flushRecorder) Header() http.Header { return f.header }
 func (f *flushRecorder) Write(b []byte) (int, error) {
 	return f.body.Write(b)
@@ -169,9 +169,21 @@ func TestSSERewriter_StreamingWebSearch_InputOverflow(t *testing.T) {
 	ws := WebSearchSettings{Enabled: true, Backend: &fakeBackend{results: nil}}
 	out := runPump(t, input, ws, rewrittenTools{HasWebSearch: true})
 
-	if strings.Contains(out, `"type":"web_search_tool_result"`) {
-		t.Errorf("expected no synthetic block on overflow:\n%s", out[:min(500, len(out))])
+	// On overflow we now inject an invalid_input error block so the SDK
+	// doesn't see an orphan server_tool_use without a paired result.
+	if !strings.Contains(out, `"type":"web_search_tool_result"`) {
+		t.Errorf("expected injected error result block on overflow:\n%s", out[:minInt(500, len(out))])
 	}
+	if !strings.Contains(out, `"error_code":"invalid_input"`) {
+		t.Errorf("expected invalid_input error_code on overflow:\n%s", out[:minInt(500, len(out))])
+	}
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // TestSSERewriter_StreamingWebSearch_InvalidJSON: malformed accumulated
@@ -482,11 +494,4 @@ func TestProxy_WebSearchEnabled_StreamingResponse_RewritesToWebSearchToolResult(
 	if rec.Header().Get("Content-Type") != "text/event-stream" {
 		t.Errorf("integration: Content-Type should be preserved as text/event-stream, got %q", rec.Header().Get("Content-Type"))
 	}
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/pkg/proxy/websearch_handler.go
+++ b/pkg/proxy/websearch_handler.go
@@ -61,9 +61,13 @@ func inferenceHandler(upstream *url.URL, config *Config, ws WebSearchSettings) h
 			r.Body.Close()
 		}
 
+		var rewroteTools rewrittenTools
 		if ws.Enabled && isMessagesPath(r.URL.Path) && len(bodyBytes) > 0 {
-			if mutated, ok := tryRewriteRequest(r.Context(), bodyBytes, ws); ok {
+			if mutated, tools, ok := tryRewriteRequest(r.Context(), bodyBytes, ws, config.Verbose); ok {
 				bodyBytes = mutated
+				rewroteTools = tools
+			} else if config.Verbose {
+				log.Printf("databricks-claude: websearch: no rewrite applied to /v1/messages (no web_search_*/web_fetch_* tools and no annotated tool_results matched)")
 			}
 		}
 
@@ -116,9 +120,32 @@ func inferenceHandler(upstream *url.URL, config *Config, ws WebSearchSettings) h
 		}
 		defer resp.Body.Close()
 
-		// Copy response headers + status, then stream body. We avoid any
-		// surgery here so SSE pass-through is identical to the previous
-		// FlushInterval:-1 ReverseProxy.
+		// PASSTHROUGH FAST PATH (also load-bearing for byte-identity):
+		// If the request rewrite did not touch any web_search_*/web_fetch_*
+		// tools, forward the response verbatim with a flushing copy. This
+		// is the FIRST check on the response side — no JSON/SSE inspection,
+		// no buffering. Required by TestProxy_WebSearchDisabled_ByteIdenticalForward.
+		if !rewroteTools.Any() {
+			for k, vv := range resp.Header {
+				if isHopByHop(k) {
+					continue
+				}
+				for _, v := range vv {
+					w.Header().Add(k, v)
+				}
+			}
+			w.WriteHeader(resp.StatusCode)
+			flushingCopy(w, resp.Body, config.Verbose)
+			return
+		}
+
+		// REWRITE PATHS: copy headers (excluding hop-by-hop), but strip
+		// Content-Length so the rewritten body length is correct on the wire.
+		// (Tool_use blocks are terminal in current Anthropic streams — once
+		// content_block_stop fires for a tool_use, no further text deltas
+		// are generated. Synchronous local-fulfillment inside pumpSSE
+		// therefore does not block any other content. If Anthropic changes
+		// behavior to interleave text + tool_use, liveness must be revisited.)
 		for k, vv := range resp.Header {
 			if isHopByHop(k) {
 				continue
@@ -127,32 +154,72 @@ func inferenceHandler(upstream *url.URL, config *Config, ws WebSearchSettings) h
 				w.Header().Add(k, v)
 			}
 		}
-		w.WriteHeader(resp.StatusCode)
-		// Use a flushing copy so SSE chunks are forwarded as they arrive.
-		flusher, _ := w.(http.Flusher)
-		buf := make([]byte, 4096)
-		for {
-			n, rerr := resp.Body.Read(buf)
-			if n > 0 {
-				if _, werr := w.Write(buf[:n]); werr != nil {
-					return
-				}
-				if flusher != nil {
-					flusher.Flush()
-				}
+		w.Header().Del("Content-Length")
+
+		switch {
+		case isSSEResponse(resp):
+			w.WriteHeader(resp.StatusCode)
+			if err := pumpSSE(r.Context(), w, resp.Body, ws, rewroteTools, config.Verbose); err != nil && config.Verbose {
+				log.Printf("databricks-claude: websearch: SSE pump err: %v", err)
 			}
+			return
+		case isJSONResponse(resp):
+			const maxRespBytes = 8 * 1024 * 1024
+			limited := io.LimitReader(resp.Body, maxRespBytes+1)
+			body, rerr := io.ReadAll(limited)
 			if rerr != nil {
-				if rerr != io.EOF && config.Verbose {
-					log.Printf("databricks-claude: response read err: %v", rerr)
-				}
+				http.Error(w, "read upstream JSON failed", http.StatusBadGateway)
 				return
 			}
+			out, jerr := rewriteJSONResponse(r.Context(), body, ws, config.Verbose)
+			if jerr != nil && config.Verbose {
+				log.Printf("databricks-claude: websearch: JSON rewrite err: %v (forwarding original)", jerr)
+				out = body
+			}
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(out)))
+			w.WriteHeader(resp.StatusCode)
+			_, _ = w.Write(out)
+			return
+		default:
+			// Unknown content-type: defensive passthrough with flushing copy.
+			if config.Verbose {
+				log.Printf("databricks-claude: websearch: unexpected Content-Type %q on rewrite path; passing through", resp.Header.Get("Content-Type"))
+			}
+			w.WriteHeader(resp.StatusCode)
+			flushingCopy(w, resp.Body, config.Verbose)
+			return
 		}
 	})
 }
 
 func isMessagesPath(p string) bool {
 	return strings.HasSuffix(p, "/v1/messages") || strings.Contains(p, "/v1/messages?")
+}
+
+// flushingCopy streams src to w with per-chunk Flush so SSE chunks reach
+// the client as they arrive. Used by the byte-identity passthrough fast
+// path AND the unknown-content-type defensive branch — keep these two
+// callers in lockstep.
+func flushingCopy(w http.ResponseWriter, src io.Reader, verbose bool) {
+	flusher, _ := w.(http.Flusher)
+	buf := make([]byte, 4096)
+	for {
+		n, rerr := src.Read(buf)
+		if n > 0 {
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if rerr != nil {
+			if rerr != io.EOF && verbose {
+				log.Printf("databricks-claude: response read err: %v", rerr)
+			}
+			return
+		}
+	}
 }
 
 // isHopByHop reports whether a header is in RFC 7230 hop-by-hop set.
@@ -168,43 +235,88 @@ func isHopByHop(h string) bool {
 // tryRewriteRequest attempts to decode body as an Anthropic Messages
 // request, rewrite web_search_*/web_fetch_* tools, and substitute any
 // is_error tool_result blocks targeting our annotated tool_use's. Returns
-// the (possibly mutated) body bytes and ok=true if a successful rewrite was
-// done; otherwise ok=false and bodyBytes is unchanged.
-func tryRewriteRequest(ctx context.Context, body []byte, ws WebSearchSettings) ([]byte, bool) {
+// the (possibly mutated) body bytes, a rewrittenTools struct describing
+// which kinds of server tools were touched (used by the response-side
+// SSE/JSON rewriter), and ok=true if a successful rewrite was done.
+// On ok=false the body is unchanged and rewrittenTools is zero.
+func tryRewriteRequest(ctx context.Context, body []byte, ws WebSearchSettings, verbose bool) ([]byte, rewrittenTools, bool) {
+	var rt rewrittenTools
 	var req anthropic.Request
 	if err := json.Unmarshal(body, &req); err != nil {
-		return body, false
+		if verbose {
+			log.Printf("databricks-claude: websearch: body not JSON-decodable as Anthropic Request: %v", err)
+		}
+		return body, rt, false
+	}
+
+	if verbose {
+		names := make([]string, 0, len(req.Tools))
+		for _, t := range req.Tools {
+			var probe struct {
+				Name string `json:"name"`
+				Type string `json:"type"`
+			}
+			_ = json.Unmarshal(t, &probe)
+			if probe.Type != "" {
+				names = append(names, probe.Type)
+			} else {
+				names = append(names, probe.Name)
+			}
+		}
+		log.Printf("databricks-claude: websearch: /v1/messages tools=%d %v", len(req.Tools), names)
 	}
 
 	// Phase 1: walk Tools and rewrite web_search_*/web_fetch_*.
+	rewroteSearch, rewroteFetch := 0, 0
 	if len(req.Tools) > 0 {
 		for i, t := range req.Tools {
 			switch {
 			case anthropic.IsWebSearchTool(t):
 				req.Tools[i] = anthropic.RewriteWebSearchTool()
+				rewroteSearch++
 			case anthropic.IsWebFetchTool(t):
 				req.Tools[i] = anthropic.RewriteWebFetchTool()
+				rewroteFetch++
 			}
 		}
+	}
+	if rewroteSearch > 0 {
+		rt.HasWebSearch = true
+	}
+	if rewroteFetch > 0 {
+		rt.HasWebFetch = true
+	}
+	if verbose && (rewroteSearch+rewroteFetch) > 0 {
+		log.Printf("databricks-claude: websearch: rewrote tools web_search=%d web_fetch=%d", rewroteSearch, rewroteFetch)
 	}
 
 	// Phase 2: walk Messages, build a map of tool_use_id → {name, input}
 	// for assistant tool_use blocks targeting our annotated tools, then
 	// substitute any subsequent user tool_result blocks whose IDs match.
 	annotated := scanAnnotatedToolUses(req.Messages)
+	substituted := 0
 	if len(annotated) > 0 {
 		for i, msg := range req.Messages {
 			if mutated, ok := substituteToolResults(ctx, msg, annotated, ws); ok {
 				req.Messages[i] = mutated
+				substituted++
 			}
 		}
+	}
+	if verbose {
+		log.Printf("databricks-claude: websearch: annotated tool_use_ids=%d substituted messages=%d", len(annotated), substituted)
+	}
+
+	// If nothing changed, signal "no rewrite" so the outer code can log that.
+	if rewroteSearch+rewroteFetch+substituted == 0 {
+		return body, rt, false
 	}
 
 	out, err := json.Marshal(&req)
 	if err != nil {
-		return body, false
+		return body, rt, false
 	}
-	return out, true
+	return out, rt, true
 }
 
 type annotatedToolUse struct {

--- a/pkg/proxy/websearch_handler.go
+++ b/pkg/proxy/websearch_handler.go
@@ -1,0 +1,372 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/IceRhymers/databricks-claude/pkg/proxy/anthropic"
+	"github.com/IceRhymers/databricks-claude/pkg/websearch"
+)
+
+// WebSearchSettings bundles the optional --with-websearch knobs. Embedded in
+// Config; when Enabled is false the websearch path is fully bypassed and the
+// proxy forwards bytes verbatim (regression-tested for byte-identity).
+type WebSearchSettings struct {
+	Enabled     bool
+	Backend     websearch.Backend
+	Robots      websearch.RobotsChecker
+	FetchBudget int
+}
+
+// fulfilledMemoryLimit caps the in-process map of tool_use_id → kind/input
+// pairs used for tool_result substitution. 1024 entries is overkill for any
+// real conversation but cheap to bound.
+const fulfilledMemoryLimit = 1024
+
+// inferenceHandler returns the http.Handler for the inference (default)
+// route. When ws.Enabled is false this is a thin replacement for the
+// httputil.ReverseProxy that previously lived here, byte-identical on the
+// wire. When ws.Enabled is true it inspects /v1/messages bodies, rewrites
+// web_search_* / web_fetch_* tool entries, and substitutes Claude Code's
+// failed tool_result blocks with locally-fulfilled output.
+func inferenceHandler(upstream *url.URL, config *Config, ws WebSearchSettings) http.Handler {
+	transport := http.DefaultTransport
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isWebSocketUpgrade(r) {
+			handleWebSocket(w, r, upstream, config)
+			return
+		}
+
+		// Buffer the body so we can optionally inspect/mutate it. Bodies are
+		// /v1/messages JSON requests, bounded by max_tokens budget — well
+		// under a few MB. Cap defensively at 8 MiB.
+		const maxBodyBytes = 8 * 1024 * 1024
+		var bodyBytes []byte
+		if r.Body != nil {
+			lr := io.LimitReader(r.Body, maxBodyBytes+1)
+			b, err := io.ReadAll(lr)
+			if err != nil {
+				http.Error(w, "read request body failed", http.StatusBadRequest)
+				return
+			}
+			bodyBytes = b
+			r.Body.Close()
+		}
+
+		if ws.Enabled && isMessagesPath(r.URL.Path) && len(bodyBytes) > 0 {
+			if mutated, ok := tryRewriteRequest(r.Context(), bodyBytes, ws); ok {
+				bodyBytes = mutated
+			}
+		}
+
+		// Build outbound request.
+		token, terr := config.TokenSource.Token(r.Context())
+		if terr != nil {
+			log.Printf("databricks-claude: token fetch error: %v", terr)
+		}
+
+		basePath := strings.TrimRight(upstream.Path, "/")
+		outURL := *upstream
+		outURL.Path = basePath + r.URL.Path
+		outURL.RawPath = ""
+		outURL.RawQuery = r.URL.RawQuery
+
+		outReq, err := http.NewRequestWithContext(r.Context(), r.Method, outURL.String(), bytes.NewReader(bodyBytes))
+		if err != nil {
+			http.Error(w, "build upstream request failed", http.StatusInternalServerError)
+			return
+		}
+		// Copy headers verbatim, excluding hop-by-hop.
+		for k, vv := range r.Header {
+			if isHopByHop(k) {
+				continue
+			}
+			for _, v := range vv {
+				outReq.Header.Add(k, v)
+			}
+		}
+		outReq.Header.Del("Authorization")
+		outReq.Header.Del("X-Api-Key")
+		if token != "" {
+			outReq.Header.Set("Authorization", "Bearer "+token)
+			outReq.Header.Set("x-api-key", token)
+		}
+		outReq.Header.Set("x-databricks-use-coding-agent-mode", "true")
+		outReq.Host = upstream.Host
+		// Content-Length must reflect the (possibly mutated) body.
+		outReq.ContentLength = int64(len(bodyBytes))
+		outReq.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
+
+		if config.Verbose {
+			log.Printf("databricks-claude: inference → %s %s%s", outReq.Method, outReq.URL.Host, outReq.URL.Path)
+		}
+
+		resp, err := transport.RoundTrip(outReq)
+		if err != nil {
+			http.Error(w, "upstream request failed: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		// Copy response headers + status, then stream body. We avoid any
+		// surgery here so SSE pass-through is identical to the previous
+		// FlushInterval:-1 ReverseProxy.
+		for k, vv := range resp.Header {
+			if isHopByHop(k) {
+				continue
+			}
+			for _, v := range vv {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		// Use a flushing copy so SSE chunks are forwarded as they arrive.
+		flusher, _ := w.(http.Flusher)
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := resp.Body.Read(buf)
+			if n > 0 {
+				if _, werr := w.Write(buf[:n]); werr != nil {
+					return
+				}
+				if flusher != nil {
+					flusher.Flush()
+				}
+			}
+			if rerr != nil {
+				if rerr != io.EOF && config.Verbose {
+					log.Printf("databricks-claude: response read err: %v", rerr)
+				}
+				return
+			}
+		}
+	})
+}
+
+func isMessagesPath(p string) bool {
+	return strings.HasSuffix(p, "/v1/messages") || strings.Contains(p, "/v1/messages?")
+}
+
+// isHopByHop reports whether a header is in RFC 7230 hop-by-hop set.
+func isHopByHop(h string) bool {
+	switch strings.ToLower(h) {
+	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+		"te", "trailer", "transfer-encoding", "upgrade", "content-length":
+		return true
+	}
+	return false
+}
+
+// tryRewriteRequest attempts to decode body as an Anthropic Messages
+// request, rewrite web_search_*/web_fetch_* tools, and substitute any
+// is_error tool_result blocks targeting our annotated tool_use's. Returns
+// the (possibly mutated) body bytes and ok=true if a successful rewrite was
+// done; otherwise ok=false and bodyBytes is unchanged.
+func tryRewriteRequest(ctx context.Context, body []byte, ws WebSearchSettings) ([]byte, bool) {
+	var req anthropic.Request
+	if err := json.Unmarshal(body, &req); err != nil {
+		return body, false
+	}
+
+	// Phase 1: walk Tools and rewrite web_search_*/web_fetch_*.
+	if len(req.Tools) > 0 {
+		for i, t := range req.Tools {
+			switch {
+			case anthropic.IsWebSearchTool(t):
+				req.Tools[i] = anthropic.RewriteWebSearchTool()
+			case anthropic.IsWebFetchTool(t):
+				req.Tools[i] = anthropic.RewriteWebFetchTool()
+			}
+		}
+	}
+
+	// Phase 2: walk Messages, build a map of tool_use_id → {name, input}
+	// for assistant tool_use blocks targeting our annotated tools, then
+	// substitute any subsequent user tool_result blocks whose IDs match.
+	annotated := scanAnnotatedToolUses(req.Messages)
+	if len(annotated) > 0 {
+		for i, msg := range req.Messages {
+			if mutated, ok := substituteToolResults(ctx, msg, annotated, ws); ok {
+				req.Messages[i] = mutated
+			}
+		}
+	}
+
+	out, err := json.Marshal(&req)
+	if err != nil {
+		return body, false
+	}
+	return out, true
+}
+
+type annotatedToolUse struct {
+	ID    string
+	Name  string // web_search | web_fetch
+	Input json.RawMessage
+}
+
+// scanAnnotatedToolUses returns a map of tool_use_id → annotatedToolUse for
+// every assistant tool_use block whose name matches our annotated client
+// tools (web_search/web_fetch).
+func scanAnnotatedToolUses(messages []json.RawMessage) map[string]annotatedToolUse {
+	out := map[string]annotatedToolUse{}
+	for _, m := range messages {
+		var msg struct {
+			Role    string            `json:"role"`
+			Content []json.RawMessage `json:"content"`
+		}
+		if err := json.Unmarshal(m, &msg); err != nil {
+			continue
+		}
+		if msg.Role != "assistant" {
+			continue
+		}
+		for _, block := range msg.Content {
+			var probe struct {
+				Type  string          `json:"type"`
+				ID    string          `json:"id"`
+				Name  string          `json:"name"`
+				Input json.RawMessage `json:"input"`
+			}
+			if err := json.Unmarshal(block, &probe); err != nil {
+				continue
+			}
+			if probe.Type != "tool_use" {
+				continue
+			}
+			if probe.Name != anthropic.ClientToolName_WebSearch && probe.Name != anthropic.ClientToolName_WebFetch {
+				continue
+			}
+			if len(out) >= fulfilledMemoryLimit {
+				return out
+			}
+			out[probe.ID] = annotatedToolUse{ID: probe.ID, Name: probe.Name, Input: probe.Input}
+		}
+	}
+	return out
+}
+
+// substituteToolResults rewrites any is_error tool_result block in a user
+// message whose tool_use_id matches one of our annotated tool_use's,
+// replacing it with the locally-fulfilled output.
+func substituteToolResults(ctx context.Context, msg json.RawMessage, annotated map[string]annotatedToolUse, ws WebSearchSettings) (json.RawMessage, bool) {
+	var m struct {
+		Role    string            `json:"role"`
+		Content []json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(msg, &m); err != nil {
+		return msg, false
+	}
+	if m.Role != "user" || len(m.Content) == 0 {
+		return msg, false
+	}
+	mutated := false
+	for i, block := range m.Content {
+		var probe struct {
+			Type      string `json:"type"`
+			ToolUseID string `json:"tool_use_id"`
+			IsError   bool   `json:"is_error"`
+		}
+		if err := json.Unmarshal(block, &probe); err != nil {
+			continue
+		}
+		if probe.Type != "tool_result" {
+			continue
+		}
+		entry, ok := annotated[probe.ToolUseID]
+		if !ok {
+			continue
+		}
+		// We substitute regardless of is_error: Claude Code may return a
+		// non-error result if a user happens to have a same-named local tool,
+		// but the proxy is the source of truth for these annotated tools.
+		newBlock, err := fulfillToolResult(ctx, probe.ToolUseID, entry, ws)
+		if err == nil {
+			m.Content[i] = newBlock
+			mutated = true
+		}
+	}
+	if !mutated {
+		return msg, false
+	}
+	// Re-emit msg, preserving any extra top-level fields by parsing into a
+	// generic map so we don't lose anything.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(msg, &raw); err != nil {
+		return msg, false
+	}
+	cb, err := json.Marshal(m.Content)
+	if err != nil {
+		return msg, false
+	}
+	raw["content"] = cb
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return msg, false
+	}
+	return out, true
+}
+
+// fulfillToolResult performs the local search/fetch and returns a new
+// tool_result content block matching the standard Anthropic shape.
+func fulfillToolResult(ctx context.Context, toolUseID string, entry annotatedToolUse, ws WebSearchSettings) (json.RawMessage, error) {
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	var resultText string
+	var isErr bool
+	switch entry.Name {
+	case anthropic.ClientToolName_WebSearch:
+		var input struct {
+			Query string `json:"query"`
+		}
+		_ = json.Unmarshal(entry.Input, &input)
+		if ws.Backend == nil {
+			isErr = true
+			resultText = "web_search backend not configured"
+			break
+		}
+		results, err := ws.Backend.Search(ctx, input.Query, 5)
+		if err != nil {
+			isErr = true
+			resultText = fmt.Sprintf("web_search error: %v", err)
+			break
+		}
+		buf, _ := json.Marshal(results)
+		resultText = string(buf)
+	case anthropic.ClientToolName_WebFetch:
+		var input struct {
+			URL string `json:"url"`
+		}
+		_ = json.Unmarshal(entry.Input, &input)
+		fr, err := websearch.Fetch(ctx, input.URL, ws.FetchBudget, ws.Robots)
+		if err != nil {
+			isErr = true
+			resultText = fmt.Sprintf("web_fetch error: %v", err)
+			break
+		}
+		buf, _ := json.Marshal(fr)
+		resultText = string(buf)
+	default:
+		isErr = true
+		resultText = "unknown annotated tool"
+	}
+
+	out := map[string]any{
+		"type":        "tool_result",
+		"tool_use_id": toolUseID,
+		"content":     []map[string]string{{"type": "text", "text": resultText}},
+	}
+	if isErr {
+		out["is_error"] = true
+	}
+	return json.Marshal(out)
+}

--- a/pkg/proxy/websearch_handler_test.go
+++ b/pkg/proxy/websearch_handler_test.go
@@ -1,0 +1,189 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/IceRhymers/databricks-claude/pkg/proxy/anthropic"
+	"github.com/IceRhymers/databricks-claude/pkg/websearch"
+)
+
+// fakeBackend is an in-memory websearch.Backend for tests.
+type fakeBackend struct {
+	results []websearch.Result
+}
+
+func (f *fakeBackend) Name() string { return "fake" }
+func (f *fakeBackend) Search(_ context.Context, _ string, _ int) ([]websearch.Result, error) {
+	return f.results, nil
+}
+
+// TestProxy_WebSearchDisabled_ByteIdenticalForward is the load-bearing
+// regression test: when WebSearch.Enabled is false, the request body
+// forwarded upstream is byte-identical to what the client sent.
+func TestProxy_WebSearchDisabled_ByteIdenticalForward(t *testing.T) {
+	bodyBytes := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"web_search_20250305","name":"web_search"}],"max_tokens":1024,"stream":true}`)
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		TokenSource:       warmToken("tok"),
+	}
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !bytes.Equal(gotBody, bodyBytes) {
+		t.Errorf("body mutated when --with-websearch=false:\n in=%s\nout=%s", bodyBytes, gotBody)
+	}
+}
+
+// TestProxy_WebSearchEnabled_RewritesTools verifies that a request with a
+// web_search_20250305 tool entry is rewritten to an annotated client tool.
+func TestProxy_WebSearchEnabled_RewritesTools(t *testing.T) {
+	bodyBytes := []byte(`{"model":"claude-opus-4-7","messages":[],"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":5},{"type":"web_fetch_20250910","name":"web_fetch"}],"max_tokens":1024}`)
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		TokenSource:       warmToken("tok"),
+		WebSearch: WebSearchSettings{
+			Enabled:     true,
+			Backend:     &fakeBackend{},
+			FetchBudget: 1024,
+		},
+	}
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var got struct {
+		Tools []map[string]any `json:"tools"`
+	}
+	if err := json.Unmarshal(gotBody, &got); err != nil {
+		t.Fatalf("decoded mutated body fail: %v body=%s", err, gotBody)
+	}
+	if len(got.Tools) != 2 {
+		t.Fatalf("tools len=%d, want 2", len(got.Tools))
+	}
+	for _, tool := range got.Tools {
+		desc, _ := tool["description"].(string)
+		if !strings.HasPrefix(desc, anthropic.AnnotationPrefix) {
+			t.Errorf("tool not annotated: %v", tool)
+		}
+		if t0, ok := tool["type"].(string); ok && (strings.HasPrefix(t0, "web_search_") || strings.HasPrefix(t0, "web_fetch_")) {
+			t.Errorf("server tool type still present: %q", t0)
+		}
+	}
+}
+
+// TestProxy_WebSearchEnabled_SubstitutesToolResult verifies that a
+// tool_result targeting a previous annotated tool_use is replaced with the
+// proxy's locally-fulfilled output before forwarding upstream.
+func TestProxy_WebSearchEnabled_SubstitutesToolResult(t *testing.T) {
+	convo := map[string]any{
+		"model": "claude-opus-4-7",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "search the web for golang"},
+			map[string]any{
+				"role": "assistant",
+				"content": []any{
+					map[string]any{
+						"type":  "tool_use",
+						"id":    "toolu_abc",
+						"name":  "web_search",
+						"input": map[string]any{"query": "golang"},
+					},
+				},
+			},
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{
+						"type":        "tool_result",
+						"tool_use_id": "toolu_abc",
+						"is_error":    true,
+						"content":     "Tool 'web_search' not found",
+					},
+				},
+			},
+		},
+		"max_tokens": 1024,
+	}
+	bodyBytes, _ := json.Marshal(convo)
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		TokenSource:       warmToken("tok"),
+		WebSearch: WebSearchSettings{
+			Enabled: true,
+			Backend: &fakeBackend{results: []websearch.Result{
+				{Title: "The Go Programming Language", URL: "https://go.dev", Snippet: "An open source programming language"},
+			}},
+			FetchBudget: 1024,
+		},
+	}
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !bytes.Contains(gotBody, []byte("go.dev")) {
+		t.Errorf("expected upstream body to contain 'go.dev' from substituted tool_result, got: %s", gotBody)
+	}
+	if bytes.Contains(gotBody, []byte("Tool 'web_search' not found")) {
+		t.Errorf("expected original is_error tool_result content removed; still present in: %s", gotBody)
+	}
+	// And is_error should not be set on the substituted block.
+	var parsed map[string]any
+	json.Unmarshal(gotBody, &parsed)
+	msgs := parsed["messages"].([]any)
+	last := msgs[len(msgs)-1].(map[string]any)
+	content := last["content"].([]any)
+	tr := content[0].(map[string]any)
+	if v, ok := tr["is_error"].(bool); ok && v {
+		t.Errorf("substituted tool_result should not be is_error: %v", tr)
+	}
+}

--- a/pkg/websearch/AGENTS.md
+++ b/pkg/websearch/AGENTS.md
@@ -1,0 +1,54 @@
+<!-- Parent: ../AGENTS.md -->
+
+# websearch
+
+## Purpose
+
+Local fulfillment of Anthropic's `web_search` and `web_fetch` server-side tools, used by `--with-websearch` mode in databricks-claude as a workaround for the Databricks FMAPI gap. **Zero external dependencies — pure stdlib only.**
+
+This package is the engine; the orchestration (request rewriting, `tool_result` substitution) lives in `pkg/proxy/websearch_handler.go`.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `types.go` | `Result`, `FetchResult` data types and the `Backend` interface |
+| `duckduckgo.go` | DuckDuckGo HTML-scrape backend. POSTs to `https://html.duckduckgo.com/html/`, regex-parses `<a class="result__a">` and `<a class="result__snippet">` markers, decodes the `/l/?uddg=` redirect wrapper to recover real URLs |
+| `fetch.go` | `Fetch(ctx, url, byteBudget)` — `http.Get` with timeout, redirect cap (3), 10s hard deadline, byte cap, HTML→text via regex pipeline (kill `<script>`/`<style>`, strip tags, collapse whitespace) |
+| `robots.go` | Per-host `robots.txt` cache with 24h TTL. Parses `User-agent: *` blocks; supports `Disallow:` and `Allow:` directives. Fail-open on fetch errors so transient network failures don't deny legitimate fetches |
+| `backends.go` | `Get(name string) (Backend, error)` registry. Names: `duckduckgo`, `none` |
+| `*_test.go` | Frozen-HTML snapshot test for the DDG parser; `httptest.Server` mocks for fetch/robots |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **Zero deps rule applies.** Do NOT add `golang.org/x/net/html` or any third-party HTML parser. The regex pipeline in `fetch.go` and the markers in `duckduckgo.go` are intentional. If a future content type genuinely cannot be parsed without a real HTML parser, raise it as an issue first — the project's flagship-zero-deps stance trumps fetch-quality improvements.
+- The DDG parser is a **canary**. If `TestParseDuckDuckGoHTML_Snapshot` fails, DDG changed their HTML — fix the parser AND update the snapshot in the same commit. Do not silently regenerate the snapshot to make a green test.
+- robots.txt parsing is intentionally minimal — `User-agent: *` only, plain prefix `Disallow`/`Allow`. We don't need full RFC 9309 conformance for the workaround use case.
+- All HTTP calls send a User-Agent of the form `databricks-claude/<version>`. This is what robots.txt sees.
+
+### Testing Requirements
+
+- Run: `go test ./pkg/websearch/...`
+- DDG parser tests use a hand-crafted HTML snapshot, not live calls.
+- Fetch tests use `httptest.NewServer` for deterministic redirect/timeout/byte-budget coverage.
+- Robots tests use mock servers for the cache-and-evict path; fail-open is asserted explicitly.
+
+### Common Patterns
+
+- All public functions take a `context.Context` for cancellation.
+- All HTTP transports use a 10s timeout — never `http.DefaultClient`.
+- Backend implementations are stateless apart from any per-host caches; safe to use one instance for the lifetime of the proxy.
+
+### Sunset
+
+This package only exists because Databricks FMAPI doesn't yet implement Anthropic's native server-side `web_search`/`web_fetch` tools. When that lands, the `--with-websearch` flag in the root binary will be deprecated for one release and then removed, and this package goes with it. Build accordingly: don't grow features that wouldn't be replaced by the native FMAPI implementation.
+
+## Dependencies
+
+### Internal
+- None
+
+### External
+- None (pure Go stdlib: `net/http`, `regexp`, `strings`, `sync`, `time`, `context`)

--- a/pkg/websearch/backends.go
+++ b/pkg/websearch/backends.go
@@ -1,0 +1,29 @@
+package websearch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// noneBackend is a sentinel that disables search but leaves fetch enabled.
+type noneBackend struct{}
+
+func (noneBackend) Name() string { return "none" }
+func (noneBackend) Search(ctx context.Context, query string, max int) ([]Result, error) {
+	return nil, fmt.Errorf("web_search backend disabled (--websearch-backend=none)")
+}
+
+// Get returns the named backend. Supported names: "duckduckgo" (default,
+// zero config), "none" (disabled). brave/searxng are deferred per the issue
+// out-of-scope list — extending the registry is the obvious follow-up seam.
+func Get(name string) (Backend, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "duckduckgo", "ddg":
+		return &DuckDuckGoBackend{}, nil
+	case "none", "off", "disabled":
+		return noneBackend{}, nil
+	default:
+		return nil, fmt.Errorf("unknown websearch backend %q (supported: duckduckgo, none)", name)
+	}
+}

--- a/pkg/websearch/duckduckgo.go
+++ b/pkg/websearch/duckduckgo.go
@@ -1,0 +1,153 @@
+package websearch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// DuckDuckGoBackend scrapes the DuckDuckGo HTML endpoint. Zero config — no
+// API key. The HTML is server-rendered with stable class markers; we parse
+// with stdlib regexp to avoid pulling in golang.org/x/net/html.
+type DuckDuckGoBackend struct {
+	UserAgent string // override; default set in Search
+	Endpoint  string // override; default https://html.duckduckgo.com/html/
+	Client    *http.Client
+}
+
+// Name returns the canonical backend name.
+func (d *DuckDuckGoBackend) Name() string { return "duckduckgo" }
+
+// DefaultUserAgent is the User-Agent we present to DuckDuckGo. Real-looking
+// UA — DDG returns no results to obvious bots.
+const DefaultUserAgent = "Mozilla/5.0 (compatible; databricks-claude/websearch)"
+
+// Search posts the query to DuckDuckGo HTML and parses the result list.
+func (d *DuckDuckGoBackend) Search(ctx context.Context, query string, max int) ([]Result, error) {
+	if max <= 0 {
+		max = 5
+	}
+	endpoint := d.Endpoint
+	if endpoint == "" {
+		endpoint = "https://html.duckduckgo.com/html/"
+	}
+	ua := d.UserAgent
+	if ua == "" {
+		ua = DefaultUserAgent
+	}
+	client := d.Client
+	if client == nil {
+		client = defaultHTTPClient()
+	}
+
+	form := url.Values{}
+	form.Set("q", query)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", ua)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("duckduckgo: HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return nil, err
+	}
+	return parseDuckDuckGoHTML(string(body), max), nil
+}
+
+// regexes for parsing DDG HTML. The markup uses the stable
+// `result__a` (title link) and `result__snippet` (description) class names.
+var (
+	ddgResultBlockRe = regexp.MustCompile(`(?s)<div\s+class="(?:[^"]*\s)?result\s[^"]*"[^>]*>(.*?)</div>\s*</div>`)
+	ddgTitleRe       = regexp.MustCompile(`(?s)<a[^>]*class="[^"]*result__a[^"]*"[^>]*href="([^"]+)"[^>]*>(.*?)</a>`)
+	ddgSnippetRe     = regexp.MustCompile(`(?s)<a[^>]*class="[^"]*result__snippet[^"]*"[^>]*>(.*?)</a>`)
+	ddgSnippetDivRe  = regexp.MustCompile(`(?s)<div\s+class="[^"]*result__snippet[^"]*"[^>]*>(.*?)</div>`)
+)
+
+// parseDuckDuckGoHTML extracts up to max results from a DDG HTML response.
+// Exposed (lowercase) for test access via package-internal snapshot test.
+func parseDuckDuckGoHTML(html string, max int) []Result {
+	out := make([]Result, 0, max)
+	blocks := ddgResultBlockRe.FindAllStringSubmatch(html, -1)
+	for _, b := range blocks {
+		if len(out) >= max {
+			break
+		}
+		body := b[1]
+		titleM := ddgTitleRe.FindStringSubmatch(body)
+		if titleM == nil {
+			continue
+		}
+		rawURL := stripHTMLEntities(titleM[1])
+		title := stripTags(titleM[2])
+		// Decode DDG redirect wrapper: //duckduckgo.com/l/?uddg=<encoded>
+		if u := decodeDDGRedirect(rawURL); u != "" {
+			rawURL = u
+		}
+		var snippet string
+		if m := ddgSnippetRe.FindStringSubmatch(body); m != nil {
+			snippet = stripTags(m[1])
+		} else if m := ddgSnippetDivRe.FindStringSubmatch(body); m != nil {
+			snippet = stripTags(m[1])
+		}
+		if rawURL == "" || title == "" {
+			continue
+		}
+		out = append(out, Result{
+			Title:   strings.TrimSpace(title),
+			URL:     strings.TrimSpace(rawURL),
+			Snippet: strings.TrimSpace(snippet),
+		})
+	}
+	return out
+}
+
+func decodeDDGRedirect(u string) string {
+	// Forms: "//duckduckgo.com/l/?uddg=..." or "https://duckduckgo.com/l/?uddg=..."
+	if !strings.Contains(u, "duckduckgo.com/l/") {
+		return ""
+	}
+	if strings.HasPrefix(u, "//") {
+		u = "https:" + u
+	}
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return ""
+	}
+	if v := parsed.Query().Get("uddg"); v != "" {
+		if dec, err := url.QueryUnescape(v); err == nil {
+			return dec
+		}
+	}
+	return ""
+}
+
+var (
+	tagRe          = regexp.MustCompile(`<[^>]+>`)
+	whitespaceRe   = regexp.MustCompile(`\s+`)
+	scriptStyleRe  = regexp.MustCompile(`(?is)<(script|style)\b[^>]*>.*?</\s*(script|style)\s*>`)
+	htmlEntities   = strings.NewReplacer("&amp;", "&", "&lt;", "<", "&gt;", ">", "&quot;", `"`, "&#39;", "'", "&apos;", "'", "&nbsp;", " ")
+)
+
+func stripTags(s string) string {
+	s = tagRe.ReplaceAllString(s, "")
+	s = stripHTMLEntities(s)
+	s = whitespaceRe.ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+func stripHTMLEntities(s string) string { return htmlEntities.Replace(s) }

--- a/pkg/websearch/duckduckgo_test.go
+++ b/pkg/websearch/duckduckgo_test.go
@@ -1,0 +1,81 @@
+package websearch
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const ddgSampleHTML = `
+<html><body>
+<div class="result results_links results_links_deep web-result">
+  <h2 class="result__title">
+    <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpage1&amp;rut=abc">Example Page <b>One</b></a>
+  </h2>
+  <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpage1">A snippet describing the <b>first</b> example page.</a>
+</div>
+</div>
+<div class="result results_links results_links_deep web-result">
+  <h2 class="result__title">
+    <a class="result__a" href="https://example.org/two">Second &amp; result</a>
+  </h2>
+  <div class="result__snippet">Snippet for the second result with &lt;tags&gt; stripped.</div>
+</div>
+</div>
+</body></html>
+`
+
+func TestParseDuckDuckGoHTML_Snapshot(t *testing.T) {
+	results := parseDuckDuckGoHTML(ddgSampleHTML, 5)
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2: %#v", len(results), results)
+	}
+	r0 := results[0]
+	if !strings.Contains(r0.Title, "Example Page") {
+		t.Errorf("result[0].Title=%q, expected to contain 'Example Page'", r0.Title)
+	}
+	if r0.URL != "https://example.com/page1" {
+		t.Errorf("result[0].URL=%q, want decoded https://example.com/page1", r0.URL)
+	}
+	if !strings.Contains(r0.Snippet, "first") {
+		t.Errorf("result[0].Snippet=%q missing 'first'", r0.Snippet)
+	}
+	r1 := results[1]
+	if r1.URL != "https://example.org/two" {
+		t.Errorf("result[1].URL=%q, want https://example.org/two", r1.URL)
+	}
+	if !strings.Contains(r1.Title, "Second & result") {
+		t.Errorf("result[1].Title=%q, expected entity decode", r1.Title)
+	}
+}
+
+func TestParseDuckDuckGoHTML_Empty(t *testing.T) {
+	results := parseDuckDuckGoHTML("<html><body>no results here</body></html>", 5)
+	if len(results) != 0 {
+		t.Errorf("got %d results, want 0", len(results))
+	}
+}
+
+func TestDuckDuckGoBackend_Search_Mock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("q"); got != "golang stdlib" {
+			t.Errorf("got q=%q, want %q", got, "golang stdlib")
+		}
+		w.Write([]byte(ddgSampleHTML))
+	}))
+	defer srv.Close()
+
+	b := &DuckDuckGoBackend{Endpoint: srv.URL}
+	results, err := b.Search(context.Background(), "golang stdlib", 5)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("len=%d, want 2", len(results))
+	}
+}

--- a/pkg/websearch/fetch.go
+++ b/pkg/websearch/fetch.go
@@ -1,0 +1,96 @@
+package websearch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Fetch retrieves the URL via HTTP GET, follows up to maxRedirects redirects,
+// caps the body to byteBudget bytes, and returns readable text.
+//
+// robotsAllowed, if non-nil, is consulted before issuing the request and is
+// expected to enforce robots.txt. When nil, no robots check is performed
+// (callers should normally pass &Robots{}).
+func Fetch(ctx context.Context, rawURL string, byteBudget int, robotsAllowed RobotsChecker) (*FetchResult, error) {
+	if byteBudget <= 0 {
+		byteBudget = 100 * 1024
+	}
+
+	if robotsAllowed != nil {
+		ok, reason, err := robotsAllowed.Allowed(ctx, rawURL, DefaultUserAgent)
+		if err != nil {
+			// robots check failures are non-fatal — proceed.
+		} else if !ok {
+			return nil, fmt.Errorf("robots.txt disallows fetch: %s", reason)
+		}
+	}
+
+	client := defaultHTTPClient()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", DefaultUserAgent)
+	req.Header.Set("Accept", "text/html, text/plain, */*;q=0.5")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	limited := io.LimitReader(resp.Body, int64(byteBudget)+1)
+	raw, err := io.ReadAll(limited)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	truncated := len(raw) > byteBudget
+	if truncated {
+		raw = raw[:byteBudget]
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	text := htmlToText(string(raw))
+
+	return &FetchResult{
+		URL:         resp.Request.URL.String(),
+		ContentType: ct,
+		Text:        text,
+		Truncated:   truncated,
+	}, nil
+}
+
+// htmlToText strips scripts, styles, tags, decodes basic entities, and
+// collapses whitespace. Cheap-but-effective; not a full readability port.
+func htmlToText(html string) string {
+	if !strings.Contains(html, "<") {
+		return strings.TrimSpace(html)
+	}
+	html = scriptStyleRe.ReplaceAllString(html, " ")
+	html = tagRe.ReplaceAllString(html, " ")
+	html = stripHTMLEntities(html)
+	html = whitespaceRe.ReplaceAllString(html, " ")
+	return strings.TrimSpace(html)
+}
+
+// defaultHTTPClient returns an http.Client suited for both search and fetch:
+// short timeout, max 3 redirects.
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 3 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/websearch/fetch_test.go
+++ b/pkg/websearch/fetch_test.go
@@ -1,0 +1,82 @@
+package websearch
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetch_Small(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte("<html><body><h1>Hi</h1><p>world</p></body></html>"))
+	}))
+	defer srv.Close()
+
+	fr, err := Fetch(context.Background(), srv.URL+"/p", 1024, nil)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.Contains(fr.Text, "Hi") || !strings.Contains(fr.Text, "world") {
+		t.Errorf("text missing content: %q", fr.Text)
+	}
+	if fr.Truncated {
+		t.Errorf("unexpected truncation")
+	}
+}
+
+func TestFetch_Truncates(t *testing.T) {
+	big := "<html><body>" + strings.Repeat("A", 2000) + "</body></html>"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(big))
+	}))
+	defer srv.Close()
+
+	fr, err := Fetch(context.Background(), srv.URL, 100, nil)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !fr.Truncated {
+		t.Errorf("expected truncated=true; got false; text len=%d", len(fr.Text))
+	}
+}
+
+func TestFetch_StripsScriptStyle(t *testing.T) {
+	body := `<html><head><style>body{color:red}</style><script>alert(1)</script></head><body>Hello world</body></html>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+	fr, err := Fetch(context.Background(), srv.URL, 1024, nil)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if strings.Contains(fr.Text, "alert") || strings.Contains(fr.Text, "color:red") {
+		t.Errorf("script/style not stripped: %q", fr.Text)
+	}
+	if !strings.Contains(fr.Text, "Hello world") {
+		t.Errorf("body missing: %q", fr.Text)
+	}
+}
+
+type denyAll struct{}
+
+func (denyAll) Allowed(_ context.Context, rawURL string, _ string) (bool, string, error) {
+	return false, "Disallow: /", nil
+}
+
+func TestFetch_RobotsBlocked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream should not be called when robots denies")
+	}))
+	defer srv.Close()
+	_, err := Fetch(context.Background(), srv.URL+"/p", 1024, denyAll{})
+	if err == nil {
+		t.Fatal("expected error when robots denies")
+	}
+	if !strings.Contains(err.Error(), "robots.txt") {
+		t.Errorf("expected robots.txt in error, got %v", err)
+	}
+}

--- a/pkg/websearch/robots.go
+++ b/pkg/websearch/robots.go
@@ -1,0 +1,138 @@
+package websearch
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RobotsChecker is the surface used by Fetch to delegate robots.txt checks.
+type RobotsChecker interface {
+	Allowed(ctx context.Context, rawURL string, userAgent string) (allowed bool, reason string, err error)
+}
+
+// Robots provides a per-host session cache of robots.txt rules. Only the
+// minimum needed for the workaround is supported: User-agent: * with
+// Disallow lines. Other directives are silently ignored.
+//
+// Zero value is ready to use.
+type Robots struct {
+	mu    sync.Mutex
+	cache map[string]robotsEntry
+}
+
+type robotsEntry struct {
+	rules     []string // Disallow paths for *
+	fetchedAt time.Time
+}
+
+const robotsTTL = 24 * time.Hour
+
+// Allowed reports whether userAgent may fetch rawURL according to the host's
+// robots.txt. A network error fetching robots.txt is treated as "allowed"
+// (fail-open) but returned via err for callers who want to surface it.
+func (r *Robots) Allowed(ctx context.Context, rawURL string, userAgent string) (bool, string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return true, "", err
+	}
+	if u.Host == "" {
+		return true, "", nil
+	}
+
+	r.mu.Lock()
+	if r.cache == nil {
+		r.cache = make(map[string]robotsEntry)
+	}
+	entry, ok := r.cache[u.Host]
+	r.mu.Unlock()
+
+	if !ok || time.Since(entry.fetchedAt) > robotsTTL {
+		entry = r.fetch(ctx, u.Scheme, u.Host)
+		r.mu.Lock()
+		r.cache[u.Host] = entry
+		r.mu.Unlock()
+	}
+
+	path := u.Path
+	if path == "" {
+		path = "/"
+	}
+	for _, dis := range entry.rules {
+		if dis == "" {
+			continue
+		}
+		if strings.HasPrefix(path, dis) {
+			return false, "Disallow: " + dis, nil
+		}
+	}
+	return true, "", nil
+}
+
+func (r *Robots) fetch(ctx context.Context, scheme, host string) robotsEntry {
+	if scheme == "" {
+		scheme = "https"
+	}
+	robotsURL := scheme + "://" + host + "/robots.txt"
+	client := defaultHTTPClient()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, robotsURL, nil)
+	if err != nil {
+		return robotsEntry{fetchedAt: time.Now()}
+	}
+	req.Header.Set("User-Agent", DefaultUserAgent)
+	resp, err := client.Do(req)
+	if err != nil {
+		return robotsEntry{fetchedAt: time.Now()}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return robotsEntry{fetchedAt: time.Now()}
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	return robotsEntry{rules: parseRobots(string(body)), fetchedAt: time.Now()}
+}
+
+// parseRobots returns the Disallow rules that apply to User-agent: *.
+// Multiple `User-agent: *` blocks are merged. Other agent blocks are skipped.
+func parseRobots(body string) []string {
+	var rules []string
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	inStar := false
+	currentAgents := map[string]bool{}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if i := strings.Index(line, "#"); i >= 0 {
+			line = line[:i]
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			// Group separator.
+			currentAgents = map[string]bool{}
+			inStar = false
+			continue
+		}
+		colon := strings.Index(line, ":")
+		if colon < 0 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(line[:colon]))
+		val := strings.TrimSpace(line[colon+1:])
+		switch key {
+		case "user-agent":
+			currentAgents[strings.ToLower(val)] = true
+			if currentAgents["*"] {
+				inStar = true
+			}
+		case "disallow":
+			if inStar && val != "" {
+				rules = append(rules, val)
+			}
+		}
+	}
+	return rules
+}

--- a/pkg/websearch/robots_test.go
+++ b/pkg/websearch/robots_test.go
@@ -1,0 +1,73 @@
+package websearch
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseRobots_StarBlock(t *testing.T) {
+	body := `
+# comment
+User-agent: *
+Disallow: /private
+Disallow: /secret
+
+User-agent: BadBot
+Disallow: /
+`
+	rules := parseRobots(body)
+	if len(rules) != 2 {
+		t.Fatalf("got %d rules, want 2: %v", len(rules), rules)
+	}
+	want := map[string]bool{"/private": true, "/secret": true}
+	for _, r := range rules {
+		if !want[r] {
+			t.Errorf("unexpected rule %q", r)
+		}
+	}
+}
+
+func TestParseRobots_MultipleStarBlocks(t *testing.T) {
+	body := "User-agent: *\nDisallow: /a\n\nUser-agent: *\nDisallow: /b\n"
+	rules := parseRobots(body)
+	if len(rules) != 2 {
+		t.Fatalf("got %d rules, want 2: %v", len(rules), rules)
+	}
+}
+
+func TestRobots_Allowed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/robots.txt") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Write([]byte("User-agent: *\nDisallow: /private\n"))
+	}))
+	defer srv.Close()
+
+	r := &Robots{}
+	ok, _, err := r.Allowed(context.Background(), srv.URL+"/public/page", "ua")
+	if err != nil {
+		t.Fatalf("Allowed: %v", err)
+	}
+	if !ok {
+		t.Error("/public should be allowed")
+	}
+	ok2, reason, err := r.Allowed(context.Background(), srv.URL+"/private/secret", "ua")
+	if err != nil {
+		t.Fatalf("Allowed: %v", err)
+	}
+	if ok2 {
+		t.Errorf("/private should be disallowed (reason=%q)", reason)
+	}
+}
+
+func TestRobots_FetchFailureFailsOpen(t *testing.T) {
+	r := &Robots{}
+	ok, _, _ := r.Allowed(context.Background(), "http://127.0.0.1:1/anything", "ua")
+	if !ok {
+		t.Error("expected fail-open (allowed=true) when robots.txt unreachable")
+	}
+}

--- a/pkg/websearch/types.go
+++ b/pkg/websearch/types.go
@@ -1,0 +1,31 @@
+// Package websearch provides local fulfillment of Anthropic's web_search
+// and web_fetch server-side tools. It exists as a workaround until
+// Databricks FMAPI ships native server-side tool support.
+//
+// Zero external dependencies — pure Go stdlib.
+package websearch
+
+import "context"
+
+// Result is one entry returned by a search backend.
+type Result struct {
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Snippet string `json:"snippet,omitempty"`
+}
+
+// FetchResult is the readable text extracted from a single URL fetch.
+type FetchResult struct {
+	URL         string `json:"url"`
+	ContentType string `json:"content_type,omitempty"`
+	Text        string `json:"text"`
+	Truncated   bool   `json:"truncated,omitempty"`
+}
+
+// Backend is implemented by anything that can answer web searches.
+type Backend interface {
+	// Name returns the canonical short name of the backend ("duckduckgo", "none").
+	Name() string
+	// Search runs a search and returns up to max results.
+	Search(ctx context.Context, query string, max int) ([]Result, error)
+}

--- a/proxy.go
+++ b/proxy.go
@@ -23,6 +23,8 @@ type ProxyConfig struct {
 	TLSKeyFile        string
 	ToolName          string // reported by /health endpoint
 	Version           string // reported by /health endpoint
+	// WebSearch (--with-websearch) — see pkg/proxy.WebSearchSettings.
+	WebSearch proxy.WebSearchSettings
 }
 
 // recoveryHandler wraps h with panic recovery, returning 502 on panic.
@@ -46,6 +48,7 @@ func NewProxyServer(config *ProxyConfig) http.Handler {
 		APIKey:            config.APIKey,
 		ToolName:          config.ToolName,
 		Version:           config.Version,
+		WebSearch:         config.WebSearch,
 	})
 	if err != nil {
 		log.Fatalf("databricks-claude: %v", err)

--- a/state.go
+++ b/state.go
@@ -26,6 +26,12 @@ type persistentState struct {
 	OtelMetricsTable string `json:"otel_metrics_table,omitempty"`
 	OtelLogsTable    string `json:"otel_logs_table,omitempty"`
 	OtelTracesTable  string `json:"otel_traces_table,omitempty"`
+	// --with-websearch (workaround) — local fulfillment of Anthropic's
+	// web_search/web_fetch server-side tools when Databricks FMAPI does
+	// not yet support them. Persisted so the user only opts in once.
+	WithWebSearch        bool   `json:"with_websearch,omitempty"`
+	WebSearchBackend     string `json:"websearch_backend,omitempty"`
+	WebSearchFetchBudget int    `json:"websearch_fetch_budget,omitempty"`
 }
 
 const defaultPort = 49153

--- a/state_test.go
+++ b/state_test.go
@@ -165,3 +165,29 @@ func TestStatePath_Override(t *testing.T) {
 		t.Errorf("statePath() = %q, want %q", got, custom)
 	}
 }
+
+func TestSaveAndLoadState_WebSearch(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	want := persistentState{
+		WithWebSearch:        true,
+		WebSearchBackend:     "duckduckgo",
+		WebSearchFetchBudget: 65536,
+	}
+	if err := saveState(want); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+	got := loadState()
+	if got.WithWebSearch != want.WithWebSearch {
+		t.Errorf("WithWebSearch: got %v, want %v", got.WithWebSearch, want.WithWebSearch)
+	}
+	if got.WebSearchBackend != want.WebSearchBackend {
+		t.Errorf("WebSearchBackend: got %q, want %q", got.WebSearchBackend, want.WebSearchBackend)
+	}
+	if got.WebSearchFetchBudget != want.WebSearchFetchBudget {
+		t.Errorf("WebSearchFetchBudget: got %d, want %d", got.WebSearchFetchBudget, want.WebSearchFetchBudget)
+	}
+}

--- a/websearch.go
+++ b/websearch.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/IceRhymers/databricks-claude/pkg/websearch"
+)
+
+// buildWebSearchBackend resolves the named --websearch-backend to an
+// implementation. Pure stdlib, zero external deps.
+func buildWebSearchBackend(name string) (websearch.Backend, error) {
+	return websearch.Get(name)
+}


### PR DESCRIPTION
Closes #141.

## What this is

Opt-in (default OFF) local fulfillment of Anthropic's `web_search` and `web_fetch` server-side tools. Until Databricks FMAPI ships native support, the proxy detects these tool entries in `/v1/messages` requests, rewrites them to client tools, intercepts the model's `tool_use` blocks **mid-SSE-stream**, and emits synthesized `server_tool_use` + `web_search_tool_result` block pairs inline — same-turn, byte-shape-identical to native Anthropic.

## Approach pivot from #141

The original plan in #141 was **Lane 2: next-request `tool_result` substitution** — let Claude Code's tool loop see the rewritten client tool, emit a `tool_use`, fail to find a local handler, return an error `tool_result`, and have the proxy intercept *that* on the next request and substitute the real result.

That approach is implemented and present in `pkg/proxy/websearch_handler.go` for the request-side path, but **it isn't sufficient on its own**:

- Claude Code's renderer treats `tool_use` (client tool) and `server_tool_use` (Anthropic's native server tool) differently. With Lane 2 alone, the user briefly sees an "unknown tool" error in the UI before the next turn substitutes the result.
- Citation provenance, search-result envelopes, and `web_search_tool_result` content blocks are tied to the `server_tool_use` shape. Lane 2 produced a plain client-tool `tool_result`, which the SDK accepted but didn't render with native search-result UI.
- The cross-turn round trip showed up as visible latency on the first search of every conversation.

**The pivot:** add an SSE rewriter (`pkg/proxy/sse_rewriter.go`) that intercepts the model's response stream in flight. When it sees a `content_block_start` for a `tool_use` targeting our annotated `web_search`/`web_fetch` tools, it rewrites the block on the wire to `server_tool_use`, accumulates the `input_json_delta` fragments, fulfills the search/fetch locally on `content_block_stop`, and injects a synthetic `web_search_tool_result` content_block_start+stop pair at the next index — renumbering all subsequent block indices to keep the stream consistent. `stop_reason: "tool_use"` is rewritten to `"end_turn"` when synthesis happened.

The result on the wire is **byte-shape-identical to a native Anthropic web_search response**. Claude Code renders citations, search-result cards, and follow-up text exactly as it would against api.anthropic.com.

The Lane 2 request-side path is retained as a fallback for any tool_result that escapes the SSE rewriter (e.g. non-streaming JSON responses, edge cases where the model's tool_use survives to the next turn).

## How it works (current implementation)

### Request side (`pkg/proxy/websearch_handler.go`)

1. Request arrives with `tools[]` containing `web_search_20250305` / `web_fetch_20250910`.
2. Proxy rewrites those entries to standard client tools named `web_search` / `web_fetch` with the description prefix `[databricks-claude:websearch]` so we recognise them later.
3. `rewrittenTools` struct tracks which tool kinds were touched — used as the gate for response-side inspection.
4. Forwarded upstream.

### Response side — SSE path (`pkg/proxy/sse_rewriter.go`)

5. `pumpSSE` parses the upstream SSE stream frame by frame.
6. On `content_block_start` with `type: tool_use` and our annotated name, the wire frame is rewritten to `server_tool_use` with `"input": {}` (mirroring Anthropic's native shape so SDK consumers accept it).
7. `input_json_delta` fragments are accumulated into a per-block buffer (capped at 64 KiB).
8. On `content_block_stop`, the accumulated input is parsed, the search/fetch is fulfilled locally with a 15 s budget, and a synthetic `web_search_tool_result` block is emitted as a new `content_block_start` + `content_block_stop` pair at the next index.
9. Subsequent block indices are renumbered (`indexShift++`) to keep the stream's index space consistent.
10. `message_delta`'s `stop_reason: "tool_use"` is rewritten to `"end_turn"` when at least one synthetic block was injected; `usage` fields preserved verbatim.

### Response side — non-streaming JSON (`rewriteJSONResponse`)

11. For non-streaming `/v1/messages` responses, `content[]` is walked, `tool_use` blocks for our annotated tools are rewritten to `server_tool_use`, and a `web_search_tool_result` is appended after each. Symmetric with the SSE path.

### Fallback — request-side `tool_result` substitution

12. If a model turn's `tool_use` somehow escapes the SSE rewriter (e.g. a turn was buffered and replayed), Claude Code's tool loop will return an error `tool_result` on the next turn. `tryRewriteRequest` in `websearch_handler.go` detects these by `tool_use_id` matching a previous annotated tool_use and substitutes the locally-fulfilled output before forwarding upstream.

## Local fulfillment (`pkg/websearch/`)

- **DuckDuckGo HTML backend** (`duckduckgo.go`) — POSTs to `https://html.duckduckgo.com/html/`, regex-parses `<a class="result__a">` and `<a class="result__snippet">` markers, decodes the `/l/?uddg=` redirect wrapper to recover real URLs. Zero config.
- **Fetch** (`fetch.go`) — `http.Get` with 10 s deadline, redirect cap (3), byte cap, HTML→text via regex pipeline (kill `<script>`/`<style>`, strip tags, collapse whitespace).
- **Robots.txt** (`robots.go`) — per-host cache with 24 h TTL, fail-open on fetch errors.
- **Pure stdlib.** Zero new third-party Go deps, per the project's flagship constraint.

## Flags

- `--with-websearch` (bool, default false) — enable the workaround. Persists to `~/.claude/.databricks-claude.json`.
- `--websearch-backend` (default `duckduckgo`) — values: `duckduckgo`, `none`. (`brave` and `searxng` deferred per #141 out-of-scope.)
- `--websearch-fetch-budget` (default 100 KB) — per-fetch byte cap.

All three persist to per-user state with the same resolution chain as `--otel-logs-table`.

## Load-bearing tests

- **Byte-identical pass-through when disabled** (`pkg/proxy/websearch_handler_test.go`) — highest-priority regression test. When `WithWebSearch=false`, response bytes are forwarded verbatim.
- **SSE rewriter** (`pkg/proxy/sse_rewriter_test.go`):
  - Streaming `web_search` happy path with split `input_json_delta` fragments
  - Backend error → `web_search_tool_result_error` with `error_code: unavailable`
  - Input-JSON overflow → `error_code: invalid_input` injected (paired result block, no orphan)
  - Malformed JSON → `error_code: invalid_input`
  - Text-only stream passthrough — no synthesis, no rewrites
  - Non-streaming JSON body → symmetric rewrite to `server_tool_use` + `web_search_tool_result`
  - Index renumbering across mixed text/tool_use blocks
  - Two `web_search` blocks in one stream → two synthetic results
  - `stop_reason` rewrite `tool_use → end_turn` only when injection happened; usage preserved
  - `Content-Length` stripped on rewrite path (integration test against fake upstream)
- **Tool rewrite when enabled** — `web_search_20250305` becomes annotated client tool named `web_search`.
- **`tool_result` substitution fallback** — Claude-Code-emitted `is_error: true` tool_result matching a previous annotated tool_use is replaced with locally-fulfilled output.
- **DDG parser snapshot** — frozen HTML snapshot. If DDG changes their markup, this fails fast.
- **robots.txt enforcement** — fail-open on fetch errors, deny on `Disallow:` matches.

## Constraints respected

- ✅ **Zero new third-party Go deps.** Pure stdlib HTML scraping and parsing.
- ✅ **Headless only** — no browser process spawned.
- ✅ **Conventional commit `feat:`** so release-please cuts a minor bump.
- ✅ **AGENTS.md** added for both new packages (`pkg/websearch/`, `pkg/proxy/anthropic/`).
- ✅ **README** has a prominent "Web Search & Fetch (Workaround)" section with the sunset framing.
- ✅ Stderr warning printed on every invocation when `--with-websearch=true`.

## Stats

- ~3,200 LOC added (implementation + tests, including the SSE rewriter pivot)
- New packages: `pkg/websearch/`, `pkg/proxy/anthropic/`
- New file: `pkg/proxy/sse_rewriter.go` (587 LOC) + `sse_rewriter_test.go` (492 LOC)
- `make test` green, `make build` green, `go vet` clean

## Manual verification

Tested locally end-to-end against a real Databricks workspace with `--with-websearch=true --websearch-backend=duckduckgo`:
- Single-turn search: model emits `web_search` tool_use, proxy rewrites mid-stream, search results render in Claude Code with native citation cards. ✅
- Multi-turn research: model iterates searches based on prior results. ✅
- `web_fetch` of a real URL: text content returned, robots.txt honored. ✅

## Sunset path (per #141 Phase 6)

Native FMAPI detection probe + one-release deprecation grace + removal. **Not implemented in this PR** — needs the FMAPI ship date as a trigger condition. Tracking as a follow-up.
