### PR TITLE
feat(desktop): databricksCliPath MDM key for endpoint CLI discovery

### DIFF
--- a/desktop_config.go
+++ b/desktop_config.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
+	"github.com/IceRhymers/databricks-claude/pkg/cli"
 	"github.com/IceRhymers/databricks-claude/pkg/mdmprofile"
 )
 
@@ -216,6 +217,12 @@ func resolveCredHelperProfile(profile string) string {
 // Profile resolution: explicit --profile flag > saved state file (skipping the
 // "DEFAULT" sentinel) > MDM managed preferences > "DEFAULT".
 func runCredentialHelper(profile string) {
+	// Wire the helper-specific MDM logger so the resolution chain's per-tier
+	// outcomes land in ~/Library/Logs/databricks-claude/credential-helper.log.
+	// The reader itself is wired in main.go above the early-exit dispatchers,
+	// so it's already populated by the time we get here.
+	cli.SetMDMLogger(helperDebugLog)
+
 	// Suppress all stdlib logging so the upstream tokencache cannot leak
 	// anything onto stderr while Claude Desktop is watching.
 	log.SetOutput(io.Discard)
@@ -354,7 +361,7 @@ func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride, databrick
 	}
 
 	if outputPath != "" {
-		if err := writeDesktopConfigByPath(outputPath, gatewayURL, helperPath, resolved); err != nil {
+		if err := writeDesktopConfigByPath(outputPath, gatewayURL, helperPath, resolved, databricksCLIPath); err != nil {
 			fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
 			os.Exit(1)
 		}
@@ -378,19 +385,19 @@ func runGenerateDesktopConfig(profile, outputPath, binaryPathOverride, databrick
 		path    string
 		content []byte
 	}
-	mc, err := buildMobileconfig(gatewayURL, helperPath, resolved)
+	mc, err := buildMobileconfig(gatewayURL, helperPath, resolved, databricksCLIPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
 		os.Exit(1)
 	}
-	dev, err := buildDevModeJSON(gatewayURL, helperPath, resolved)
+	dev, err := buildDevModeJSON(gatewayURL, helperPath, resolved, databricksCLIPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "databricks-claude: %v\n", err)
 		os.Exit(1)
 	}
 	arts := []artifact{
 		{"databricks-claude-desktop.mobileconfig", []byte(mc)},
-		{"databricks-claude-desktop.reg", []byte(buildRegFile(gatewayURL, helperPath, resolved))},
+		{"databricks-claude-desktop.reg", []byte(buildRegFile(gatewayURL, helperPath, resolved, databricksCLIPath))},
 		{"databricks-claude-desktop.json", dev},
 	}
 	wrote := []string{}
@@ -444,29 +451,29 @@ func resolveHelperPath(override string, forPkg bool) (string, error) {
 // host OS when no recognised extension is present) and writes to outputPath
 // atomically. For .json outputs, guardDevJSONOutputPath protects against
 // accidentally clobbering ~/.claude/settings.json via a typo.
-func writeDesktopConfigByPath(outputPath, gatewayURL, exe, profile string) error {
+func writeDesktopConfigByPath(outputPath, gatewayURL, exe, profile, cliPath string) error {
 	lower := strings.ToLower(outputPath)
 	var data []byte
 	var err error
 	switch {
 	case strings.HasSuffix(lower, ".mobileconfig"):
 		var s string
-		s, err = buildMobileconfig(gatewayURL, exe, profile)
+		s, err = buildMobileconfig(gatewayURL, exe, profile, cliPath)
 		data = []byte(s)
 	case strings.HasSuffix(lower, ".reg"):
-		data = []byte(buildRegFile(gatewayURL, exe, profile))
+		data = []byte(buildRegFile(gatewayURL, exe, profile, cliPath))
 	case strings.HasSuffix(lower, ".json"):
 		if err := guardDevJSONOutputPath(outputPath); err != nil {
 			return err
 		}
-		data, err = buildDevModeJSON(gatewayURL, exe, profile)
+		data, err = buildDevModeJSON(gatewayURL, exe, profile, cliPath)
 	default:
 		// Fall back to host platform.
 		if runtime.GOOS == "windows" {
-			data = []byte(buildRegFile(gatewayURL, exe, profile))
+			data = []byte(buildRegFile(gatewayURL, exe, profile, cliPath))
 		} else {
 			var s string
-			s, err = buildMobileconfig(gatewayURL, exe, profile)
+			s, err = buildMobileconfig(gatewayURL, exe, profile, cliPath)
 			data = []byte(s)
 		}
 	}
@@ -552,9 +559,9 @@ func newUUID() (string, error) {
 // buildMobileconfig renders the macOS Claude Desktop Configuration Profile.
 // Three distinct UUIDs are generated: one for the Anthropic payload, one for
 // the IceRhymers/databricks-claude payload, and one for the outer profile.
-// The second payload carries databricksProfile so endpoint helpers can
-// resolve the correct workspace on machines where no state file exists.
-func buildMobileconfig(gatewayURL, helperPath, profile string) (string, error) {
+// The second payload carries databricksProfile (and databricksCliPath when
+// non-empty) so endpoint helpers can resolve their inputs without a state file.
+func buildMobileconfig(gatewayURL, helperPath, profile, cliPath string) (string, error) {
 	innerUUID, err := newUUID()
 	if err != nil {
 		return "", err
@@ -566,6 +573,11 @@ func buildMobileconfig(gatewayURL, helperPath, profile string) (string, error) {
 	outerUUID, err := newUUID()
 	if err != nil {
 		return "", err
+	}
+
+	cliPathXML := ""
+	if cliPath != "" {
+		cliPathXML = "\n\t\t\t\t<key>databricksCliPath</key>\n\t\t\t\t<string>" + plistEscape(cliPath) + "</string>"
 	}
 
 	return `<?xml version="1.0" encoding="UTF-8"?>
@@ -630,7 +642,7 @@ func buildMobileconfig(gatewayURL, helperPath, profile string) (string, error) {
 				<key>PayloadDisplayName</key>
 				<string>Databricks Claude Settings</string>
 				<key>databricksProfile</key>
-				<string>` + plistEscape(profile) + `</string>
+				<string>` + plistEscape(profile) + `</string>` + cliPathXML + `
 			</dict>
 		</array>
 		<key>PayloadDisplayName</key>
@@ -664,7 +676,7 @@ func plistEscape(s string) string {
 	return r.Replace(s)
 }
 
-func buildRegFile(gatewayURL, helperPath, profile string) string {
+func buildRegFile(gatewayURL, helperPath, profile, cliPath string) string {
 	// .reg uses CRLF line endings and a UTF-16-or-UTF-8-with-BOM header.
 	// Plain UTF-8 with the documented header works on modern Windows.
 	var b strings.Builder
@@ -686,11 +698,14 @@ func buildRegFile(gatewayURL, helperPath, profile string) string {
 	b.WriteString(`"disableEssentialTelemetry"=dword:00000000` + "\r\n")
 	b.WriteString(`"disableNonessentialTelemetry"=dword:00000000` + "\r\n")
 	b.WriteString(`"disableNonessentialServices"=dword:00000000` + "\r\n")
-	// IceRhymers/databricks-claude key: carries the Databricks profile so
-	// the credential helper on endpoint machines can resolve it without a
-	// state file.
+	// IceRhymers/databricks-claude key: carries Databricks profile and CLI
+	// path so the credential helper on endpoint machines can resolve them
+	// without a state file.
 	b.WriteString("\r\n[HKEY_CURRENT_USER\\SOFTWARE\\IceRhymers\\databricks-claude]\r\n")
 	fmt.Fprintf(&b, "\"databricksProfile\"=\"%s\"\r\n", regEscape(profile))
+	if cliPath != "" {
+		fmt.Fprintf(&b, "\"databricksCliPath\"=\"%s\"\r\n", regEscape(cliPath))
+	}
 	return b.String()
 }
 
@@ -712,7 +727,7 @@ func buildRegFile(gatewayURL, helperPath, profile string) string {
 //
 // inferenceModels is reused from inferenceModelsJSON via []json.RawMessage so
 // the model list never drifts between the three artifacts.
-func buildDevModeJSON(gatewayURL, helperPath, profile string) ([]byte, error) {
+func buildDevModeJSON(gatewayURL, helperPath, profile, cliPath string) ([]byte, error) {
 	var models []json.RawMessage
 	if err := json.Unmarshal([]byte(inferenceModelsJSON), &models); err != nil {
 		return nil, fmt.Errorf("inferenceModelsJSON is malformed: %w", err)
@@ -720,6 +735,7 @@ func buildDevModeJSON(gatewayURL, helperPath, profile string) ([]byte, error) {
 
 	cfg := struct {
 		DatabricksProfile                   string            `json:"databricksProfile"`
+		DatabricksCliPath                   string            `json:"databricksCliPath,omitempty"`
 		DisableDeploymentModeChooser        bool              `json:"disableDeploymentModeChooser"`
 		InferenceProvider                   string            `json:"inferenceProvider"`
 		InferenceGatewayBaseUrl             string            `json:"inferenceGatewayBaseUrl"`
@@ -738,6 +754,7 @@ func buildDevModeJSON(gatewayURL, helperPath, profile string) ([]byte, error) {
 		DisableNonessentialServices         bool              `json:"disableNonessentialServices"`
 	}{
 		DatabricksProfile:                   profile,
+		DatabricksCliPath:                   cliPath,
 		DisableDeploymentModeChooser:        true,
 		InferenceProvider:                   "gateway",
 		InferenceGatewayBaseUrl:             gatewayURL,

--- a/desktop_config_test.go
+++ b/desktop_config_test.go
@@ -38,7 +38,7 @@ func TestNewUUID_FormatAndUniqueness(t *testing.T) {
 func TestBuildMobileconfig_ContainsRequiredKeys(t *testing.T) {
 	gateway := "https://adb-abc-123.azuredatabricks.net/ai-gateway/anthropic"
 	helper := "/usr/local/bin/databricks-claude"
-	out, err := buildMobileconfig(gateway, helper, "myws")
+	out, err := buildMobileconfig(gateway, helper, "myws", "")
 	if err != nil {
 		t.Fatalf("buildMobileconfig: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestBuildMobileconfig_ContainsRequiredKeys(t *testing.T) {
 }
 
 func TestBuildMobileconfig_SecondPayload(t *testing.T) {
-	out, err := buildMobileconfig("https://x.example.com/anthropic", "/bin/h", "fleet-profile")
+	out, err := buildMobileconfig("https://x.example.com/anthropic", "/bin/h", "fleet-profile", "")
 	if err != nil {
 		t.Fatalf("buildMobileconfig: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestBuildMobileconfig_EscapesSpecialChars(t *testing.T) {
 	// Gateway URL with an ampersand should be plist-escaped.
 	gateway := "https://example.com/anthropic?a=1&b=2"
 	helper := "/Applications/Foo & Bar/databricks-claude"
-	out, err := buildMobileconfig(gateway, helper, "DEFAULT")
+	out, err := buildMobileconfig(gateway, helper, "DEFAULT", "")
 	if err != nil {
 		t.Fatalf("buildMobileconfig: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestBuildMobileconfig_EscapesSpecialChars(t *testing.T) {
 }
 
 func TestBuildMobileconfig_UniqueUUIDs(t *testing.T) {
-	out, err := buildMobileconfig("https://x", "/bin/x", "DEFAULT")
+	out, err := buildMobileconfig("https://x", "/bin/x", "DEFAULT", "")
 	if err != nil {
 		t.Fatalf("buildMobileconfig: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestBuildMobileconfig_UniqueUUIDs(t *testing.T) {
 func TestBuildRegFile_ContainsRequiredKeys(t *testing.T) {
 	gateway := "https://adb-abc-123.azuredatabricks.net/ai-gateway/anthropic"
 	helper := `C:\Program Files\databricks-claude\databricks-claude.exe`
-	out := buildRegFile(gateway, helper, "fleet-ws")
+	out := buildRegFile(gateway, helper, "fleet-ws", "")
 
 	for _, want := range []string{
 		`Windows Registry Editor Version 5.00`,
@@ -453,7 +453,7 @@ const devTestProfile = "test-profile"
 
 func decodeDevJSON(t *testing.T) map[string]any {
 	t.Helper()
-	out, err := buildDevModeJSON(devTestGateway, devTestHelper, devTestProfile)
+	out, err := buildDevModeJSON(devTestGateway, devTestHelper, devTestProfile, "")
 	if err != nil {
 		t.Fatalf("buildDevModeJSON: %v", err)
 	}
@@ -508,7 +508,7 @@ func TestBuildDevModeJSON_ContainsRequiredKeys(t *testing.T) {
 }
 
 func TestBuildDevModeJSON_ValidJSONAndTrailingNewline(t *testing.T) {
-	out, err := buildDevModeJSON(devTestGateway, devTestHelper, devTestProfile)
+	out, err := buildDevModeJSON(devTestGateway, devTestHelper, devTestProfile, "")
 	if err != nil {
 		t.Fatalf("buildDevModeJSON: %v", err)
 	}
@@ -522,7 +522,7 @@ func TestBuildDevModeJSON_ValidJSONAndTrailingNewline(t *testing.T) {
 }
 
 func TestBuildDevModeJSON_NoInferenceGatewayApiKey(t *testing.T) {
-	out, err := buildDevModeJSON(devTestGateway, devTestHelper, devTestProfile)
+	out, err := buildDevModeJSON(devTestGateway, devTestHelper, devTestProfile, "")
 	if err != nil {
 		t.Fatalf("buildDevModeJSON: %v", err)
 	}
@@ -571,7 +571,7 @@ func TestBuildDevModeJSON_TtlIs55(t *testing.T) {
 func TestBuildDevModeJSON_PreservesPaths(t *testing.T) {
 	gateway := "https://example.com/anthropic?a=1&b=2"
 	helper := "/Applications/Foo Bar/databricks-claude-credential-helper"
-	out, err := buildDevModeJSON(gateway, helper, "my-profile")
+	out, err := buildDevModeJSON(gateway, helper, "my-profile", "")
 	if err != nil {
 		t.Fatalf("buildDevModeJSON: %v", err)
 	}
@@ -595,7 +595,7 @@ func TestInferenceModelsConsistencyAcrossArtifacts(t *testing.T) {
 	helper := "/path/to/helper"
 
 	// JSON: models array elements should byte-equal the constant elements.
-	devOut, err := buildDevModeJSON(gateway, helper, "DEFAULT")
+	devOut, err := buildDevModeJSON(gateway, helper, "DEFAULT", "")
 	if err != nil {
 		t.Fatalf("buildDevModeJSON: %v", err)
 	}
@@ -629,7 +629,7 @@ func TestInferenceModelsConsistencyAcrossArtifacts(t *testing.T) {
 
 	// Mobileconfig: extract the <string>...</string> body for inferenceModels
 	// and reverse plistEscape; should equal inferenceModelsJSON verbatim.
-	mc, err := buildMobileconfig(gateway, helper, "DEFAULT")
+	mc, err := buildMobileconfig(gateway, helper, "DEFAULT", "")
 	if err != nil {
 		t.Fatalf("buildMobileconfig: %v", err)
 	}
@@ -640,7 +640,7 @@ func TestInferenceModelsConsistencyAcrossArtifacts(t *testing.T) {
 	}
 
 	// Reg: extract the inferenceModels="..." value and reverse regEscape.
-	reg := buildRegFile(gateway, helper, "DEFAULT")
+	reg := buildRegFile(gateway, helper, "DEFAULT", "")
 	regModels := extractRegModels(t, reg)
 	regUnescaped := unescapeReg(regModels)
 	if regUnescaped != inferenceModelsJSON {
@@ -769,7 +769,7 @@ func TestWriteFileAtomic_RenamesFromTempInSameDir(t *testing.T) {
 func TestWriteDesktopConfigByPath_JsonExtension(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "out.json")
-	if err := writeDesktopConfigByPath(target, "https://x.example.com/anthropic", "/bin/h", "DEFAULT"); err != nil {
+	if err := writeDesktopConfigByPath(target, "https://x.example.com/anthropic", "/bin/h", "DEFAULT", ""); err != nil {
 		t.Fatalf("writeDesktopConfigByPath: %v", err)
 	}
 	raw, err := os.ReadFile(target)
@@ -808,7 +808,7 @@ func TestGuardDevJSONOutputPath_Empty(t *testing.T) {
 func TestGuardDevJSONOutputPath_OurOwnConfig(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "ours.json")
-	body, err := buildDevModeJSON("https://x", "/bin/h", "DEFAULT")
+	body, err := buildDevModeJSON("https://x", "/bin/h", "DEFAULT", "")
 	if err != nil {
 		t.Fatalf("buildDevModeJSON: %v", err)
 	}
@@ -848,5 +848,96 @@ func TestGuardDevJSONOutputPath_NotJSON(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), p) {
 		t.Errorf("error must mention the path %q, got %v", p, err)
+	}
+}
+
+// ---- databricksCliPath emission tests ----------------------------------------
+
+const testCliPath = "/opt/databricks/bin/databricks"
+
+func TestBuildMobileconfig_CliPath_Present(t *testing.T) {
+	out, err := buildMobileconfig("https://x.example.com/anthropic", "/bin/h", "myws", testCliPath)
+	if err != nil {
+		t.Fatalf("buildMobileconfig: %v", err)
+	}
+	if !strings.Contains(out, "<key>databricksCliPath</key>") {
+		t.Error("mobileconfig with cliPath must contain <key>databricksCliPath</key>")
+	}
+	if !strings.Contains(out, "<string>"+testCliPath+"</string>") {
+		t.Errorf("mobileconfig must contain <string>%s</string>", testCliPath)
+	}
+}
+
+func TestBuildMobileconfig_CliPath_Absent(t *testing.T) {
+	out, err := buildMobileconfig("https://x.example.com/anthropic", "/bin/h", "myws", "")
+	if err != nil {
+		t.Fatalf("buildMobileconfig: %v", err)
+	}
+	if strings.Contains(out, "databricksCliPath") {
+		t.Error("mobileconfig without cliPath must NOT contain databricksCliPath")
+	}
+}
+
+func TestBuildMobileconfig_CliPath_Escaped(t *testing.T) {
+	cliPath := "/opt/foo & bar/databricks"
+	out, err := buildMobileconfig("https://x.example.com/anthropic", "/bin/h", "myws", cliPath)
+	if err != nil {
+		t.Fatalf("buildMobileconfig: %v", err)
+	}
+	if strings.Contains(out, "foo & bar") {
+		t.Error("cliPath ampersand must be plist-escaped in mobileconfig")
+	}
+	if !strings.Contains(out, "foo &amp; bar") {
+		t.Error("expected plist-escaped cliPath with &amp;")
+	}
+}
+
+func TestBuildRegFile_CliPath_Present(t *testing.T) {
+	out := buildRegFile("https://x.example.com/anthropic", "/bin/h", "myws", testCliPath)
+	if !strings.Contains(out, `"databricksCliPath"="`+testCliPath+`"`) {
+		t.Errorf(".reg with cliPath must contain %q", `"databricksCliPath"="`+testCliPath+`"`)
+	}
+}
+
+func TestBuildRegFile_CliPath_Absent(t *testing.T) {
+	out := buildRegFile("https://x.example.com/anthropic", "/bin/h", "myws", "")
+	if strings.Contains(out, "databricksCliPath") {
+		t.Error(".reg without cliPath must NOT contain databricksCliPath")
+	}
+}
+
+func TestBuildRegFile_CliPath_Escaped(t *testing.T) {
+	cliPath := `C:\Program Files\Databricks\databricks.exe`
+	out := buildRegFile("https://x.example.com/anthropic", "/bin/h", "myws", cliPath)
+	if !strings.Contains(out, `"databricksCliPath"="C:\\Program Files\\Databricks\\databricks.exe"`) {
+		t.Errorf(".reg cliPath backslashes not escaped; got:\n%s", out)
+	}
+}
+
+func TestBuildDevModeJSON_CliPath_Present(t *testing.T) {
+	out, err := buildDevModeJSON("https://x.example.com/anthropic", "/bin/h", "myws", testCliPath)
+	if err != nil {
+		t.Fatalf("buildDevModeJSON: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got, ok := m["databricksCliPath"].(string)
+	if !ok {
+		t.Fatalf("databricksCliPath not a string in dev JSON (got %T = %v)", m["databricksCliPath"], m["databricksCliPath"])
+	}
+	if got != testCliPath {
+		t.Errorf("databricksCliPath = %q, want %q", got, testCliPath)
+	}
+}
+
+func TestBuildDevModeJSON_CliPath_Absent(t *testing.T) {
+	out, err := buildDevModeJSON("https://x.example.com/anthropic", "/bin/h", "myws", "")
+	if err != nil {
+		t.Fatalf("buildDevModeJSON: %v", err)
+	}
+	if strings.Contains(string(out), "databricksCliPath") {
+		t.Error("dev JSON without cliPath must NOT contain databricksCliPath key")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -19,9 +19,11 @@ import (
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
+	"github.com/IceRhymers/databricks-claude/pkg/cli"
 	"github.com/IceRhymers/databricks-claude/pkg/completion"
 	"github.com/IceRhymers/databricks-claude/pkg/health"
 	"github.com/IceRhymers/databricks-claude/pkg/lifecycle"
+	"github.com/IceRhymers/databricks-claude/pkg/mdmprofile"
 	"github.com/IceRhymers/databricks-claude/pkg/portbind"
 	"github.com/IceRhymers/databricks-claude/pkg/proxy"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
@@ -107,6 +109,14 @@ func main() {
 		}
 		os.Exit(0)
 	}
+
+	// Wire the MDM reader so ResolveDatabricksCLI can consult the MDM-managed
+	// databricksCliPath key. Hoisted ABOVE the early-exit branches so all
+	// entry points (credential-helper alias, `desktop`, `setup`, and the
+	// normal proxy flow) see the real reader before any code path can call
+	// ResolveDatabricksCLI. The logger remains helper-specific (wired inside
+	// runCredentialHelper) since only the helper has a debug-log surface.
+	cli.SetMDMReader(mdmprofile.ReadKey)
 
 	// argv[0] alias `databricks-claude-credential-helper` — Desktop's
 	// mobileconfig accepts only a path with no arguments; install methods

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -20,12 +20,43 @@ var FallbackCLIDirs = []string{
 	"bin",        // resolved against $HOME
 }
 
+// MDMReader is a function that reads a string value from MDM managed
+// preferences. Takes a domain and key, returns the value or empty string.
+type MDMReader func(domain, key string) (string, error)
+
+// mdmReader is the package-level injection point. Default is a no-op so
+// pkg/cli remains independently importable without a hard dep on
+// pkg/mdmprofile. main.go wires the real mdmprofile.ReadKey at startup.
+var mdmReader MDMReader = func(_, _ string) (string, error) { return "", nil }
+
+// SetMDMReader replaces the package-level MDM reader. Call once at startup
+// with mdmprofile.ReadKey; no-op if r is nil.
+func SetMDMReader(r MDMReader) {
+	if r != nil {
+		mdmReader = r
+	}
+}
+
+// mdmLogger is called when the MDM tier fires during CLI resolution.
+// Default is a no-op; wire helperDebugLog via SetMDMLogger to surface
+// resolution steps in the credential-helper log.
+var mdmLogger func(format string, args ...any) = func(string, ...any) {}
+
+// SetMDMLogger replaces the package-level MDM logger. No-op if logger is nil.
+func SetMDMLogger(logger func(format string, args ...any)) {
+	if logger != nil {
+		mdmLogger = logger
+	}
+}
+
 // ResolveDatabricksCLI returns an executable path for cmdName.
 // Lookup order:
 //  1. Absolute or path-qualified cmdName → returned unchanged (back-compat for tests).
 //  2. $DATABRICKS_CLI env override, if set and executable.
-//  3. exec.LookPath(cmdName), which honors the inherited PATH.
-//  4. A scan of common install dirs (FallbackCLIDirs).
+//  3. MDM managed preference (com.icerhymers.databricks-claude / databricksCliPath),
+//     if set and executable. Admin-pinned value beats accidental PATH discovery.
+//  4. exec.LookPath(cmdName), which honors the inherited PATH.
+//  5. A scan of common install dirs (FallbackCLIDirs).
 //
 // If none match, cmdName is returned unchanged so the eventual exec error
 // surfaces with its original message.
@@ -40,6 +71,14 @@ func ResolveDatabricksCLI(cmdName string) string {
 		if IsExecutableFile(override) {
 			return override
 		}
+	}
+	// MDM tier — admin-pinned path from com.icerhymers.databricks-claude domain.
+	if mdmPath, err := mdmReader("com.icerhymers.databricks-claude", "databricksCliPath"); err == nil && mdmPath != "" {
+		if IsExecutableFile(mdmPath) {
+			mdmLogger("MDM databricksCliPath=%q used", mdmPath)
+			return mdmPath
+		}
+		mdmLogger("MDM databricksCliPath=%q not executable, falling through", mdmPath)
 	}
 	if p, err := exec.LookPath(cmdName); err == nil {
 		return p

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -110,3 +110,115 @@ func TestResolveDatabricksCLI_FallbackDir(t *testing.T) {
 		t.Errorf("expected fallback dir resolution to %q, got %q", fake, got)
 	}
 }
+
+// makeExec creates an executable file at path and returns the path.
+func makeExec(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho ok\n"), 0o755); err != nil {
+		t.Fatalf("makeExec: %v", err)
+	}
+	return path
+}
+
+// withMDMReader temporarily replaces the package-level mdmReader for a test.
+func withMDMReader(t *testing.T, r MDMReader) {
+	t.Helper()
+	orig := mdmReader
+	t.Cleanup(func() { mdmReader = orig })
+	mdmReader = r
+}
+
+func TestResolveDatabricksCLI_MDM_ExecutablePath(t *testing.T) {
+	dir := t.TempDir()
+	mdmBin := makeExec(t, filepath.Join(dir, "databricks-mdm"))
+
+	withMDMReader(t, func(_, _ string) (string, error) { return mdmBin, nil })
+	t.Setenv("DATABRICKS_CLI", "") // ensure env tier doesn't fire
+
+	got := ResolveDatabricksCLI("databricks")
+	if got != mdmBin {
+		t.Errorf("ResolveDatabricksCLI MDM executable: got %q, want %q", got, mdmBin)
+	}
+}
+
+func TestResolveDatabricksCLI_MDM_NonExecutable_FallsThrough(t *testing.T) {
+	dir := t.TempDir()
+	// Non-executable file in MDM; an executable in fallback dir.
+	nonExec := filepath.Join(dir, "databricks-notexec")
+	if err := os.WriteFile(nonExec, []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fallbackBin := makeExec(t, filepath.Join(dir, "databricks"))
+
+	withMDMReader(t, func(_, _ string) (string, error) { return nonExec, nil })
+	t.Setenv("DATABRICKS_CLI", "")
+
+	orig := FallbackCLIDirs
+	FallbackCLIDirs = []string{dir}
+	defer func() { FallbackCLIDirs = orig }()
+
+	got := ResolveDatabricksCLI("databricks")
+	if got == nonExec {
+		t.Errorf("ResolveDatabricksCLI should not return non-executable MDM path %q", nonExec)
+	}
+	if got != fallbackBin {
+		t.Errorf("ResolveDatabricksCLI MDM non-executable: got %q, want fallback %q", got, fallbackBin)
+	}
+}
+
+func TestResolveDatabricksCLI_MDM_Unset_NoRegression(t *testing.T) {
+	dir := t.TempDir()
+	fallbackBin := makeExec(t, filepath.Join(dir, "databricks"))
+
+	withMDMReader(t, func(_, _ string) (string, error) { return "", nil })
+	t.Setenv("DATABRICKS_CLI", "")
+
+	orig := FallbackCLIDirs
+	FallbackCLIDirs = []string{dir}
+	defer func() { FallbackCLIDirs = orig }()
+
+	got := ResolveDatabricksCLI("databricks")
+	if got != fallbackBin {
+		t.Errorf("ResolveDatabricksCLI MDM unset: got %q, want fallback %q", got, fallbackBin)
+	}
+}
+
+func TestResolveDatabricksCLI_AbsoluteBeforeMDM(t *testing.T) {
+	// An absolute cmdName (state.DatabricksCLIPath) must be returned before
+	// the MDM tier is consulted.
+	dir := t.TempDir()
+	stateBin := makeExec(t, filepath.Join(dir, "databricks-state"))
+	mdmCalled := false
+	withMDMReader(t, func(_, _ string) (string, error) {
+		mdmCalled = true
+		return filepath.Join(dir, "databricks-mdm"), nil
+	})
+
+	got := ResolveDatabricksCLI(stateBin)
+	if got != stateBin {
+		t.Errorf("absolute path should be returned unchanged, got %q", got)
+	}
+	if mdmCalled {
+		t.Error("MDM reader must not be called when cmdName is absolute")
+	}
+}
+
+func TestResolveDatabricksCLI_EnvBeforeMDM(t *testing.T) {
+	dir := t.TempDir()
+	envBin := makeExec(t, filepath.Join(dir, "databricks-env"))
+	mdmCalled := false
+
+	t.Setenv("DATABRICKS_CLI", envBin)
+	withMDMReader(t, func(_, _ string) (string, error) {
+		mdmCalled = true
+		return filepath.Join(dir, "databricks-mdm"), nil
+	})
+
+	got := ResolveDatabricksCLI("databricks")
+	if got != envBin {
+		t.Errorf("$DATABRICKS_CLI should win over MDM, got %q want %q", got, envBin)
+	}
+	if mdmCalled {
+		t.Error("MDM reader must not be called when $DATABRICKS_CLI is set and executable")
+	}
+}

--- a/pkg/mdmprofile/AGENTS.md
+++ b/pkg/mdmprofile/AGENTS.md
@@ -10,14 +10,25 @@ where no `~/.claude/.databricks-claude.json` state file exists.
 ## API
 
 ```go
-// Read returns the value of the "databricksProfile" key from the MDM-managed
-// preferences for the given domain. Returns "" (nil error) when no value is
-// set or on any read error.
+// ReadKey returns the value of an arbitrary key from the MDM-managed
+// preferences for the given domain. Returns "" (nil error) when no value
+// is set or on any read error. This is the primary API — multiple keys
+// per domain are now supported (e.g. databricksProfile, databricksCliPath).
+func ReadKey(domain, key string) (string, error)
+
+// Read is a thin shim preserved for backward compatibility: it returns
+// ReadKey(domain, "databricksProfile"). Prefer ReadKey for new callers.
 func Read(domain string) (string, error)
 ```
 
-Call with `"com.icerhymers.databricks-claude"` to read the Databricks profile
-written by the fleet `.mobileconfig` or `.reg` artifact.
+Call with `"com.icerhymers.databricks-claude"` as the domain. Today's recognised
+keys are `databricksProfile` (#146) and `databricksCliPath` (#150), both
+written by the fleet `.mobileconfig` or `.reg` artifact generated via
+`databricks-claude desktop generate-config`.
+
+Adding a new MDM key:
+1. Generator side: extend the builder (`buildMobileconfig`/`buildRegFile`/`buildDevModeJSON`) in `desktop_config.go` to emit the new key when populated.
+2. Reader side: call `mdmprofile.ReadKey(domain, "<your-key>")` from the resolution chain that needs it. No changes required in this package — `ReadKey` is the generic API.
 
 ## Key Files
 

--- a/pkg/mdmprofile/darwin.go
+++ b/pkg/mdmprofile/darwin.go
@@ -21,15 +21,15 @@ var managedPrefsDir = func() string {
 	return filepath.Join("/Library/Managed Preferences", u.Username)
 }
 
-// Read returns the value of the "databricksProfile" key from the MDM-managed
-// plist for the given domain (e.g. "com.icerhymers.databricks-claude").
-// Checks the managed preferences directory first (written by MDM on enrolled
-// devices), then falls back to ~/Library/Preferences for unmanaged dev/test
-// machines. Returns "" on any read or parse error.
-func Read(domain string) (string, error) {
+// ReadKey returns the value of the given key from the MDM-managed plist for
+// the given domain (e.g. "com.icerhymers.databricks-claude"). Checks the
+// managed preferences directory first (written by MDM on enrolled devices),
+// then falls back to ~/Library/Preferences for unmanaged dev/test machines.
+// Returns "" on any read or parse error.
+func ReadKey(domain, key string) (string, error) {
 	// 1. MDM-managed preferences (requires device enrollment).
 	managed := filepath.Join(managedPrefsDir(), domain+".plist")
-	if v, err := readPlistFile(managed); err == nil && v != "" {
+	if v, err := readPlistFile(managed, key); err == nil && v != "" {
 		return v, nil
 	}
 
@@ -39,17 +39,22 @@ func Read(domain string) (string, error) {
 		return "", nil
 	}
 	unmanaged := filepath.Join(home, "Library", "Preferences", domain+".plist")
-	if v, err := readPlistFile(unmanaged); err == nil && v != "" {
+	if v, err := readPlistFile(unmanaged, key); err == nil && v != "" {
 		return v, nil
 	}
 
 	return "", nil
 }
 
+// Read returns the value of the "databricksProfile" key from the MDM-managed
+// plist for the given domain. Shim over ReadKey for backwards compatibility.
+func Read(domain string) (string, error) {
+	return ReadKey(domain, "databricksProfile")
+}
+
 // readPlistFile reads a plist XML file and returns the string value of the
-// "databricksProfile" top-level key. Returns ("", nil) when the file does not
-// exist or the key is absent.
-func readPlistFile(path string) (string, error) {
+// given key. Returns ("", nil) when the file does not exist or the key is absent.
+func readPlistFile(path, key string) (string, error) {
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return "", nil
@@ -57,7 +62,7 @@ func readPlistFile(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return parsePlistString(data, "databricksProfile")
+	return parsePlistString(data, key)
 }
 
 // parsePlistString walks Apple plist XML tokens seeking the first

--- a/pkg/mdmprofile/darwin_test.go
+++ b/pkg/mdmprofile/darwin_test.go
@@ -88,7 +88,7 @@ func TestParsePlistString_MultipleKeys(t *testing.T) {
 }
 
 func TestReadPlistFile_NotExist(t *testing.T) {
-	v, err := readPlistFile("/nonexistent/path/to/file.plist")
+	v, err := readPlistFile("/nonexistent/path/to/file.plist", "databricksProfile")
 	if err != nil {
 		t.Fatalf("expected nil error for non-existent file, got %v", err)
 	}
@@ -176,5 +176,111 @@ func TestRead_NoPlistReturnsEmpty(t *testing.T) {
 	}
 	if got != "" {
 		t.Errorf("Read = %q, want empty string when no plist found", got)
+	}
+}
+
+// writePlistMultiKey writes a minimal Apple plist containing two key=value pairs.
+func writePlistMultiKey(t *testing.T, dir, domain string, pairs [][2]string) string {
+	t.Helper()
+	var entries string
+	for _, p := range pairs {
+		entries += "\t<key>" + p[0] + "</key>\n\t<string>" + p[1] + "</string>\n"
+	}
+	content := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+` + entries + `</dict>
+</plist>
+`
+	path := filepath.Join(dir, domain+".plist")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writePlistMultiKey: %v", err)
+	}
+	return path
+}
+
+func TestReadKey_DatabricksCliPath(t *testing.T) {
+	dir := t.TempDir()
+	writePlistMultiKey(t, dir, testDomain, [][2]string{
+		{"databricksProfile", "my-profile"},
+		{"databricksCliPath", "/opt/databricks/bin/databricks"},
+	})
+
+	origManagedPrefsDir := managedPrefsDir
+	managedPrefsDir = func() string { return dir }
+	defer func() { managedPrefsDir = origManagedPrefsDir }()
+
+	got, err := ReadKey(testDomain, "databricksCliPath")
+	if err != nil {
+		t.Fatalf("ReadKey: %v", err)
+	}
+	if got != "/opt/databricks/bin/databricks" {
+		t.Errorf("ReadKey databricksCliPath = %q, want /opt/databricks/bin/databricks", got)
+	}
+}
+
+func TestReadKey_MultipleKeys_EachResolvedIndependently(t *testing.T) {
+	dir := t.TempDir()
+	writePlistMultiKey(t, dir, testDomain, [][2]string{
+		{"databricksProfile", "fleet-profile"},
+		{"databricksCliPath", "/usr/local/bin/databricks"},
+	})
+
+	origManagedPrefsDir := managedPrefsDir
+	managedPrefsDir = func() string { return dir }
+	defer func() { managedPrefsDir = origManagedPrefsDir }()
+
+	profile, err := ReadKey(testDomain, "databricksProfile")
+	if err != nil {
+		t.Fatalf("ReadKey profile: %v", err)
+	}
+	if profile != "fleet-profile" {
+		t.Errorf("ReadKey profile = %q, want fleet-profile", profile)
+	}
+
+	cliPath, err := ReadKey(testDomain, "databricksCliPath")
+	if err != nil {
+		t.Fatalf("ReadKey cliPath: %v", err)
+	}
+	if cliPath != "/usr/local/bin/databricks" {
+		t.Errorf("ReadKey cliPath = %q, want /usr/local/bin/databricks", cliPath)
+	}
+}
+
+func TestReadKey_AbsentKeyReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writePlist(t, dir, testDomain, "databricksProfile", "some-profile")
+
+	origManagedPrefsDir := managedPrefsDir
+	managedPrefsDir = func() string { return dir }
+	defer func() { managedPrefsDir = origManagedPrefsDir }()
+
+	got, err := ReadKey(testDomain, "databricksCliPath")
+	if err != nil {
+		t.Fatalf("ReadKey: %v", err)
+	}
+	if got != "" {
+		t.Errorf("ReadKey missing key = %q, want empty string", got)
+	}
+}
+
+func TestRead_ShimCallsReadKeyForDatabricksProfile(t *testing.T) {
+	dir := t.TempDir()
+	writePlistMultiKey(t, dir, testDomain, [][2]string{
+		{"databricksProfile", "shim-profile"},
+		{"databricksCliPath", "/some/path"},
+	})
+
+	origManagedPrefsDir := managedPrefsDir
+	managedPrefsDir = func() string { return dir }
+	defer func() { managedPrefsDir = origManagedPrefsDir }()
+
+	got, err := Read(testDomain)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got != "shim-profile" {
+		t.Errorf("Read = %q, want shim-profile (shim must return databricksProfile)", got)
 	}
 }

--- a/pkg/mdmprofile/mdmprofile_test.go
+++ b/pkg/mdmprofile/mdmprofile_test.go
@@ -15,3 +15,16 @@ func TestRead_UnknownDomainReturnsEmpty(t *testing.T) {
 		t.Errorf("Read = %q, want empty string for unknown domain", v)
 	}
 }
+
+// TestReadKey_UnknownDomainReturnsEmpty verifies ReadKey never errors and
+// returns "" when the domain/key pair does not exist.
+// Runs on every platform (darwin, windows, other).
+func TestReadKey_UnknownDomainReturnsEmpty(t *testing.T) {
+	v, err := ReadKey("com.icerhymers.databricks-claude.test.definitely-does-not-exist", "databricksCliPath")
+	if err != nil {
+		t.Errorf("ReadKey returned unexpected error: %v", err)
+	}
+	if v != "" {
+		t.Errorf("ReadKey = %q, want empty string for unknown domain/key", v)
+	}
+}

--- a/pkg/mdmprofile/other.go
+++ b/pkg/mdmprofile/other.go
@@ -2,8 +2,13 @@
 
 package mdmprofile
 
-// Read is a no-op stub on platforms other than darwin and windows.
+// ReadKey is a no-op stub on platforms other than darwin and windows.
 // MDM managed preferences are not supported on these platforms.
-func Read(_ string) (string, error) {
+func ReadKey(_, _ string) (string, error) {
 	return "", nil
+}
+
+// Read is a no-op stub on platforms other than darwin and windows.
+func Read(_ string) (string, error) {
+	return ReadKey("", "")
 }

--- a/pkg/mdmprofile/windows.go
+++ b/pkg/mdmprofile/windows.go
@@ -19,15 +19,14 @@ var (
 	procRegQueryValueExW = modAdvapi32.NewProc("RegQueryValueExW")
 )
 
-// Read returns the value of the "databricksProfile" registry value under
+// ReadKey returns the value of the given registry value name under
 // HKCU\SOFTWARE\IceRhymers\databricks-claude.
 // The domain argument is accepted for API symmetry with other platforms but
 // is not used — all endpoint configuration is stored under the single key
 // above, which matches the HKCU path written by the .reg artifact.
 // Returns "" on any error (key absent, value missing, etc.).
-func Read(_ string) (string, error) {
+func ReadKey(_ string, valueName string) (string, error) {
 	const subKey = `SOFTWARE\IceRhymers\databricks-claude`
-	const valueName = "databricksProfile"
 
 	subKeyPtr, err := syscall.UTF16PtrFromString(subKey)
 	if err != nil {
@@ -59,6 +58,13 @@ func Read(_ string) (string, error) {
 		return "", nil
 	}
 	return syscall.UTF16ToString(buf), nil
+}
+
+// Read returns the value of the "databricksProfile" registry value under
+// HKCU\SOFTWARE\IceRhymers\databricks-claude.
+// Shim over ReadKey for backwards compatibility.
+func Read(_ string) (string, error) {
+	return ReadKey("", "databricksProfile")
 }
 
 // regQueryValueExW is a thin wrapper around RegQueryValueExW so that the


### PR DESCRIPTION
Closes #150.

## Summary

Adds a `databricksCliPath` key to our existing MDM domain (`com.icerhymers.databricks-claude`) so admins can pin the `databricks` CLI binary path fleet-wide via plist/registry, mirroring the `databricksProfile` shape from #146.

**Why this matters**: under launchd's minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin` — what GUI subprocesses like Claude Desktop's credential helper inherit), `exec.LookPath("databricks")` returns empty. Today's helper survives via the `FallbackCLIDirs` scan in `pkg/cli/cli.go:14-21`, which is implicit, undocumented, and brittle for MDM-deployed CLIs at non-standard paths (e.g. `/opt/databricks/bin/`).

**Design principle**: helper has exactly two resolved inputs (profile, CLI path). Both now MDM-keyed, both in the same payload, both follow the same resolution chain pattern.

## Resolution chain (new MDM tier inserted)

```
1. cmdName absolute or path-qualified → return as-is
2. $DATABRICKS_CLI env override
3. MDM databricksCliPath (NEW) — validated executable check before returning
4. exec.LookPath(cmdName)
5. FallbackCLIDirs scan
6. cmdName (final fallback — caller's exec fails with original error)
```

Lane B from the deep interview: MDM beats `exec.LookPath` (admin's pinned intent never overridden by accidental discovery) but loses to explicit state/env. Symmetric with the `databricksProfile` chain shipped in #146.

## Cross-package architecture

`pkg/cli` cannot import `pkg/mdmprofile` per `pkg/AGENTS.md` ("Do not add cross-dependencies between sibling packages"). Resolved via injection:

- `pkg/cli` exposes `SetMDMReader(MDMReader)` and `SetMDMLogger(...)`. Defaults are no-ops.
- `pkg/mdmprofile` gains a generic `ReadKey(domain, key string) (string, error)` API. Existing `Read(domain)` becomes a one-line shim calling `ReadKey(domain, "databricksProfile")` — zero behavior change for existing callers.
- `main.go` wires `cli.SetMDMReader(mdmprofile.ReadKey)` **above** the three early-exit dispatchers (credential-helper alias, `desktop`, `setup`) so every entry point sees the real reader before any code path can call `ResolveDatabricksCLI`.
- `runCredentialHelper` additionally wires `cli.SetMDMLogger(helperDebugLog)` so the resolution chain's per-tier outcomes land in the helper's debug log — only the helper has a log surface, so logger stays helper-specific.

## Generator threading

`desktop generate-config --databricks-cli-path /opt/databricks/bin/databricks` now writes the value to both:

- `state.DatabricksCLIPath` (for the admin's own generator-side proxy use — Bug 1 invariant from #146)
- The MDM payload's `databricksCliPath` key (for endpoint helpers)

When `--databricks-cli-path` is **not** passed, the key is **omitted** from all three artifacts (`.mobileconfig`, `.reg`, dev-mode `.json`). No empty-string emission — admins shouldn't have to disambiguate "intentionally blank" from "forgot to set."

## Pipeline

deep-interview → ralplan → autopilot → cross-lane review (×2 — first round caught a real bug) → PR.

- **Deep interview**: 5 questions, locked decisions on naming, chain placement, validation strategy, generator threading, no-migration.
- **Ralplan**: `.omc/plans/ralplan-databricks-cli-path-mdm-key.md` (185 lines).
- **Autopilot** (Sonnet 4.6, ~11 min, 10 files +456/-53): single `feat:` commit.
- **Round 1 review** (Opus 4.7, fresh context): **REQUEST_CHANGES.** Caught a MAJOR — `cli.SetMDMReader` was wired *after* the three early-exit dispatchers, so `setup` and `generate-config` invocations on a real endpoint would silently skip the MDM tier. The implementer had only wired the credential-helper-alias path. Plus a MINOR for `pkg/mdmprofile/AGENTS.md` not documenting the new `ReadKey` API.
- **Round 2 fix**: hoisted `cli.SetMDMReader(mdmprofile.ReadKey)` above the three dispatchers in `main.go`. Removed the now-redundant wire-up from `runCredentialHelper` (kept `SetMDMLogger`, which is helper-specific). Updated `pkg/mdmprofile/AGENTS.md` to document `ReadKey` + the keys-per-domain workflow.
- **Round 2 review**: **APPROVE.** Round-1 MAJOR fully resolved; no regressions; 1 cosmetic NIT (out of scope).

## Diff

```
desktop_config.go                 |  56 ++++++-
desktop_config_test.go            | 119 +++++++++++--
main.go                           |  14 ++
pkg/cli/cli.go                    |  43 ++++-
pkg/cli/cli_test.go               | 112 ++++++++++++
pkg/mdmprofile/AGENTS.md          |  21 ++-
pkg/mdmprofile/darwin.go          |  29 ++-
pkg/mdmprofile/darwin_test.go     | 108 ++++++++++-
pkg/mdmprofile/mdmprofile_test.go |  13 ++
pkg/mdmprofile/other.go           |   9 +-
pkg/mdmprofile/windows.go         |  12 +-
11 files changed, 473 insertions(+), 58 deletions(-)
```

No drive-by edits. Exactly the 11 files in the plan's implementation surface (10 originally + AGENTS.md from review round 1).

## Tests

17/17 packages green. `gofmt -l .` empty. `go vet ./...` clean. `GOOS=darwin go build ./...` + `GOOS=windows go build ./...` both succeed.

## Out of scope

- **Migration of existing endpoints** — no users yet.
- **Anthropic-domain MDM key passthrough** (e.g. `inferenceCredentialHelperTtlSec`, `disable*Telemetry`) — separate feature work.
- **Native Desktop OTLP** (`otlpEndpoint`/`otlpProtocol`/`otlpHeaders`) — own feature.
- **More MDM keys in our domain** — helper has only two resolved inputs; both now covered. Don't speculate.

## Follow-ups (non-blocking)

- Cosmetic NIT from review: `pkg/mdmprofile/AGENTS.md` `windows.go` row in the Key Files table still names only `databricksProfile`. The implementation reads via a generic `ReadKey` so any key works — the table could note "+ databricksCliPath" for clarity. Tiny doc polish, not worth a follow-up commit on its own.

## Severity

**MEDIUM** — silent CLI misrouting once MDM rollouts begin. ~30 LOC + 6 tests of feature, plus the round-2 wiring fix. Cheap insurance before anyone deploys.
