### PR TITLE
feat(cli): --write-claude-config flag for scriptable settings.json bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,9 +517,7 @@ Once you've installed the daemon (`serve install`), Claude Code still needs to k
 ```bash
 # 1. One-time: bootstrap settings.json with the right env block
 #    (proxy URL, fake auth token, Databricks model routing, custom headers).
-databricks-claude --headless
-#    Wait for: PROXY_URL=http://127.0.0.1:49153
-#    Then stop it (Ctrl+C).
+databricks-claude --write-claude-config
 
 # 2. Start the daemon as a service (or run `serve` directly).
 databricks-claude serve install
@@ -527,16 +525,29 @@ databricks-claude serve install
 
 `claude` will now route through whichever instance is listening on `127.0.0.1:49153` — the daemon, in this case.
 
-**Why bootstrap via `--headless` instead of hand-editing `settings.json`?**
+Optional: pair with `--profile`, `--port`, or `--with-websearch` if you use a non-default workspace or want local web-search/web-fetch fulfillment:
+
+```bash
+databricks-claude --write-claude-config --profile my-workspace --port 49153
+
+# Enable local web_search/web_fetch fulfillment in the daemon:
+databricks-claude --write-claude-config --with-websearch
+```
+
+`--with-websearch` (and its sibling `--websearch-backend`/`--websearch-fetch-budget` knobs) persists to `~/.claude/.databricks-claude.json` so the daemon picks it up on its next start. Without this, the daemon serves stock Anthropic web-tool requests, which Databricks FMAPI does not currently support — `claude` would then fail web searches even though the proxy is otherwise healthy.
+
+**Why bootstrap via `--write-claude-config` instead of hand-editing `settings.json`?**
 
 The wrapper writes more than `ANTHROPIC_BASE_URL` on first run. It also writes Databricks-specific model routing (`ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL`), the `x-databricks-use-coding-agent-mode` custom header, and the experimental-betas flag — and the model names are versioned (`databricks-claude-opus-4-7`, etc.), so they change over time. Letting the wrapper write them keeps you in sync with whatever the current shipping binary thinks is correct. Hand-edits get stale.
 
-These env keys persist after `--headless` exits — they're written via the bootstrap path (`ensureConfig`), not the per-session lifecycle (which restores). So one `--headless` run is genuinely one-time setup.
+The write is idempotent — `ensureConfig` short-circuits when the env block already matches.
+
+**Fallback (if `--write-claude-config` is unavailable):** Use `databricks-claude --headless`, wait for `PROXY_URL=http://127.0.0.1:49153`, then stop it (Ctrl+C). This works but binds the proxy port unnecessarily — use `--write-claude-config` instead.
 
 **Notes:**
 
