### PR TITLE
feat(hooks): daemon-aware no-op behavior when serve is running

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/headless"
+	"github.com/IceRhymers/databricks-claude/pkg/health"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
 )
 
@@ -32,6 +33,11 @@ func headlessEnsure(port int) {
 func headlessRelease(port int) {
 	if os.Getenv("DATABRICKS_CLAUDE_MANAGED") == "1" {
 		log.Printf("databricks-claude: --headless-release: skipped (managed session)")
+		return
+	}
+
+	if mode, _ := health.ProxyMode(port, "http"); mode == "daemon" {
+		log.Printf("databricks-claude: --headless-release: managed by daemon, hook is no-op")
 		return
 	}
 

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -90,5 +91,59 @@ func TestRefcountPathForPort(t *testing.T) {
 	got := refcount.PathForPort(".databricks-claude-sessions", 12345)
 	if got != want {
 		t.Errorf("PathForPort(..., 12345) = %q, want %q", got, want)
+	}
+}
+
+// TestHeadlessRelease_DaemonSkipsShutdown verifies that when the proxy is
+// running in daemon mode, headlessRelease does not POST /shutdown.
+func TestHeadlessRelease_DaemonSkipsShutdown(t *testing.T) {
+	shutdownCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"daemon":true}`)
+		case "/shutdown":
+			shutdownCalled = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	headlessRelease(port)
+
+	if shutdownCalled {
+		t.Error("/shutdown was called in daemon mode; headlessRelease must be a no-op when daemon is running")
+	}
+}
+
+// TestHeadlessRelease_EphemeralPostsShutdown verifies that when the proxy is
+// running in ephemeral mode, headlessRelease POSTs /shutdown as expected.
+func TestHeadlessRelease_EphemeralPostsShutdown(t *testing.T) {
+	shutdownCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"daemon":false}`)
+		case "/shutdown":
+			if r.Method == http.MethodPost {
+				shutdownCalled = true
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	headlessRelease(port)
+
+	if !shutdownCalled {
+		t.Error("/shutdown was not called in ephemeral mode; headlessRelease must POST /shutdown for non-daemon proxy")
 	}
 }

--- a/pkg/headless/headless.go
+++ b/pkg/headless/headless.go
@@ -59,6 +59,14 @@ func Ensure(cfg Config) error {
 		return nil
 	}
 
+	// Short-circuit before touching refcount: when the serve daemon is running it
+	// manages its own lifecycle — this hook must be a no-op to avoid phantom
+	// refcount entries that would prevent the daemon from running indefinitely.
+	if mode, _ := health.ProxyMode(cfg.Port, cfg.Scheme); mode == "daemon" {
+		log.Printf("%s: --headless-ensure: managed by daemon, hook is no-op", cfg.LogPrefix)
+		return nil
+	}
+
 	// Acquire refcount FIRST so every ensure/release pair is symmetric.
 	if cfg.RefcountPath != "" {
 		if err := refcount.Acquire(cfg.RefcountPath); err != nil {

--- a/pkg/headless/headless_test.go
+++ b/pkg/headless/headless_test.go
@@ -1,11 +1,15 @@
 package headless
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
+
+	"github.com/IceRhymers/databricks-claude/pkg/refcount"
 )
 
 func TestEnsure_ManagedSessionSkips(t *testing.T) {
@@ -55,6 +59,71 @@ func TestEnsure_BadBinaryReturnsError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected non-nil error when binary does not exist, got nil")
+	}
+}
+
+// TestEnsure_DaemonModeNoOp verifies that when the proxy answers /health with
+// daemon:true, Ensure returns nil immediately without acquiring the refcount.
+func TestEnsure_DaemonModeNoOp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"daemon":true}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	rcPath := refcount.PathForPort(".databricks-claude-sessions-headlesstest", port)
+	os.Remove(rcPath)
+	t.Cleanup(func() { os.Remove(rcPath) })
+
+	if err := Ensure(Config{
+		Port:         port,
+		Scheme:       "http",
+		LogPrefix:    "test",
+		RefcountPath: rcPath,
+	}); err != nil {
+		t.Fatalf("Ensure in daemon mode returned error: %v", err)
+	}
+
+	if _, err := os.Stat(rcPath); !os.IsNotExist(err) {
+		t.Error("refcount file was created in daemon mode; Ensure must not touch refcount when daemon is running")
+	}
+}
+
+// TestEnsure_EphemeralAcquiresRefcount verifies that when the proxy answers
+// /health with daemon:false, Ensure follows the normal path and acquires the
+// refcount before returning.
+func TestEnsure_EphemeralAcquiresRefcount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"daemon":false}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	rcPath := refcount.PathForPort(".databricks-claude-sessions-headlesstest", port)
+	os.Remove(rcPath)
+	t.Cleanup(func() { os.Remove(rcPath) })
+
+	if err := Ensure(Config{
+		Port:         port,
+		Scheme:       "http",
+		LogPrefix:    "test",
+		RefcountPath: rcPath,
+	}); err != nil {
+		t.Fatalf("Ensure in ephemeral mode returned error: %v", err)
+	}
+
+	if _, err := os.Stat(rcPath); os.IsNotExist(err) {
+		t.Error("refcount file was not created in ephemeral mode; Ensure must acquire refcount for non-daemon proxy")
 	}
 }
 

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -4,6 +4,7 @@ package health
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -25,4 +26,40 @@ func ProxyHealthy(port int, scheme string) bool {
 	}
 	resp.Body.Close()
 	return resp.StatusCode == http.StatusOK
