### PR TITLE
docs(serve): add Using serve with Claude Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,39 @@ databricks-claude serve uninstall
 
 > **Linux user-session note:** `systemd --user` services run inside your login session. If you log out, the daemon stops — it restarts automatically on your next login. This is correct behavior for interactive per-user deployments. If you want the daemon to survive all logouts, run `loginctl enable-linger` first (requires your admin's approval on managed devices). This is not done automatically.
 
+### Using `serve` with Claude Code
+
+Once you've installed the daemon (`serve install`), Claude Code still needs to know to talk to it. Rather than hand-editing `~/.claude/settings.json` and getting model names wrong as Databricks ships new ones, **let the wrapper bootstrap your settings once**:
+
+```bash
+# 1. One-time: bootstrap settings.json with the right env block
+#    (proxy URL, fake auth token, Databricks model routing, custom headers).
+databricks-claude --headless
+#    Wait for: PROXY_URL=http://127.0.0.1:49153
+#    Then stop it (Ctrl+C).
+
+# 2. Start the daemon as a service (or run `serve` directly).
+databricks-claude serve install
+```
+
+`claude` will now route through whichever instance is listening on `127.0.0.1:49153` — the daemon, in this case.
+
+**Why bootstrap via `--headless` instead of hand-editing `settings.json`?**
+
+The wrapper writes more than `ANTHROPIC_BASE_URL` on first run. It also writes Databricks-specific model routing (`ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL`), the `x-databricks-use-coding-agent-mode` custom header, and the experimental-betas flag — and the model names are versioned (`databricks-claude-opus-4-7`, etc.), so they change over time. Letting the wrapper write them keeps you in sync with whatever the current shipping binary thinks is correct. Hand-edits get stale.
+
+These env keys persist after `--headless` exits — they're written via the bootstrap path (`ensureConfig`), not the per-session lifecycle (which restores). So one `--headless` run is genuinely one-time setup.
+
+**Notes:**
+
+- **The daemon does NOT mutate `~/.claude/settings.json`.** That's the whole point of the daemon vs. the per-session CLI wrapper — it lives outside the per-tool lifecycle. The one-time `--headless` bootstrap above is the wrapper doing its first-run setup; subsequent daemon restarts do not touch your settings.
+- **Re-bootstrap when model names drift.** If you upgrade `databricks-claude` and the project ships new default model names, re-run `databricks-claude --headless` once to refresh them. The bootstrap is idempotent and only writes keys that differ.
+- **OTEL tables persist to state.** Run `databricks-claude serve --otel-metrics-table foo --otel-logs-table bar` once; the daemon (or its installed service) picks them up from `~/.claude/.databricks-claude.json` on every restart thereafter.
+- **Don't run the CLI wrapper (`databricks-claude claude …`) at the same time as the daemon for the same workspace.** Pick one deployment mode per workspace; mixing both means two proxies fighting over the same port and settings block.
+- **Hooks coexist cleanly.** If you've also installed SessionStart hooks (`databricks-claude --install-hooks`), they probe the daemon's `/health` and no-op when it's running, falling back to per-session proxy only if the daemon is down.
+
+To stop using the daemon, run `databricks-claude serve uninstall` and remove the `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` lines from `~/.claude/settings.json` (or delete the whole `env` block if you don't use Claude Code anymore).
+
 ## Headless Mode
 
 `--headless` starts the proxy without launching a `claude` child process, for use by IDE extensions and external tooling.


### PR DESCRIPTION
Closes Path A of #157 — the docs-only half of "one-time Claude Code setup for the serve daemon."

## What

New README subsection under `## serve Subcommand` → `### Using \`serve\` with Claude Code`, immediately after `### Installing as a background service`.

**Approach: bootstrap via `--headless`, don't recommend hand-edits.**

```bash
# 1. One-time: bootstrap settings.json with the right env block.
databricks-claude --headless
#    Wait for: PROXY_URL=http://127.0.0.1:49153
#    Then stop it (Ctrl+C).

# 2. Start the daemon as a service.
databricks-claude serve install
```

## Why `--headless`, not a JSON snippet

The wrapper's first-run setup writes more than `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`. From `main.go:738-746`, the `needsFullSetup` path also writes:

- `ANTHROPIC_MODEL` = `databricks-claude-opus-4-7`
- `ANTHROPIC_DEFAULT_OPUS_MODEL` = `databricks-claude-opus-4-7`
- `ANTHROPIC_DEFAULT_SONNET_MODEL` = `databricks-claude-sonnet-4-6`
- `ANTHROPIC_DEFAULT_HAIKU_MODEL` = `databricks-claude-haiku-4-5`
- `ANTHROPIC_CUSTOM_HEADERS` = `x-databricks-use-coding-agent-mode: true`
- `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` = `1`

The model names are versioned (`-opus-4-7`, etc.) and drift as Databricks ships new models — a copy-paste JSON snippet in the README would go stale every release. Bootstrapping via the binary itself keeps the user in sync with whatever the current shipping wrapper thinks is correct. Hand-edits are a footgun.

`ensureConfig` (the bootstrap write path) does NOT restore on exit — those keys persist after `--headless` is stopped. So one `--headless` run is genuinely one-time setup, then the daemon takes over.

## Notes covered in the new section

- Daemon does not mutate `settings.json` (the `--headless` bootstrap is the wrapper doing its first-run setup, not the daemon).
- Re-bootstrap with `--headless` after upgrades to refresh model names.
- OTEL flag persistence (set once, omit on subsequent restarts).
- Mode-mixing guidance (don't run the CLI wrapper concurrently with the daemon).
- Hooks coexistence (daemon-aware hooks no-op when serve is up).

## Why this PR (Path A) and not the helper subcommand (Path B)

Issue #157 explicitly offers "docs only" as a valid resolution path. Path B (`serve setup-claude-code` idempotent patcher) is the right long-term answer but needs a lifecycle-invariant call locked in first (B1 top-level sentinel key vs. B2 state-file sentinel listing skip-keys). That's a design discussion, not autopilot fodder, and it shouldn't gate getting users unstuck today.

After this lands, #157 can either close (if Path A is sufficient) or stay open scoped to Path B only.

## Acceptance criteria from #157 (Path A)

- [x] README has a top-level subsection under `## serve Subcommand` titled "Using serve with Claude Code"
- [x] Provides the path to a correct `env` block in `~/.claude/settings.json` — via the wrapper's own bootstrap rather than a copy-paste snippet (model names drift)
- [x] Mentions OTEL flags persist to state on first invocation (set once, omit thereafter)
- [x] Mentions the daemon does NOT mutate settings.json by design

## Out of scope

- Path B helper subcommand (separate PR, separate design discussion).
- Auto-detecting the running daemon's port.

Refs #157