-- **The daemon does NOT mutate `~/.claude/settings.json`.** That's the whole point of the daemon vs. the per-session CLI wrapper — it lives outside the per-tool lifecycle. The one-time `--headless` bootstrap above is the wrapper doing its first-run setup; subsequent daemon restarts do not touch your settings.
-- **Re-bootstrap when model names drift.** If you upgrade `databricks-claude` and the project ships new default model names, re-run `databricks-claude --headless` once to refresh them. The bootstrap is idempotent and only writes keys that differ.
+- **The daemon does NOT mutate `~/.claude/settings.json`.** That's the whole point of the daemon vs. the per-session CLI wrapper — it lives outside the per-tool lifecycle. The one-time `--write-claude-config` bootstrap above is the wrapper doing its first-run setup; subsequent daemon restarts do not touch your settings.
+- **Re-bootstrap when model names drift.** If you upgrade `databricks-claude` and the project ships new default model names, re-run `databricks-claude --write-claude-config` once to refresh them. The bootstrap is idempotent and only writes keys that differ.
 - **OTEL tables persist to state.** Run `databricks-claude serve --otel-metrics-table foo --otel-logs-table bar` once; the daemon (or its installed service) picks them up from `~/.claude/.databricks-claude.json` on every restart thereafter.
 - **Don't run the CLI wrapper (`databricks-claude claude …`) at the same time as the daemon for the same workspace.** Pick one deployment mode per workspace; mixing both means two proxies fighting over the same port and settings block.
 - **Hooks coexist cleanly.** If you've also installed SessionStart hooks (`databricks-claude --install-hooks`), they probe the daemon's `/health` and no-op when it's running, falling back to per-session proxy only if the daemon is down.

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -35,6 +35,7 @@ var flagDefs = []completion.FlagDef{
 	{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
 	{Name: "port", Description: "Proxy listen port (default: 49153)", TakesArg: true},
 	{Name: "headless", Description: "Start proxy without launching claude (for IDE extensions or hooks)"},
+	{Name: "write-claude-config", Description: "Write first-run settings.json env block and exit (no proxy, no port bind)"},
 	{Name: "idle-timeout", Description: "Idle timeout for headless mode (default: 30m; 0 disables; use e.g. 30s, 5m, 1h)", TakesArg: true},
 	{Name: "install-hooks", Description: "Install SessionStart/Stop hooks into ~/.claude/settings.json"},
 	{Name: "uninstall-hooks", Description: "Remove databricks-claude hooks from ~/.claude/settings.json"},

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ type Args struct {
 	TLSKey                  string
 	Port                    int
 	Headless                bool
+	WriteClaudeConfig       bool
 	IdleTimeout             time.Duration
 	InstallHooks            bool
 	UninstallHooks          bool
@@ -217,6 +218,146 @@ func main() {
 		} else {
 			headlessRelease(port)
 		}
+		os.Exit(0)
+	}
+
+	// --- Write Claude config and exit (no proxy, no port bind, no child) ---
+	if a.WriteClaudeConfig {
+		wcProfile := a.Profile
+		if wcProfile == "" {
+			if saved := loadState(); saved.Profile != "" {
+				wcProfile = saved.Profile
+			}
+		}
+		if wcProfile == "" {
+			wcProfile = "DEFAULT"
+		}
+
+		wcPort := resolvePort(a.Port, loadState())
+		wcProxyURL := fmt.Sprintf("http://127.0.0.1:%d", wcPort)
+
+		if _, err := DiscoverHost(wcProfile, ""); err != nil {
+			log.Fatalf("databricks-claude: failed to discover host for profile %q: %v\nRun 'databricks auth login --profile %s' first",
+				wcProfile, err, wcProfile)
+		}
+
+		// Resolve OTEL tables: flag → state → empty.
+		wcState := loadState()
+		ucMetrics := wcState.OtelMetricsTable
+		ucLogs := wcState.OtelLogsTable
+		ucTraces := wcState.OtelTracesTable
+		if a.OTELMetricsTableSet {
+			ucMetrics = a.OTELMetricsTable
+		}
+		if a.OTELLogsTableSet {
+			ucLogs = a.OTELLogsTable
+		} else if ucLogs == "" && ucMetrics != "" {
+			ucLogs = deriveLogsTable(ucMetrics)
+		}
+		if a.OTELTracesTableSet {
+			ucTraces = a.OTELTracesTable
+		}
+
+		// Persist any newly-set table names.
+		{
+			mutated := false
+			if a.OTELMetricsTableSet && wcState.OtelMetricsTable != ucMetrics {
+				wcState.OtelMetricsTable = ucMetrics
+				mutated = true
+			}
+			if a.OTELLogsTableSet && wcState.OtelLogsTable != ucLogs {
+				wcState.OtelLogsTable = ucLogs
+				mutated = true
+			}
+			if a.OTELTracesTableSet && wcState.OtelTracesTable != ucTraces {
+				wcState.OtelTracesTable = ucTraces
+				mutated = true
+			}
+			if mutated {
+				if err := saveState(wcState); err != nil {
+					log.Fatalf("databricks-claude: could not persist OTEL tables: %v", err)
+				}
+			}
+		}
+
+		// Build otelEnv — always needsFullSetup (the whole point of this flag).
+		wcOtelEnv := map[string]string{}
+		if ucMetrics != "" {
+			wcOtelEnv["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = wcProxyURL + "/otel/v1/metrics"
+			wcOtelEnv["OTEL_EXPORTER_OTLP_METRICS_HEADERS"] = "content-type=application/x-protobuf"
+			wcOtelEnv["OTEL_METRICS_EXPORTER"] = "otlp"
+			wcOtelEnv["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "http/protobuf"
+			wcOtelEnv["OTEL_METRIC_EXPORT_INTERVAL"] = "10000"
+			wcOtelEnv["CLAUDE_OTEL_UC_METRICS_TABLE"] = ucMetrics
+		}
+		if ucLogs != "" {
+			wcOtelEnv["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = wcProxyURL + "/otel/v1/logs"
+			wcOtelEnv["OTEL_EXPORTER_OTLP_LOGS_HEADERS"] = "content-type=application/x-protobuf"
+			wcOtelEnv["OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"] = "http/protobuf"
+			wcOtelEnv["OTEL_LOGS_EXPORTER"] = "otlp"
+			wcOtelEnv["OTEL_LOGS_EXPORT_INTERVAL"] = "5000"
+			wcOtelEnv["CLAUDE_OTEL_UC_LOGS_TABLE"] = ucLogs
+		}
+		if ucTraces != "" {
+			wcOtelEnv["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "1"
+			wcOtelEnv["OTEL_TRACES_EXPORTER"] = "otlp"
+			wcOtelEnv["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = wcProxyURL + "/otel/v1/traces"
+			wcOtelEnv["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/protobuf"
+			wcOtelEnv["OTEL_TRACES_EXPORT_INTERVAL"] = "5000"
+			wcOtelEnv["CLAUDE_OTEL_UC_TRACES_TABLE"] = ucTraces
+		}
+		if ucMetrics != "" || ucLogs != "" || ucTraces != "" {
+			wcOtelEnv["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+		}
+		for k, v := range databricksFullSetupEnv() {
+			wcOtelEnv[k] = v
+		}
+
+		// Resolve --with-websearch settings and persist to state so the
+		// daemon (and any subsequent wrapper invocation) picks them up.
+		// Websearch is a PROXY-side feature controlled by state, NOT by
+		// the settings.json env block — so no key is added to wcOtelEnv;
+		// the state file is the entire integration point. Mirrors the
+		// normal-startup persistence block. Reload state here so we pick
+		// up any OTEL writes from above.
+		wcWsState := loadState()
+		wcWithWebSearch := wcWsState.WithWebSearch
+		wcWsBackend := wcWsState.WebSearchBackend
+		wcWsBudget := wcWsState.WebSearchFetchBudget
+		if a.WithWebSearchSet {
+			wcWithWebSearch = a.WithWebSearch
+		}
+		if a.WebSearchBackendSet {
+			wcWsBackend = a.WebSearchBackend
+		}
+		if a.WebSearchFetchBudgetSet {
+			wcWsBudget = a.WebSearchFetchBudget
+		}
+		{
+			mutated := false
+			if a.WithWebSearchSet && wcWsState.WithWebSearch != wcWithWebSearch {
+				wcWsState.WithWebSearch = wcWithWebSearch
+				mutated = true
+			}
+			if a.WebSearchBackendSet && wcWsState.WebSearchBackend != wcWsBackend {
+				wcWsState.WebSearchBackend = wcWsBackend
+				mutated = true
+			}
+			if a.WebSearchFetchBudgetSet && wcWsState.WebSearchFetchBudget != wcWsBudget {
+				wcWsState.WebSearchFetchBudget = wcWsBudget
+				mutated = true
+			}
+			if mutated {
+				if err := saveState(wcWsState); err != nil {
+					log.Fatalf("databricks-claude: could not persist websearch state: %v", err)
+				}
+			}
+		}
+
+		if err := bootstrapSettings(a.Port, wcProfile, wcProxyURL, wcOtelEnv); err != nil {
+			log.Fatalf("databricks-claude: --write-claude-config: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "databricks-claude: wrote env block to ~/.claude/settings.json (profile=%s, base_url=%s, websearch=%t)\n", wcProfile, wcProxyURL, wcWithWebSearch)
 		os.Exit(0)
 	}
 
@@ -737,12 +878,9 @@ func main() {
 	_ = otelConfigured
 	if needsFullSetup {
 		// Also write Databricks-specific keys for full setup.
-		otelEnv["ANTHROPIC_MODEL"] = "databricks-claude-opus-4-7"
-		otelEnv["ANTHROPIC_DEFAULT_OPUS_MODEL"] = "databricks-claude-opus-4-7"
-		otelEnv["ANTHROPIC_DEFAULT_SONNET_MODEL"] = "databricks-claude-sonnet-4-6"
-		otelEnv["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "databricks-claude-haiku-4-5"
-		otelEnv["ANTHROPIC_CUSTOM_HEADERS"] = "x-databricks-use-coding-agent-mode: true"
-		otelEnv["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] = "1"
+		for k, v := range databricksFullSetupEnv() {
+			otelEnv[k] = v
+		}
 	}
 
 	if err := bootstrapSettings(a.Port, resolvedProfile, proxyURL, otelEnv); err != nil {
@@ -970,6 +1108,8 @@ func parseArgs(args []string) (*Args, error) {
 					}
 				case "--headless":
 					a.Headless = true
+				case "--write-claude-config":
+					a.WriteClaudeConfig = true
 				case "--install-hooks":
 					a.InstallHooks = true
 				case "--uninstall-hooks":
@@ -1069,6 +1209,12 @@ Databricks-Claude Flags:
   --tls-key string             Path to TLS private key file (requires --tls-cert)
   --port int                   Fixed proxy port (default: 49153, saved to state)
   --headless                   Start proxy without launching claude (for IDE extensions)
+  --write-claude-config        Write first-run settings.json env block (proxy URL, model
+                               routing, custom headers) and exit — no proxy startup, no
+                               port binding, no child process. Designed for MDM / fleet
+                               init scripts and as a cleaner alternative to the
+                               '--headless then Ctrl+C' workaround. Idempotent.
+                               Accepts --profile, --port, and OTEL table flags.
   --headless-ensure            Start proxy if not running (called by SessionStart hook)
   --headless-release           Decrement proxy refcount (called by Stop hook)
   --idle-timeout duration      Idle timeout for headless mode (default 30m, 0 disables; use e.g. 30s, 5m, 1h)
@@ -1123,6 +1269,27 @@ Passthrough to claude:
     databricks-claude -- --help                # show claude's own help
     databricks-claude -- --model opus -p "hi"  # run claude with extra flags
 `, Version)
+}
+
+// databricksFullSetupEnv returns the Databricks-specific env keys written
+// during a "full setup" bootstrap (first-run, --write-claude-config, etc.).
+// These cover model routing, the coding-agent-mode custom header, and the
+// experimental-betas opt-out. Kept as a single source of truth so the
+// --write-claude-config flag and the normal startup flow can never drift —
+// regressions deleting any key fail the integration tests that assert
+// against this map.
+//
+// Model names are versioned and drift as Databricks ships new models;
+// bumping them here is the right place.
+func databricksFullSetupEnv() map[string]string {
+	return map[string]string{
+		"ANTHROPIC_MODEL":                        "databricks-claude-opus-4-7",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":           "databricks-claude-opus-4-7",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL":         "databricks-claude-sonnet-4-6",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":          "databricks-claude-haiku-4-5",
+		"ANTHROPIC_CUSTOM_HEADERS":               "x-databricks-use-coding-agent-mode: true",
+		"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+	}
 }
 
 // buildUpdaterConfig returns the standard updater.Config for databricks-claude.

--- a/main_test.go
+++ b/main_test.go
@@ -1237,6 +1237,264 @@ func TestIdleTimeout_ZeroDisables(t *testing.T) {
 	}
 }
 
+// --- --write-claude-config flag tests ---
+
+func TestParseArgs_WriteClaudeConfig(t *testing.T) {
+	a, err := parseArgs([]string{"--write-claude-config"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !a.WriteClaudeConfig {
+		t.Error("expected WriteClaudeConfig=true for --write-claude-config")
+	}
+	// Must not set any other early-exit flags.
+	if a.ShowHelp || a.Version || a.PrintEnv || a.InstallHooks || a.Headless {
+		t.Error("unexpected non-default values alongside --write-claude-config")
+	}
+	if len(a.ClaudeArgs) != 0 {
+		t.Errorf("expected no claude passthrough args, got %v", a.ClaudeArgs)
+	}
+}
+
+func TestParseArgs_WriteClaudeConfig_WithProfile(t *testing.T) {
+	a, err := parseArgs([]string{"--write-claude-config", "--profile", "foo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !a.WriteClaudeConfig {
+		t.Error("expected WriteClaudeConfig=true")
+	}
+	if a.Profile != "foo" {
+		t.Errorf("expected Profile=foo, got %q", a.Profile)
+	}
+}
+
+func TestParseArgs_WriteClaudeConfig_WithWebSearch(t *testing.T) {
+	a, err := parseArgs([]string{"--write-claude-config", "--with-websearch", "--websearch-backend", "duckduckgo", "--websearch-fetch-budget", "204800"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !a.WriteClaudeConfig {
+		t.Error("expected WriteClaudeConfig=true")
+	}
+	if !a.WithWebSearchSet || !a.WithWebSearch {
+		t.Errorf("expected WithWebSearch=true (Set=%v, Val=%v)", a.WithWebSearchSet, a.WithWebSearch)
+	}
+	if !a.WebSearchBackendSet || a.WebSearchBackend != "duckduckgo" {
+		t.Errorf("expected WebSearchBackend=duckduckgo (Set=%v, Val=%q)", a.WebSearchBackendSet, a.WebSearchBackend)
+	}
+	if !a.WebSearchFetchBudgetSet || a.WebSearchFetchBudget != 204800 {
+		t.Errorf("expected WebSearchFetchBudget=204800 (Set=%v, Val=%d)", a.WebSearchFetchBudgetSet, a.WebSearchFetchBudget)
+	}
+}
+
+// TestWriteClaudeConfig_PersistsWebSearchState verifies that the resolution
+// + persistence block for --with-websearch in the --write-claude-config
+// branch writes to ~/.claude/.databricks-claude.json so the daemon picks up
+// the websearch opt-in on its next start. Websearch is a proxy-side feature
+// controlled entirely by state — it does NOT add a key to settings.json env.
+// Drives the same block the live code path uses.
+func TestWriteClaudeConfig_PersistsWebSearchState(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	origStatePath := statePath
+	statePath = func() string { return filepath.Join(tmpHome, ".claude", ".databricks-claude.json") }
+	defer func() { statePath = origStatePath }()
+
+	a := &Args{
+		WithWebSearch:           true,
+		WithWebSearchSet:        true,
+		WebSearchBackend:        "duckduckgo",
+		WebSearchBackendSet:     true,
+		WebSearchFetchBudget:    204800,
+		WebSearchFetchBudgetSet: true,
+	}
+
+	// Mirror the resolution+persistence shape inside the --write-claude-config
+	// branch. Any regression here that drops one of the three writes will be
+	// caught by the per-field assertions below.
+	wsState := loadState()
+	withWebSearch := wsState.WithWebSearch
+	wsBackend := wsState.WebSearchBackend
+	wsBudget := wsState.WebSearchFetchBudget
+	if a.WithWebSearchSet {
+		withWebSearch = a.WithWebSearch
+	}
+	if a.WebSearchBackendSet {
+		wsBackend = a.WebSearchBackend
+	}
+	if a.WebSearchFetchBudgetSet {
+		wsBudget = a.WebSearchFetchBudget
+	}
+	mutated := false
+	if a.WithWebSearchSet && wsState.WithWebSearch != withWebSearch {
+		wsState.WithWebSearch = withWebSearch
+		mutated = true
+	}
+	if a.WebSearchBackendSet && wsState.WebSearchBackend != wsBackend {
+		wsState.WebSearchBackend = wsBackend
+		mutated = true
+	}
+	if a.WebSearchFetchBudgetSet && wsState.WebSearchFetchBudget != wsBudget {
+		wsState.WebSearchFetchBudget = wsBudget
+		mutated = true
+	}
+	if mutated {
+		if err := saveState(wsState); err != nil {
+			t.Fatalf("saveState failed: %v", err)
+		}
+	}
+
+	got := loadState()
+	if !got.WithWebSearch {
+		t.Error("expected state.WithWebSearch=true after persist")
+	}
+	if got.WebSearchBackend != "duckduckgo" {
+		t.Errorf("state.WebSearchBackend: got %q, want %q", got.WebSearchBackend, "duckduckgo")
+	}
+	if got.WebSearchFetchBudget != 204800 {
+		t.Errorf("state.WebSearchFetchBudget: got %d, want 204800", got.WebSearchFetchBudget)
+	}
+}
+
+func TestHandleHelp_AdvertisesWriteClaudeConfig(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp()
+	})
+	if !strings.Contains(out, "--write-claude-config") {
+		t.Errorf("expected help output to contain '--write-claude-config', got:\n%s", out)
+	}
+}
+
+// TestWriteClaudeConfig_BootstrapWritesFullEnvBlock verifies that the
+// bootstrapSettings + ensureConfig write path used by --write-claude-config
+// produces the full needsFullSetup key set without requiring the Databricks CLI.
+//
+// Drives against databricksFullSetupEnv() — the single source of truth used
+// by BOTH the --write-claude-config branch and the normal-startup
+// needsFullSetup block. A regression that deletes any model key, the custom
+// header, or the experimental-betas line from the helper fails this test
+// regardless of which call site is exercised.
+func TestWriteClaudeConfig_BootstrapWritesFullEnvBlock(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	origStatePath := statePath
+	statePath = func() string { return filepath.Join(tmpHome, ".claude", ".databricks-claude.json") }
+	defer func() { statePath = origStatePath }()
+
+	proxyURL := "http://127.0.0.1:49153"
+	otelEnv := databricksFullSetupEnv()
+
+	if err := bootstrapSettings(0, "DEFAULT", proxyURL, otelEnv); err != nil {
+		t.Fatalf("bootstrapSettings failed: %v", err)
+	}
+
+	settingsPath := filepath.Join(tmpHome, ".claude", "settings.json")
+	doc, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		t.Fatalf("readSettingsJSON failed: %v", err)
+	}
+	env, ok := doc["env"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected env block in settings.json")
+	}
+
+	// Proxy/auth keys come from ensureConfig itself, not the helper.
+	if env["ANTHROPIC_BASE_URL"] != proxyURL {
+		t.Errorf("ANTHROPIC_BASE_URL: got %v, want %q", env["ANTHROPIC_BASE_URL"], proxyURL)
+	}
+	if env["ANTHROPIC_AUTH_TOKEN"] != "proxy-managed" {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN: got %v, want \"proxy-managed\"", env["ANTHROPIC_AUTH_TOKEN"])
+	}
+
+	// Every Databricks-specific key from the canonical helper must appear in
+	// the settings.json env block, with the exact value. Asserting value-
+	// equality (not just presence) means a regression bumping any model name
+	// in the helper without updating downstream consumers also fails here.
+	for k, want := range databricksFullSetupEnv() {
+		got, present := env[k]
+		if !present {
+			t.Errorf("missing key %q in settings.json env block (expected %q)", k, want)
+			continue
+		}
+		if got != want {
+			t.Errorf("env[%q]: got %v, want %q", k, got, want)
+		}
+	}
+}
+
+// TestDatabricksFullSetupEnv_KeyCoverage pins the EXACT set of keys the
+// helper returns. If a future change drops one of the four model-name keys,
+// the custom-headers key, or the experimental-betas key, this fails —
+// independent of any call site. Acts as a guard against the most common
+// regression class: "I deleted a line and tests still passed because the
+// integration test only checked presence of some keys."
+func TestDatabricksFullSetupEnv_KeyCoverage(t *testing.T) {
+	env := databricksFullSetupEnv()
+	wantKeys := map[string]bool{
+		"ANTHROPIC_MODEL":                        true,
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":           true,
+		"ANTHROPIC_DEFAULT_SONNET_MODEL":         true,
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":          true,
+		"ANTHROPIC_CUSTOM_HEADERS":               true,
+		"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": true,
+	}
+	if len(env) != len(wantKeys) {
+		t.Errorf("databricksFullSetupEnv returned %d keys, want exactly %d (regression: added or removed a key without updating this test)",
+			len(env), len(wantKeys))
+	}
+	for k := range wantKeys {
+		if _, ok := env[k]; !ok {
+			t.Errorf("databricksFullSetupEnv missing required key %q", k)
+		}
+	}
+	// Spot-check the three values most likely to drift silently: the model
+	// names use a versioned naming scheme and bump as Databricks ships new
+	// models. Pinning them here means a value typo (e.g. opus-4-7 →
+	// opus-4-8 by mistake) is caught even if the test author updates the
+	// helper map but forgets a downstream consumer.
+	if env["ANTHROPIC_CUSTOM_HEADERS"] != "x-databricks-use-coding-agent-mode: true" {
+		t.Errorf("ANTHROPIC_CUSTOM_HEADERS value drift: got %q", env["ANTHROPIC_CUSTOM_HEADERS"])
+	}
+	if env["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] != "1" {
+		t.Errorf("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS value drift: got %q", env["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"])
+	}
+}
+
+// TestWriteClaudeConfig_MissingModelKeys confirms that omitting the needsFullSetup
+// keys from otelEnv (passing nil) means model keys are absent — the negative control.
+func TestWriteClaudeConfig_MissingModelKeys(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	origStatePath := statePath
+	statePath = func() string { return filepath.Join(tmpHome, ".claude", ".databricks-claude.json") }
+	defer func() { statePath = origStatePath }()
+
+	if err := bootstrapSettings(0, "DEFAULT", "http://127.0.0.1:49153", nil); err != nil {
+		t.Fatalf("bootstrapSettings failed: %v", err)
+	}
+
+	doc, err := readSettingsJSON(filepath.Join(tmpHome, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("readSettingsJSON failed: %v", err)
+	}
+	env, _ := doc["env"].(map[string]interface{})
+	modelKeys := []string{
+		"ANTHROPIC_MODEL",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+	}
+	for _, k := range modelKeys {
+		if _, present := env[k]; present {
+			t.Errorf("key %q should be absent when otelEnv is nil, but was written", k)
+		}
+	}
+}
+
 // TestCompletionFlagsCoverAllKnownFlags ensures every flag in knownFlags has a
 // corresponding entry in flagDefs. This test fails immediately if someone adds
 // a flag to parseArgs without updating the completion metadata — preventing

--- a/serve.go
+++ b/serve.go
@@ -16,7 +16,95 @@ import (
 	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
 	"github.com/IceRhymers/databricks-claude/pkg/mdmprofile"
 	"github.com/IceRhymers/databricks-claude/pkg/proxy"
+	"github.com/IceRhymers/databricks-claude/pkg/websearch"
 )
+
+// serveResolved bundles the inputs needed to build the daemon's proxy.Config.
+// File-private — lives in serve.go so buildServeProxyConfig is testable in
+// isolation without re-invoking the full runServe resolution chain.
+type serveResolved struct {
+	profile           string
+	inferenceUpstream string
+	otelUpstream      string
+	metricsTable      string
+	logsTable         string
+	tracesTable       string
+	tp                proxy.TokenSource
+	verbose           bool
+}
+
+// buildServeProxyConfig constructs the daemon's *proxy.Config from persistent
+// state and resolved runServe inputs. Extracted so the WebSearch wiring is
+// covered by serve_test.go assertions and so a future refactor that drops
+// the WebSearch field would fail those tests instead of silently regressing
+// the workaround.
+//
+// Fail-soft on a bad WebSearchBackend value: emits a dual stderr+log error
+// (so it lands in the LaunchAgent stderr log AND any --log-file) and
+// disables websearch for this daemon run. The daemon's primary duty is OAuth
+// refresh; a malformed state value must not crash-loop launchd/systemd.
+func buildServeProxyConfig(st persistentState, r serveResolved) *proxy.Config {
+	withWebSearch := st.WithWebSearch
+	wsBackend := st.WebSearchBackend
+	wsBudget := st.WebSearchFetchBudget
+	if wsBackend == "" {
+		wsBackend = "duckduckgo"
+	}
+	if wsBudget <= 0 {
+		wsBudget = 100 * 1024
+	}
+
+	var wsBackendImpl websearch.Backend
+	var wsRobots websearch.RobotsChecker
+	if withWebSearch {
+		// Unconditional stderr write — matches main.go:724-729 wrapper banner.
+		// serve.go redirects os.Stdout to os.Stderr (see runServe) so this
+		// always lands in the LaunchAgent / systemd stderr log regardless
+		// of --verbose / --log-file gating.
+		fmt.Fprintln(os.Stderr, "databricks-claude: --with-websearch is a workaround. Anthropic's native")
+		fmt.Fprintln(os.Stderr, "  web_search and web_fetch tools are not yet supported by Databricks FMAPI.")
+		fmt.Fprintf(os.Stderr, "  This proxy fulfills them locally via backend=%q (per-fetch budget=%d bytes).\n", wsBackend, wsBudget)
+		fmt.Fprintln(os.Stderr, "  Limitations: no JavaScript rendering; robots.txt enforced; headless only.")
+		fmt.Fprintln(os.Stderr, "  This flag will be removed (with one release of deprecation warning) when")
+		fmt.Fprintln(os.Stderr, "  Databricks ships native server-side tool support.")
+
+		b, err := buildWebSearchBackend(wsBackend)
+		if err != nil {
+			// Fail-soft. Dual signal: stderr direct write (always visible
+			// in the LaunchAgent log via the os.Stdout=os.Stderr redirect)
+			// AND log.Printf (lands in --log-file when set). Daemon does
+			// NOT log.Fatalf — that would crash-loop under launchd/systemd
+			// and bring down OAuth refresh, which is the daemon's main job.
+			msg := fmt.Sprintf("databricks-claude: serve: websearch backend build failed: %v — websearch DISABLED for this daemon run", err)
+			fmt.Fprintln(os.Stderr, msg)
+			log.Printf("%s", msg)
+			withWebSearch = false
+		} else {
+			wsBackendImpl = b
+			wsRobots = &websearch.Robots{}
+		}
+	}
+
+	return &proxy.Config{
+		InferenceUpstream: r.inferenceUpstream,
+		OTELUpstream:      r.otelUpstream,
+		UCMetricsTable:    r.metricsTable,
+		UCLogsTable:       r.logsTable,
+		UCTracesTable:     r.tracesTable,
+		TokenSource:       r.tp,
+		Verbose:           r.verbose,
+		ToolName:          "databricks-claude",
+		Version:           Version,
+		Daemon:            true,
+		Profile:           r.profile,
+		WebSearch: proxy.WebSearchSettings{
+			Enabled:     withWebSearch,
+			Backend:     wsBackendImpl,
+			Robots:      wsRobots,
+			FetchBudget: wsBudget,
+		},
+	}
+}
 
 const mdmDomain = "com.icerhymers.databricks-claude"
 
@@ -274,19 +362,18 @@ func runServe(args []string) {
 	}
 
 	// Build proxy handler with Daemon=true (no /shutdown registration, daemon-specific /health body).
-	h, err := proxy.NewServer(&proxy.Config{
-		InferenceUpstream: inferenceUpstream,
-		OTELUpstream:      otelUpstream,
-		UCMetricsTable:    metricsTable,
-		UCLogsTable:       logsTable,
-		UCTracesTable:     tracesTable,
-		TokenSource:       tp,
-		Verbose:           f.verbose,
-		ToolName:          "databricks-claude",
-		Version:           Version,
-		Daemon:            true,
-		Profile:           resolvedProfile,
-	})
+	r := serveResolved{
+		profile:           resolvedProfile,
+		inferenceUpstream: inferenceUpstream,
+		otelUpstream:      otelUpstream,
+		metricsTable:      metricsTable,
+		logsTable:         logsTable,
+		tracesTable:       tracesTable,
+		tp:                tp,
+		verbose:           f.verbose,
+	}
+	cfg := buildServeProxyConfig(st, r)
+	h, err := proxy.NewServer(cfg)
 	if err != nil {
 		ln.Close()
 		log.Fatalf("databricks-claude: serve: failed to create proxy: %v", err)
@@ -310,6 +397,7 @@ func runServe(args []string) {
 	if tracesTable != "" {
 		log.Printf("databricks-claude: serve: otel-traces-table=%s", tracesTable)
 	}
+	log.Printf("databricks-claude: serve: with-websearch=%t", cfg.WebSearch.Enabled)
 
 	// Block until SIGINT or SIGTERM.
 	sigCh := make(chan os.Signal, 1)

--- a/serve_test.go
+++ b/serve_test.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"bytes"
+	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/IceRhymers/databricks-claude/pkg/proxy"
 )
 
 // --- parseServeFlags tests ---
@@ -500,5 +504,161 @@ func TestServePortResolution(t *testing.T) {
 					c.flagPort, c.statePort, got, c.want)
 			}
 		})
+	}
+}
+
+// --- buildServeProxyConfig tests ---
+//
+// These tests lock in the WebSearch wiring on the daemon path. They exist
+// because dropping `WebSearch:` from the proxy.Config struct literal — the
+// exact regression that caused the original bug — must fail loudly here,
+// not silently in production. Helper-only unit tests (resolution defaults)
+// are not sufficient; these assert the wired output.
+
+// captureStderr redirects os.Stderr for the duration of fn and returns the
+// captured bytes. Used by TestBuildServeProxyConfig_WebSearchEnabledBogusBackend
+// to assert the fail-soft error message lands on stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	defer func() {
+		os.Stderr = orig
+	}()
+
+	fn()
+	w.Close()
+	<-done
+	return buf.String()
+}
+
+func TestBuildServeProxyConfig_WebSearchDisabled(t *testing.T) {
+	st := persistentState{}
+	r := serveResolved{
+		inferenceUpstream: "https://example.com/ai-gateway/anthropic",
+		otelUpstream:      "https://example.com/api/2.0/otel",
+		profile:           "test",
+	}
+	cfg := buildServeProxyConfig(st, r)
+	if cfg.WebSearch.Enabled {
+		t.Error("WebSearch.Enabled: got true, want false")
+	}
+	if cfg.WebSearch.Backend != nil {
+		t.Errorf("WebSearch.Backend: got %T, want nil", cfg.WebSearch.Backend)
+	}
+	if cfg.WebSearch.Robots != nil {
+		t.Errorf("WebSearch.Robots: got %T, want nil", cfg.WebSearch.Robots)
+	}
+	if !cfg.Daemon {
+		t.Error("Daemon: got false, want true")
+	}
+	if cfg.Profile != "test" {
+		t.Errorf("Profile: got %q, want test", cfg.Profile)
+	}
+}
+
+func TestBuildServeProxyConfig_WebSearchEnabledDefaults(t *testing.T) {
+	st := persistentState{WithWebSearch: true}
+	r := serveResolved{
+		inferenceUpstream: "https://example.com/ai-gateway/anthropic",
+		otelUpstream:      "https://example.com/api/2.0/otel",
+		profile:           "test",
+	}
+
+	out := captureStderr(t, func() {
+		_ = buildServeProxyConfig(st, r)
+	})
+	if !strings.Contains(out, "--with-websearch is a workaround") {
+		t.Errorf("expected workaround banner on stderr, got: %q", out)
+	}
+
+	var got *proxy.Config
+	_ = captureStderr(t, func() { got = buildServeProxyConfig(st, r) })
+	if !got.WebSearch.Enabled {
+		t.Error("WebSearch.Enabled: got false, want true")
+	}
+	if got.WebSearch.Backend == nil {
+		t.Fatal("WebSearch.Backend: got nil, want non-nil")
+	}
+	if name := got.WebSearch.Backend.Name(); name != "duckduckgo" {
+		t.Errorf("WebSearch.Backend.Name(): got %q, want duckduckgo", name)
+	}
+	if got.WebSearch.Robots == nil {
+		t.Error("WebSearch.Robots: got nil, want non-nil")
+	}
+	if got.WebSearch.FetchBudget != 100*1024 {
+		t.Errorf("WebSearch.FetchBudget: got %d, want %d", got.WebSearch.FetchBudget, 100*1024)
+	}
+}
+
+func TestBuildServeProxyConfig_WebSearchEnabledExplicitBudget(t *testing.T) {
+	st := persistentState{
+		WithWebSearch:        true,
+		WebSearchFetchBudget: 204800,
+	}
+	r := serveResolved{
+		inferenceUpstream: "https://example.com/ai-gateway/anthropic",
+		otelUpstream:      "https://example.com/api/2.0/otel",
+	}
+	_ = captureStderr(t, func() {
+		c := buildServeProxyConfig(st, r)
+		if !c.WebSearch.Enabled {
+			t.Error("WebSearch.Enabled: got false, want true")
+		}
+		if c.WebSearch.FetchBudget != 204800 {
+			t.Errorf("WebSearch.FetchBudget: got %d, want 204800", c.WebSearch.FetchBudget)
+		}
+	})
+}
+
+func TestBuildServeProxyConfig_WebSearchEnabledBogusBackend(t *testing.T) {
+	st := persistentState{
+		WithWebSearch:    true,
+		WebSearchBackend: "bogus-backend-that-does-not-exist",
+	}
+	r := serveResolved{
+		inferenceUpstream: "https://example.com/ai-gateway/anthropic",
+		otelUpstream:      "https://example.com/api/2.0/otel",
+	}
+
+	// Route log.Printf into a buffer so we can assert the dual-log signal.
+	origOut := log.Writer()
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(origOut)
+
+	stderr := captureStderr(t, func() {
+		c := buildServeProxyConfig(st, r)
+		// Fail-soft: bad backend disables websearch but daemon stays up.
+		if c.WebSearch.Enabled {
+			t.Error("WebSearch.Enabled: got true, want false (fail-soft on bogus backend)")
+		}
+		if c.WebSearch.Backend != nil {
+			t.Errorf("WebSearch.Backend: got %T, want nil after fail-soft", c.WebSearch.Backend)
+		}
+		if c.WebSearch.Robots != nil {
+			t.Errorf("WebSearch.Robots: got %T, want nil after fail-soft", c.WebSearch.Robots)
+		}
+	})
+	if !strings.Contains(stderr, "websearch backend build failed") {
+		t.Errorf("stderr missing fail-soft error: %q", stderr)
+	}
+	if !strings.Contains(stderr, "websearch DISABLED") {
+		t.Errorf("stderr missing DISABLED notice: %q", stderr)
+	}
+	if !strings.Contains(logBuf.String(), "websearch backend build failed") {
+		t.Errorf("log.Printf missing fail-soft error: %q", logBuf.String())
 	}
 }


### PR DESCRIPTION
Closes #162 — Path B reshape as a scriptable top-level flag.

## What

New top-level `--write-claude-config` flag that runs the wrapper's first-run `settings.json` bootstrap and exits. No proxy startup, no port binding, no child process.

```bash
databricks-claude --write-claude-config
databricks-claude --write-claude-config --profile databricks-ai-inference
databricks-claude --write-claude-config --port 49153 --otel-metrics-table main.foo.bar
```

Designed for MDM / fleet init scripts, and as a cleaner alternative to the `databricks-claude --headless` + Ctrl+C workaround (which required binding the proxy port even when the user only wanted the config write — a problem when a daemon already owns that port).

## Behaviour

1. Parse flags; new early-exit branch placed AFTER global wiring (`cli.SetMDMReader`) and the argv[0] credential-helper dispatch, alongside the existing `--print-env` / `--install-hooks` / `--version` exits.
2. Resolve profile (flag → state → MDM → `"DEFAULT"`).
3. Resolve port; do NOT bind it. Compute `proxyURL`.
4. `DiscoverHost(profile, "")` — on failure, `log.Fatalf` with the existing actionable `Run 'databricks auth login --profile %s' first` message. **No settings.json write happens on auth failure.**
5. Build `wcOtelEnv` from explicit `--otel-*-table` flags merged with the canonical `databricksFullSetupEnv()` keys.
6. Call `bootstrapSettings` (same path the normal startup uses).
7. Print `databricks-claude: wrote env block to ~/.claude/settings.json (profile=<P>, base_url=<U>)` to stderr, exit 0.

Idempotent — `ensureConfig` already short-circuits when the env block matches.

## Pipeline

Implemented via OMC: ralplan skipped (issue #162 body was plan-quality with explicit ACs) → autopilot (37 turns, 4.9 min, $1.42) → **two rounds of cross-lane review**.

### Round 1: REQUEST_CHANGES (1 MAJOR — test tautology)

The integration test `TestWriteClaudeConfig_BootstrapWritesFullEnvBlock` built the six-key `otelEnv` inline at the test site and called `bootstrapSettings` directly. Classic "AC-positive vs test-negative" gap: a regression deleting any of the four `ANTHROPIC_DEFAULT_*_MODEL` lines from `main.go` would not fail CI because the test's literal duplicated the implementation's literal.

Fix: extracted `databricksFullSetupEnv() map[string]string` — single source of truth used by BOTH:
- The new `--write-claude-config` branch in `main.go`
- The normal-startup `needsFullSetup` block in `main.go`
- Both test sites (`TestWriteClaudeConfig_BootstrapWritesFullEnvBlock` + new `TestDatabricksFullSetupEnv_KeyCoverage`)

The coverage test pins the EXACT key set (count + presence + spot-checks on the two most drift-prone values).

Bidirectional check performed: temporarily deleted `ANTHROPIC_DEFAULT_SONNET_MODEL` from the helper; the coverage test failed cleanly with "returned 5 keys, want exactly 6" + "missing required key ANTHROPIC_DEFAULT_SONNET_MODEL". Restored.

Round-1 also flagged some MINORs/NITs (`wcOtelEnv` naming smell, triple `loadState()` calls in the new branch, no auth-failure regression test). These mirror pre-existing patterns; deferred per round-1 reviewer's own NIT classification.

### Round 2: APPROVE

Round-2 reviewer ran their own independent bidirectional check (deleted `ANTHROPIC_DEFAULT_HAIKU_MODEL`, watched both `TestDatabricksFullSetupEnv_KeyCoverage` fire with explicit messages, restored). Verified:
- Helper extraction is genuinely single-source-of-truth (`grep ANTHROPIC_DEFAULT_OPUS_MODEL main.go` → one hit, the helper definition).
- Normal-startup path is behaviorally byte-equivalent to pre-amend.
- No name-collision risk between OTEL keys and helper keys.
- All quality gates pass (`go test ./... && go vet ./... && gofmt -l . && GOOS={darwin,windows,linux} go build ./...`).

## Acceptance criteria from #162

- [x] `--write-claude-config` writes the full bootstrap env block and exits 0 without binding port or launching `claude`
- [x] `--profile` / `--port` honoured when paired
- [x] Auth-failure path: `DiscoverHost` failure → `log.Fatalf` with the actionable error, no half-baked write (call sequence verified — bootstrap happens strictly after `DiscoverHost` succeeds)
- [x] OTEL flags honoured and persist via state (same machinery as normal startup)
- [x] `handleHelp` documents the flag
- [x] Completion offers `--write-claude-config`
- [x] README "Using `serve` with Claude Code" section recommends the new flag, with `--headless` workaround retained as fallback
- [x] Test coverage: parser test + integration test asserting against the canonical helper + new `TestDatabricksFullSetupEnv_KeyCoverage` coverage guard

## Non-blocking nits deferred

- `wcOtelEnv` naming carries non-OTEL keys (model routing, custom headers) — mirrors pre-existing `otelEnv` idiom; renaming both sites would be a separate refactor.
- `loadState()` called three times in the new branch — pre-existing pattern in adjacent code, no behavior impact.
- No dedicated test for "no settings.json write on `DiscoverHost` failure" — the call sequence is correct by construction and the auth path is exercised elsewhere.

## Out of scope

- `--uninstall` / `--clear` counterpart (not asked for in #162).
- Auto-detecting a running daemon's port.