+}
+
+// ProxyMode probes the /health endpoint and reports the proxy's deployment mode.
+// Returns "daemon" when the proxy is up and running as a long-lived daemon (serve
+// subcommand), "ephemeral" when it is up but not in daemon mode, or "" with
+// healthy=false when the endpoint is unreachable or returns non-200.
+//
+// Callers should short-circuit hook logic when mode == "daemon": the daemon
+// manages its own lifecycle and neither refcount acquisition nor /shutdown POSTs
+// are appropriate.
+func ProxyMode(port int, scheme string) (mode string, healthy bool) {
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	if scheme == "https" {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+	resp, err := client.Get(fmt.Sprintf("%s://127.0.0.1:%d/health", scheme, port))
+	if err != nil {
+		return "", false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+	var body struct {
+		Daemon bool `json:"daemon"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		// 200 but unparseable body — treat as ephemeral (not a daemon).
+		return "ephemeral", true
+	}
+	if body.Daemon {
+		return "daemon", true
+	}
+	return "ephemeral", true
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -63,5 +64,91 @@ func TestProxyHealthy_SchemeMismatch(t *testing.T) {
 	port := srv.Listener.Addr().(*net.TCPAddr).Port
 	if ProxyHealthy(port, "https") {
 		t.Error("expected ProxyHealthy to return false for HTTP server checked with https scheme")
+	}
+}
+
+func TestProxyMode_DaemonTrue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"daemon":true}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	mode, healthy := ProxyMode(port, "http")
+	if mode != "daemon" || !healthy {
+		t.Errorf("ProxyMode = (%q, %v), want (\"daemon\", true)", mode, healthy)
+	}
+}
+
+func TestProxyMode_DaemonFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"daemon":false}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	mode, healthy := ProxyMode(port, "http")
+	if mode != "ephemeral" || !healthy {
+		t.Errorf("ProxyMode = (%q, %v), want (\"ephemeral\", true)", mode, healthy)
+	}
+}
+
+func TestProxyMode_DaemonMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"tool":"databricks-claude","version":"1.0.0"}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	mode, healthy := ProxyMode(port, "http")
+	if mode != "ephemeral" || !healthy {
+		t.Errorf("ProxyMode = (%q, %v), want (\"ephemeral\", true)", mode, healthy)
+	}
+}
+
+func TestProxyMode_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "not json {{{")
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	mode, healthy := ProxyMode(port, "http")
+	if mode != "ephemeral" || !healthy {
+		t.Errorf("ProxyMode = (%q, %v), want (\"ephemeral\", true)", mode, healthy)
+	}
+}
+
+func TestProxyMode_Unreachable(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	mode, healthy := ProxyMode(port, "http")
+	if mode != "" || healthy {
+		t.Errorf("ProxyMode = (%q, %v), want (\"\", false)", mode, healthy)
 	}
 }


### PR DESCRIPTION
## Summary

Implements #154 — when `databricks-claude serve` (the daemon from #156) is running, the existing `--headless-ensure` and `--headless-release` hook entry points short-circuit to side-effect-free no-ops. When no daemon is present, behavior is byte-identical to today.

This closes the coexistence story: hooks and daemon can both be configured without fighting for port 49153 or mutating refcount state behind each other's back.

## Mechanism

New `pkg/health.ProxyMode(port, scheme) → "daemon" | "ephemeral" | ""` consults the existing `/health` endpoint and parses the JSON body's `daemon: true` field (added in #156). Hooks call it first and return early when mode == `"daemon"`.

- **`pkg/headless.Ensure`** — daemon check goes BEFORE `refcount.Acquire`, so the refcount file is never touched in daemon mode.
- **`hooks.go:headlessRelease`** — daemon check goes BEFORE the POST to `/shutdown`, so no upstream request is made.

## Pipeline

Implemented via OMC: autopilot (44 turns, 5.2 min, $1.14) → cross-lane review round 1 (**APPROVE** with two non-blocking nits) → push + PR.

Round-1 review verified:
- Daemon short-circuit precedes `refcount.Acquire` in `Ensure` (the central ordering invariant)
- Byte-identical no-daemon path (both modified functions are pure prefix-adds)
- Test fidelity — daemon-mode tests assert refcount file is not created; ephemeral tests assert it IS created. Counter-tests guard against over-aggressive short-circuit.
- Mixed-version safety — old hook + new daemon → old hook POSTs `/shutdown` → daemon returns 404 (explicit handler from #153), refcount never decremented but daemon ignores refcount entirely. Safe degradation.

## Non-blocking nits from review (deferred)

- **MINOR:** Warm-ephemeral path now makes two health probes (`ProxyMode` returns healthy, then `ProxyHealthy` runs again). Adds ~1ms. Worth threading the `healthy` bool through in a future cleanup.
- **NIT:** New tests use `refcount.PathForPort(".databricks-claude-sessions-headlesstest", port)` (home-relative) instead of `t.TempDir()`. Cleanup is registered. Cosmetic.

## Acceptance criteria from #154

- [x] With `databricks-claude serve` running, `databricks-claude --headless-ensure` returns immediately, refcount file unchanged
- [x] With `databricks-claude serve` running, `databricks-claude --headless-release` returns immediately, no `/shutdown` POST occurs
- [x] Without daemon, both entry points behave exactly as today (existing test suite passes unchanged)
- [x] Hook completes in <200ms when daemon is up (500ms timeout on probe, ~1ms in practice)
- [x] No new docs surfaces required (hook behavior is internal)

Refs #154
