### PR TITLE
feat!: consolidate persistent-config flags under a `config` subcommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, 'feat/**']
   pull_request:
-    branches: [master]
+    branches: [master, 'feat/**']
 
 jobs:
   ci:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ Transparent proxy wrapper for Claude Code that auto-refreshes Databricks OAuth t
 | `state.go` | `persistentState` struct and helpers for `~/.claude/.databricks-claude.json` (profile, port, CLI path, OTEL table names) |
 | `hooks.go` | Session hook install/uninstall: `installHooks`, `uninstallHooks` |
 | `ensureconfig.go` | Bootstrap helpers for first-run settings patching |
+| `commands.go` | Source-of-truth `rootCommand` declaration plus `desktopCommand` / `setupCommand` / `configCommand` / `serveCommand` tree nodes (drives parsing, help, completion) |
+| `config.go` | `config` subcommand runner: dispatches `config otel enable\|disable`, `config websearch enable\|disable`, `config write`, `config show`. Pure resolvers `resolveConfigOTEL` / `resolveConfigWebSearch` for testability |
 | `completion_flags.go` | `flagDefs` slice shared by shell completion and flag parsing |
 | `databrickscfg.go` | Reads `~/.databrickscfg` section headers for profile completion |
 | `desktop_config.go` | `desktop` subcommand: `generate-config` writing `.mobileconfig`, `.reg`, and `.json` artifacts for Claude Desktop; credential-helper alias dispatch |
@@ -28,6 +30,7 @@ Transparent proxy wrapper for Claude Code that auto-refreshes Databricks OAuth t
 | `serve_install_other.go` | Stub returning "unsupported platform" for non-darwin/linux/windows (build tag: `!darwin && !windows && !linux`) |
 | `desktop_config_test.go` | Tests for `buildMobileconfig`, `buildRegFile`, `buildDevModeJSON`, `writeDesktopConfigByPath`, `guardDevJSONOutputPath`, `writeFileAtomic`, install-instruction routing, and model-list consistency across all three artifacts |
 | `main_test.go` | Tests for `parseArgs`, `handlePrintEnv`, persistent config, `deriveLogsTable`, full integration scenarios |
+| `config_test.go` | Tests for `config` subcommand parity, OTEL orchestration matrix, websearch resolver, state-preservation invariant on `config otel disable` |
 | `process_test.go` | Tests for `RunChild`, signal forwarding, exit code propagation |
 | `proxy_test.go` | Tests for inference and OTEL proxy routing, token injection, panic recovery |
 | `token_test.go` | Tests using helper binaries compiled at test time to mock the `databricks` CLI |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ The root package is a set of `.go` files that act as thin facades wiring togethe
 - **state.go** — `persistentState` struct: JSON schema for `~/.claude/.databricks-claude.json` (profile, port, CLI path, OTEL table names).
 - **hooks.go** — Session hook install/uninstall (`installHooks`, `uninstallHooks`).
 - **ensureconfig.go** — Bootstrap helpers for first-run settings setup.
+- **commands.go** — Source-of-truth `rootCommand` declaration plus `desktopCommand` / `setupCommand` / `configCommand` / `serveCommand` tree nodes. Drives parsing (via `internal/cmd.Command.Parse`), help (via `cmd.Render` against the `Long` template fields), and shell completion (via `CompletionFlags()` / `CompletionSubcommands()` exposed through `completion_flags.go`).
+- **config.go** — `config` subcommand runner introduced in #172. Dispatches `config otel enable|disable`, `config websearch enable|disable`, `config write`, `config show`. Pure-function resolvers `resolveConfigOTEL` and `resolveConfigWebSearch` make the orchestration matrix testable in isolation. Storage semantics (two-store model, sentinel-guarded writers, OTEL section *removal* on disable, state-file preservation) are byte-identical with the legacy root flags this subcommand replaced.
 - **completion_flags.go** — `flagDefs` slice driving shell completion and flag parsing; `knownSubcommands` slice driving subcommand-name completion.
 - **databrickscfg.go** — Reads `~/.databrickscfg` section headers for profile name resolution.
 - **desktop_config.go** — `desktop` subcommand: `generate-config` writing `.mobileconfig`, `.reg`, and `.json` artifacts for Claude Desktop.
@@ -74,7 +76,7 @@ Each package is independently importable with no cross-dependencies:
 - **No breaking changes to settings.json** — a botched restore leaves the user's Claude config pointing at a dead proxy. Any change to key names, restore logic, or the save/restore lifecycle requires extreme care.
 - **Atomic file writes everywhere** — all JSON writes (settings, registry, persistent config) use temp-file + `os.Rename` in the same directory.
 - **Session handoff** — when multiple `databricks-claude` instances run concurrently, the exiting one hands `ANTHROPIC_BASE_URL` to the most recent survivor.
-- **OTEL key persistence** — when `--otel` is active, OTEL keys survive settings restore (controlled by `otelKeysPersistent` flag).
+- **OTEL key persistence** — when OTEL is active (state file has any `otel_*_table` set, or settings.json carries OTEL keys), OTEL keys survive settings restore (controlled by `otelKeysPersistent` flag).
 
 ## Testing Patterns
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ The two automated modes are independent — neither requires the other — and t
 Enable with:
 
 ```bash
-databricks-claude --with-websearch --profile <name>
+databricks-claude config websearch enable --backend duckduckgo
 ```
+
+This persists `with_websearch=true` to `~/.claude/.databricks-claude.json`; subsequent `databricks-claude` invocations (and the `serve` daemon) pick it up automatically. To turn it off, run `databricks-claude config websearch disable`.
 
 How it works:
 
@@ -75,13 +77,12 @@ How it works:
 - All fulfillment is **headless** — pure stdlib HTTP, no browser process. JavaScript-rendered pages are not supported.
 - `robots.txt` is enforced per host with a session cache.
 
-Flags:
+`config websearch enable` flags:
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--with-websearch` | `false` | Enable the workaround. Persists to `~/.claude/.databricks-claude.json`. |
-| `--websearch-backend` | `duckduckgo` | Search backend. Values: `duckduckgo` (zero config, HTML scrape), `none` (disable search but keep fetch). |
-| `--websearch-fetch-budget` | `102400` (100KB) | Max bytes returned per `web_fetch` call. Larger pages are truncated. |
+| `--backend` | `duckduckgo` | Search backend. Values: `duckduckgo` (zero config, HTML scrape), `none` (disable search but keep fetch). |
+| `--fetch-budget` | `102400` (100KB) | Max bytes returned per `web_fetch` call. Larger pages are truncated. |
 
 Limitations:
 
@@ -90,7 +91,7 @@ Limitations:
 - Per-fetch byte cap defaults to 100KB to protect the context window.
 - Search backends `brave` and `searxng` are deferred to follow-up work; only `duckduckgo` and `none` are wired today.
 
-When `--with-websearch=false` (the default), the proxy forwards request bytes unchanged — there is no behavior change for users who don't opt in.
+When `with_websearch=false` (the default), the proxy forwards request bytes unchanged — there is no behavior change for users who don't opt in.
 
 ## Session Hooks (recommended)
 
@@ -395,7 +396,7 @@ A single command an admin can run to check endpoint health:
 
 ```bash
 # Helper-mode:
-databricks-claude setup --profile <fleet-profile> && databricks-claude --print-env
+databricks-claude setup --profile <fleet-profile> && databricks-claude config show
 
 # Daemon-mode (additionally):
 databricks-claude serve status
@@ -428,29 +429,16 @@ databricks-claude --log-file /tmp/dc.log "fix the bug in main.go"
 # Both stderr and file:
 databricks-claude -v --log-file /tmp/dc.log "fix the bug in main.go"
 
-# With OTEL telemetry (metrics + logs by default):
-databricks-claude --otel "summarize this PR"
-
-# With custom OTEL tables (each signal is independent — only emit what you point at a table):
-databricks-claude --otel --otel-metrics-table main.catalog.metrics --otel-logs-table main.catalog.logs "summarize this PR"
-
-# Enable Claude Code traces beta (CLAUDE_CODE_ENHANCED_TELEMETRY_BETA):
-databricks-claude --otel-traces --otel-traces-table main.catalog.traces "summarize this PR"
-
-# Per-signal disable — clears just that signal's keys, leaves others intact:
-databricks-claude --no-otel-metrics
-databricks-claude --no-otel-logs
-databricks-claude --no-otel-traces
-
-# Disable all OTEL (clears every persisted signal key):
-databricks-claude --no-otel
-
 # With proxy API key authentication:
 databricks-claude --proxy-api-key my-secret-key "explain this codebase"
 
 # With TLS:
 databricks-claude --tls-cert cert.pem --tls-key key.pem "explain this codebase"
 ```
+
+OTEL telemetry, websearch, and the persistent settings.json bootstrap moved
+behind the `config` subcommand in v0.x — see [`config` Subcommand](#config-subcommand)
+below.
 
 ### Alias (optional)
 
@@ -459,6 +447,96 @@ echo 'alias claude="databricks-claude"' >> ~/.zshrc  # or ~/.bashrc
 ```
 
 Claude Desktop integration lives under the `desktop` subcommand — run `databricks-claude desktop` for its action list and flags.
+
+## `config` Subcommand
+
+Persistent config editor. Mutates `~/.claude/settings.json` (env block) and `~/.claude/.databricks-claude.json` (state file) for *future* invocations — none of these subcommands affect the current invocation, and the storage semantics (two-store model, sentinel guards, OTEL section *removal* on disable, state-file preservation when toggling) match the legacy root flags exactly.
+
+```
+config otel enable  [--metrics-table T] [--logs-table T] [--traces] [--traces-table T]
+config otel disable [--metrics] [--logs] [--traces]      # no flags = disable everything
+config websearch enable  [--backend duckduckgo|none] [--fetch-budget N]
+config websearch disable
+config write                                             # bootstrap settings.json
+config show                                              # diagnostic dump
+```
+
+### `config otel enable|disable`
+
+Toggle OpenTelemetry signal export. Tables (metrics/logs/traces) persist to the state file; OTEL env keys are written to settings.json's env block. `disable` clears settings.json keys but **preserves** state-file table preferences so a subsequent `enable` restores them.
+
+```bash
+# Enable with explicit metrics + logs tables:
+databricks-claude config otel enable \
+  --metrics-table main.claude_telemetry.claude_otel_metrics \
+  --logs-table   main.claude_telemetry.claude_otel_logs
+
+# Bare enable — applies the legacy default metrics table and derives logs from it:
+databricks-claude config otel enable
+
+# Per-signal disable (others stay live):
+databricks-claude config otel disable --metrics
+databricks-claude config otel disable --logs
+databricks-claude config otel disable --traces
+
+# Disable everything (state file table prefs preserved):
+databricks-claude config otel disable
+```
+
+### `config websearch enable|disable`
+
+Toggle local web_search / web_fetch fulfillment in the proxy (workaround until Databricks FMAPI ships native server-side tool support). State file only — no settings.json key.
+
+```bash
+# Default backend (duckduckgo, 100KB fetch budget):
+databricks-claude config websearch enable
+
+# Disable scraping but keep web_fetch:
+databricks-claude config websearch enable --backend none --fetch-budget 204800
+
+# Turn it off (clears backend + fetch-budget so a re-enable picks up defaults):
+databricks-claude config websearch disable
+```
+
+See [Web Search & Fetch (Workaround, opt-in)](#web-search--fetch-workaround-opt-in) for backend details and limitations.
+
+### `config write`
+
+Writes the first-run `~/.claude/settings.json` env block (proxy URL, model routing, custom headers, optional OTEL keys) and exits. No proxy startup, no port binding, no child process — purely a settings bootstrap. Idempotent.
+
+```bash
+# Bare bootstrap (default profile, default port):
+databricks-claude config write
+
+# MDM rollout — bake fleet-wide profile + workspace into settings.json:
+databricks-claude config write --profile databricks-ai-inference
+
+# Bootstrap with OTEL routing AND websearch enabled:
+databricks-claude config write \
+  --metrics-table main.telemetry.claude_otel_metrics \
+  --logs-table   main.telemetry.claude_otel_logs \
+  --with-websearch
+```
+
+### `config show`
+
+Print the resolved configuration with the token redacted. Read-only — zero writes to settings.json or state. Equivalent to the legacy `--print-env`.
+
+```bash
+databricks-claude config show
+```
+
+```
+databricks-claude configuration:
+  Profile:              DEFAULT
+  DATABRICKS_HOST:      https://adb-1234567890123456.7.azuredatabricks.net
+  ANTHROPIC_BASE_URL:   https://adb-.../ai-gateway/anthropic
+  ANTHROPIC_AUTH_TOKEN: dapi-***
+  Upstream binary:      /usr/local/bin/claude
+  OTEL enabled:         false
+```
+
+> **Migrating from pre-`config` versions:** the 14 root flags (`--otel*`, `--no-otel*`, `--write-claude-config`, `--print-env`, `--with-websearch`, `--websearch-*`) were **removed, not aliased** — they now pass through to claude as unknown args. Update any scripts to use the new `config` subcommands. Storage stayed identical: settings.json + `.databricks-claude.json` written exactly the same way as before.
 
 ## `setup` Subcommand
 
@@ -622,7 +700,7 @@ Once you've installed the daemon (`serve install`), Claude Code still needs to k
 ```bash
 # 1. One-time: bootstrap settings.json with the right env block
 #    (proxy URL, fake auth token, Databricks model routing, custom headers).
-databricks-claude --write-claude-config
+databricks-claude config write
 
 # 2. Start the daemon as a service (or run `serve` directly).
 databricks-claude serve install
@@ -633,26 +711,26 @@ databricks-claude serve install
 Optional: pair with `--profile`, `--port`, or `--with-websearch` if you use a non-default workspace or want local web-search/web-fetch fulfillment:
 
 ```bash
-databricks-claude --write-claude-config --profile my-workspace --port 49153
+databricks-claude config write --profile my-workspace --port 49153
 
 # Enable local web_search/web_fetch fulfillment in the daemon:
-databricks-claude --write-claude-config --with-websearch
+databricks-claude config write --with-websearch
 ```
 
-`--with-websearch` (and its sibling `--websearch-backend`/`--websearch-fetch-budget` knobs) persists to `~/.claude/.databricks-claude.json` so the daemon picks it up on its next start. Without this, the daemon serves stock Anthropic web-tool requests, which Databricks FMAPI does not currently support — `claude` would then fail web searches even though the proxy is otherwise healthy.
+`--with-websearch` (and its sibling `--backend` / `--fetch-budget` knobs) persists to `~/.claude/.databricks-claude.json` so the daemon picks it up on its next start. Without this, the daemon serves stock Anthropic web-tool requests, which Databricks FMAPI does not currently support — `claude` would then fail web searches even though the proxy is otherwise healthy. (You can also turn websearch on independently of the bootstrap with `databricks-claude config websearch enable`.)
 
-**Why bootstrap via `--write-claude-config` instead of hand-editing `settings.json`?**
+**Why bootstrap via `config write` instead of hand-editing `settings.json`?**
 
 The wrapper writes more than `ANTHROPIC_BASE_URL` on first run. It also writes Databricks-specific model routing (`ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL`), the `x-databricks-use-coding-agent-mode` custom header, and the experimental-betas flag — and the model names are versioned (`databricks-claude-opus-4-7`, etc.), so they change over time. Letting the wrapper write them keeps you in sync with whatever the current shipping binary thinks is correct. Hand-edits get stale.
 
 The write is idempotent — `ensureConfig` short-circuits when the env block already matches.
 
-**Fallback (if `--write-claude-config` is unavailable):** Use `databricks-claude --headless`, wait for `PROXY_URL=http://127.0.0.1:49153`, then stop it (Ctrl+C). This works but binds the proxy port unnecessarily — use `--write-claude-config` instead.
+**Fallback (if `config write` is unavailable):** Use `databricks-claude --headless`, wait for `PROXY_URL=http://127.0.0.1:49153`, then stop it (Ctrl+C). This works but binds the proxy port unnecessarily — use `config write` instead.
 
 **Notes:**
 
-- **The daemon does NOT mutate `~/.claude/settings.json`.** That's the whole point of the daemon vs. the per-session CLI wrapper — it lives outside the per-tool lifecycle. The one-time `--write-claude-config` bootstrap above is the wrapper doing its first-run setup; subsequent daemon restarts do not touch your settings.
-- **Re-bootstrap when model names drift.** If you upgrade `databricks-claude` and the project ships new default model names, re-run `databricks-claude --write-claude-config` once to refresh them. The bootstrap is idempotent and only writes keys that differ.
+- **The daemon does NOT mutate `~/.claude/settings.json`.** That's the whole point of the daemon vs. the per-session CLI wrapper — it lives outside the per-tool lifecycle. The one-time `config write` bootstrap above is the wrapper doing its first-run setup; subsequent daemon restarts do not touch your settings.
+- **Re-bootstrap when model names drift.** If you upgrade `databricks-claude` and the project ships new default model names, re-run `databricks-claude config write` once to refresh them. The bootstrap is idempotent and only writes keys that differ.
 - **OTEL tables persist to state.** Run `databricks-claude serve --otel-metrics-table foo --otel-logs-table bar` once; the daemon (or its installed service) picks them up from `~/.claude/.databricks-claude.json` on every restart thereafter.
 - **Don't run the CLI wrapper (`databricks-claude claude …`) at the same time as the daemon for the same workspace.** Pick one deployment mode per workspace; mixing both means two proxies fighting over the same port and settings block.
 - **Hooks coexist cleanly.** If you've also installed SessionStart hooks (`databricks-claude --install-hooks`), they probe the daemon's `/health` and no-op when it's running, falling back to per-session proxy only if the daemon is down.
@@ -693,15 +771,6 @@ databricks-claude --headless
 | `--profile` | `DEFAULT` | Databricks CLI profile |
 | `--verbose`, `-v` | `false` | Enable debug logging to stderr |
 | `--log-file` | | Write debug logs to a file (combinable with `--verbose`) |
-| `--otel` | `false` | Enable OTEL telemetry proxying (metrics + logs). A signal is emitted only when its table is set. |
-| `--otel-metrics-table` | `main.claude_telemetry.claude_otel_metrics` (only when `--otel` is set) | Unity Catalog table for OTEL metrics |
-| `--otel-logs-table` | derived from metrics table when `--otel` is set | Unity Catalog table for OTEL logs |
-| `--otel-traces` | `false` | Enable Claude Code's `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA` traces export. Standalone — does not require `--otel`. |
-| `--otel-traces-table` | (none) | Unity Catalog table for OTEL traces — required for traces to actually be emitted |
-| `--no-otel` | | Clear every persisted OTEL key (metrics + logs + traces + telemetry toggle) |
-| `--no-otel-metrics` | | Clear only the metrics keys from `~/.claude/settings.json` |
-| `--no-otel-logs` | | Clear only the logs keys from `~/.claude/settings.json` |
-| `--no-otel-traces` | | Clear only the traces keys (incl. `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA`) from `~/.claude/settings.json` |
 | `--upstream` | auto-discovered | Override the AI Gateway URL |
 | `--proxy-api-key` | | Require Bearer token auth on all proxy requests |
 | `--port` | `49153` | Proxy listen port (saved for future sessions) |
@@ -710,8 +779,9 @@ databricks-claude --headless
 | `--headless` | `false` | Start proxy without launching claude (for IDE extensions) |
 | `--idle-timeout` | `30m` | Idle timeout in headless mode (`0` disables) |
 | `--version` | | Print version and exit |
-| `--print-env` | | Print resolved configuration (token redacted) and exit |
 | `--help`, `-h` | | Print the wrapper's flags and exit. Use `databricks-claude -- --help` to forward to claude's own `--help`. |
+
+OpenTelemetry, websearch, settings.json bootstrap, and resolved-config diagnostic flags moved behind the [`config` subcommand](#config-subcommand) tree.
 
 All other flags and args are forwarded to `claude`.
 
@@ -753,10 +823,10 @@ The file is only written when the profile is not `DEFAULT` (the implicit default
 
 ### Verify your auth setup
 
-Run `--print-env` to see the resolved configuration without starting the proxy. The token is redacted so it's safe to share output for debugging.
+Run `databricks-claude config show` to see the resolved configuration without starting the proxy. The token is redacted so it's safe to share output for debugging.
 
 ```bash
-databricks-claude --print-env
+databricks-claude config show
 ```
 
 Example output:
@@ -802,7 +872,7 @@ databricks-claude completion fish | source
 - **Flag values** — context-aware completions for flags that accept a value:
   - `--profile` completes from `~/.databrickscfg` section headers (updated live, no rehash needed).
   - `--upstream`, `--log-file`, `--tls-cert`, `--tls-key` complete with local file paths.
-  - Flags like `--port` or `--otel-metrics-table` suppress file completion.
+  - Flags like `--port` (or `--metrics-table` under `config otel enable`) suppress file completion.
 - **Passthrough boundary** — after a bare `--`, completions stop. Everything beyond that is forwarded to the wrapped `claude` binary.
 
 ### How the engine works

--- a/commands.go
+++ b/commands.go
@@ -64,30 +64,22 @@ var rootCommand = cmd.Command{
 	// The few flags that previously ordered "profile" first now have
 	// it pulled into Persistent (which renders first in AllFlags), so
 	// "profile" still leads the completion script.
+	//
+	// #172 removed 14 "persistent config editor" flags from the root —
+	// they live under `config` now (config otel enable|disable, config
+	// websearch enable|disable, config write, config show). The root is
+	// the transparent-proxy launcher; persistent state mutation lives
+	// under its own subcommand tree.
 	Flags: []cmd.FlagDef{
 		{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
 		{Name: "version", Description: "Print version and exit"},
 		{Name: "help", Short: "h", Description: "Show help message"},
-		{Name: "print-env", Description: "Print resolved configuration (token redacted) and exit"},
-		{Name: "otel", Description: "Enable OpenTelemetry logs/metrics export"},
-		{Name: "no-otel", Description: "Disable OpenTelemetry (clears all signal keys + telemetry toggle)"},
-		{Name: "no-otel-metrics", Description: "Clear persisted OTel metrics keys from settings.json"},
-		{Name: "no-otel-logs", Description: "Clear persisted OTel logs keys from settings.json"},
-		{Name: "no-otel-traces", Description: "Clear persisted OTel traces keys from settings.json"},
-		{Name: "otel-metrics-table", Description: "Unity Catalog table for OTel metrics (cat.schema.table)", TakesArg: true,
-			StateKey: "otel_metrics_table"},
-		{Name: "otel-logs-table", Description: "Unity Catalog table for OTel logs (cat.schema.table)", TakesArg: true,
-			StateKey: "otel_logs_table"},
-		{Name: "otel-traces", Description: "Enable OpenTelemetry traces export (Claude Code beta)"},
-		{Name: "otel-traces-table", Description: "Unity Catalog table for OTel traces (cat.schema.table)", TakesArg: true,
-			StateKey: "otel_traces_table"},
 		{Name: "upstream", Description: "Override upstream claude binary path", TakesArg: true, Completer: "__files"},
 		{Name: "log-file", Description: "Write debug logs to file (combinable with --verbose)", TakesArg: true, Completer: "__files"},
 		{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
 		{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
 		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
 		{Name: "headless", Description: "Start proxy without launching claude (for IDE extensions or hooks)"},
-		{Name: "write-claude-config", Description: "Write first-run settings.json env block and exit (no proxy, no port bind)"},
 		{Name: "idle-timeout", Description: "Idle timeout for headless mode (default: 30m; 0 disables; use e.g. 30s, 5m, 1h)", TakesArg: true,
 			Default: "30m"},
 		{Name: "install-hooks", Description: "Install SessionStart/Stop hooks into ~/.claude/settings.json"},
@@ -96,12 +88,6 @@ var rootCommand = cmd.Command{
 		{Name: "headless-release", Description: "Decrement proxy refcount — called by the Stop hook"},
 		{Name: "no-update-check", Description: "Skip the automatic update check on startup",
 			EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
-		{Name: "with-websearch", Description: "Locally fulfill Anthropic web_search/web_fetch tools (workaround for FMAPI gap)",
-			StateKey: "with_websearch"},
-		{Name: "websearch-backend", Description: "Web search backend (duckduckgo|none)", TakesArg: true,
-			StateKey: "websearch_backend", Default: "duckduckgo"},
-		{Name: "websearch-fetch-budget", Description: "Per-fetch byte budget for --with-websearch (default 102400)", TakesArg: true,
-			StateKey: "websearch_fetch_budget", Default: "102400"},
 		// NOTE: --daemon and --daemon-fake-key are *desktop generate-config*
 		// flags and are deliberately not declared here. They were previously
 		// in the root flag set so completion would offer them, but completion
@@ -132,6 +118,7 @@ var rootCommand = cmd.Command{
 		{Name: "update", Short: "Check for a newer release and print upgrade instructions"},
 		desktopCommand,
 		setupCommand,
+		configCommand,
 		serveCommand,
 	},
 }
@@ -250,32 +237,15 @@ Usage:
   databricks-claude [databricks-claude flags] [claude flags] [claude args]
 
 Databricks-Claude Flags:
-  --profile string      Databricks config profile (saved to ~/.claude/.databricks-claude.json)
-  --upstream string     Override the AI Gateway URL (default: auto-discovered)
-  --print-env           Print resolved configuration and exit (token redacted)
-  --verbose, -v         Enable debug logging to stderr
-  --log-file string     Write debug logs to a file (combinable with --verbose)
-  --otel                       Enable OpenTelemetry metrics + logs export
-  --otel-metrics-table string  Unity Catalog table for OTEL metrics
-  --otel-logs-table string     Unity Catalog table for OTEL logs (derived from metrics table if omitted)
-  --otel-traces                Enable OpenTelemetry traces export (Claude Code beta;
-                               requires --otel-traces-table; can be used standalone)
-  --otel-traces-table string   Unity Catalog table for OTEL traces (cat.schema.table)
-  --no-otel                    Clear persisted OTEL keys and disable OTEL for future sessions
-  --no-otel-metrics            Clear persisted OTEL metrics keys (other signals untouched)
-  --no-otel-logs               Clear persisted OTEL logs keys (other signals untouched)
-  --no-otel-traces             Clear persisted OTEL traces keys (other signals untouched)
+  --profile string             Databricks config profile (saved to ~/.claude/.databricks-claude.json)
+  --upstream string            Override the AI Gateway URL (default: auto-discovered)
+  --verbose, -v                Enable debug logging to stderr
+  --log-file string            Write debug logs to a file (combinable with --verbose)
   --proxy-api-key string       Require Bearer token auth on all proxy requests
   --tls-cert string            Path to TLS certificate file (requires --tls-key)
   --tls-key string             Path to TLS private key file (requires --tls-cert)
   --port int                   Fixed proxy port (default: 49153, saved to state)
   --headless                   Start proxy without launching claude (for IDE extensions)
-  --write-claude-config        Write first-run settings.json env block (proxy URL, model
-                               routing, custom headers) and exit — no proxy startup, no
-                               port binding, no child process. Designed for MDM / fleet
-                               init scripts and as a cleaner alternative to the
-                               '--headless then Ctrl+C' workaround. Idempotent.
-                               Accepts --profile, --port, and OTEL table flags.
   --headless-ensure            Start proxy if not running (called by SessionStart hook)
   --headless-release           Decrement proxy refcount (called by Stop hook)
   --idle-timeout duration      Idle timeout for headless mode (default 30m, 0 disables; use e.g. 30s, 5m, 1h)
@@ -284,12 +254,6 @@ Databricks-Claude Flags:
                                persist them; no prior databricks-claude invocation needed.
   --uninstall-hooks            Remove databricks-claude hooks from ~/.claude/settings.json
   --no-update-check            Skip the automatic update check on startup
-  --with-websearch             Enable local fulfillment of Anthropic web_search/web_fetch
-                               tools (workaround until Databricks FMAPI ships native
-                               support; saved to state). Default: disabled.
-  --websearch-backend string   Search backend when --with-websearch is enabled.
-                               Values: duckduckgo (default, zero config), none
-  --websearch-fetch-budget int Max bytes returned per web_fetch call (default 102400)
   --version                    Print version and exit
   --help, -h                   Show this help message
 
@@ -302,6 +266,14 @@ Subcommands:
                                runs 'databricks auth login' when not authenticated. Designed
                                for fleet init scripts and per-user login agents.
                                Run 'databricks-claude setup --help' for flags.
+  config <subcommand>          Persistent config editor. Mutates settings.json env block
+                               and ~/.claude/.databricks-claude.json for FUTURE runs (does
+                               not affect the current invocation).
+                                 config otel enable|disable      Toggle OTEL signals
+                                 config websearch enable|disable Toggle web_search/_fetch
+                                 config write                    Bootstrap settings.json
+                                 config show                     Print resolved config
+                               Run 'databricks-claude config --help' for details.
   serve [install|uninstall|status|flags]
                                Long-lived daemon serving Claude Code and Claude
                                Desktop with persistent Databricks OAuth. Owns
@@ -621,4 +593,353 @@ Examples:
   databricks-claude desktop generate-trust-profile \
     --cert ./codesign-cert.pem \
     --output dist/databricks-claude-trust.mobileconfig
+`
+
+// configCommand declares the `config` subcommand tree introduced in #172.
+// Consolidates the 14 "persistent config editor" flags (--otel*, --no-otel*,
+// --with-websearch / --websearch-*, --write-claude-config, --print-env) that
+// previously lived on the root command into a discoverable tree. Storage
+// semantics — two-store model (settings.json env block vs. state file),
+// sentinel-guard write logic, --no-otel*-preserves-state-file behavior, OTEL
+// section *removal* (not just skip-the-write) — are unchanged; this is a
+// pure surface reshape.
+//
+// Tree shape:
+//
+//	config
+//	├── otel
+//	│   ├── enable     [--metrics-table T] [--logs-table T] [--traces] [--traces-table T]
+//	│   └── disable    [--metrics] [--logs] [--traces]      (no flags = all signals)
+//	├── websearch
+//	│   ├── enable     [--backend duckduckgo|none] [--fetch-budget N]
+//	│   └── disable
+//	├── write          (was --write-claude-config)
+//	└── show           (was --print-env)
+//
+// Each leaf re-declares --profile / --port locally where it needs them.
+// Persistent-flag inheritance from the root is not yet enforced at parse
+// time (see internal/cmd.Command.Persistent doc), so leaves carry their
+// own flag declarations — mirrors how serveCommand re-declares --port /
+// --profile on its own Flags slice.
+var configCommand = cmd.Command{
+	Name:  "config",
+	Short: "Persistent config editor (otel, websearch, write, show)",
+	Long:  configHelpTemplate,
+	Subcommands: []cmd.Command{
+		{
+			Name:  "otel",
+			Short: "Toggle OpenTelemetry signals (enable|disable)",
+			Long:  configOtelHelpTemplate,
+			Subcommands: []cmd.Command{
+				{
+					Name:  "enable",
+					Short: "Enable OTEL — write OTEL keys into ~/.claude/settings.json",
+					Long:  configOtelEnableHelpTemplate,
+					Flags: []cmd.FlagDef{
+						{Name: "metrics-table", Description: "Unity Catalog table for OTEL metrics (cat.schema.table)", TakesArg: true, StateKey: "otel_metrics_table"},
+						{Name: "logs-table", Description: "Unity Catalog table for OTEL logs (cat.schema.table)", TakesArg: true, StateKey: "otel_logs_table"},
+						{Name: "traces", Description: "Enable OTEL traces export (Claude Code beta)"},
+						{Name: "traces-table", Description: "Unity Catalog table for OTEL traces (cat.schema.table)", TakesArg: true, StateKey: "otel_traces_table"},
+						{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+						{Name: "port", Description: "Proxy listen port (default: state file > 49153)", TakesArg: true, StateKey: "port", Default: "49153"},
+						{Name: "help", Short: "h", Description: "Show help message"},
+					},
+				},
+				{
+					Name:  "disable",
+					Short: "Disable OTEL — clear OTEL keys from ~/.claude/settings.json (state file preserved)",
+					Long:  configOtelDisableHelpTemplate,
+					Flags: []cmd.FlagDef{
+						{Name: "metrics", Description: "Clear only OTEL metrics keys"},
+						{Name: "logs", Description: "Clear only OTEL logs keys"},
+						{Name: "traces", Description: "Clear only OTEL traces keys"},
+						{Name: "help", Short: "h", Description: "Show help message"},
+					},
+				},
+			},
+		},
+		{
+			Name:  "websearch",
+			Short: "Toggle local web_search/web_fetch fulfillment (enable|disable)",
+			Long:  configWebSearchHelpTemplate,
+			Subcommands: []cmd.Command{
+				{
+					Name:  "enable",
+					Short: "Enable websearch workaround — saved to state file",
+					Long:  configWebSearchEnableHelpTemplate,
+					Flags: []cmd.FlagDef{
+						{Name: "backend", Description: "Web search backend (duckduckgo|none)", TakesArg: true, StateKey: "websearch_backend", Default: "duckduckgo"},
+						{Name: "fetch-budget", Description: "Per-fetch byte budget for web_fetch (default 102400)", TakesArg: true, StateKey: "websearch_fetch_budget", Default: "102400"},
+						{Name: "help", Short: "h", Description: "Show help message"},
+					},
+				},
+				{
+					Name:  "disable",
+					Short: "Disable websearch workaround — clears state file keys",
+					Long:  configWebSearchDisableHelpTemplate,
+					Flags: []cmd.FlagDef{
+						{Name: "help", Short: "h", Description: "Show help message"},
+					},
+				},
+			},
+		},
+		{
+			Name:  "write",
+			Short: "Write first-run settings.json env block (was --write-claude-config)",
+			Long:  configWriteHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+				{Name: "port", Description: "Proxy port for ANTHROPIC_BASE_URL (default: state file > 49153)", TakesArg: true, StateKey: "port", Default: "49153"},
+				{Name: "metrics-table", Description: "Unity Catalog table for OTEL metrics", TakesArg: true, StateKey: "otel_metrics_table"},
+				{Name: "logs-table", Description: "Unity Catalog table for OTEL logs", TakesArg: true, StateKey: "otel_logs_table"},
+				{Name: "traces", Description: "Enable OTEL traces export"},
+				{Name: "traces-table", Description: "Unity Catalog table for OTEL traces", TakesArg: true, StateKey: "otel_traces_table"},
+				{Name: "with-websearch", Description: "Enable websearch workaround", StateKey: "with_websearch"},
+				{Name: "backend", Description: "Web search backend (duckduckgo|none)", TakesArg: true, StateKey: "websearch_backend", Default: "duckduckgo"},
+				{Name: "fetch-budget", Description: "Per-fetch byte budget for web_fetch (default 102400)", TakesArg: true, StateKey: "websearch_fetch_budget", Default: "102400"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "show",
+			Short: "Print resolved configuration (was --print-env)",
+			Long:  configShowHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+				{Name: "port", Description: "Proxy port for the displayed ANTHROPIC_BASE_URL", TakesArg: true, StateKey: "port", Default: "49153"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+	},
+}
+
+const configHelpTemplate = `Usage: databricks-claude config <subcommand> [flags]
+
+Persistent config editor. Mutates ~/.claude/settings.json (env block) and
+~/.claude/.databricks-claude.json (state file) for FUTURE invocations.
+None of these subcommands affect the current invocation — they are pure
+config-editor commands. Storage semantics match the legacy root flags
+they replace exactly.
+
+Subcommands:
+  otel enable [flags]       Enable OTEL signals; writes OTEL keys + tables
+                            into settings.json env block.
+  otel disable [flags]      Clear OTEL keys from settings.json. State-file
+                            table preferences are PRESERVED so a subsequent
+                            'config otel enable' restores them.
+  websearch enable [flags]  Enable local web_search/web_fetch fulfillment
+                            (workaround for FMAPI gap). State file only.
+  websearch disable         Clear websearch state-file keys.
+  write [flags]             Write the full first-run settings.json env block
+                            (proxy URL, model routing, custom headers,
+                            optional OTEL keys). Idempotent.
+  show [flags]              Print resolved configuration (token redacted).
+                            Read-only — no writes.
+
+Run 'databricks-claude config <subcommand> --help' for per-subcommand flags.
+
+Examples:
+  # Enable OTEL with explicit metrics + logs tables:
+  databricks-claude config otel enable \
+    --metrics-table main.claude_telemetry.claude_otel_metrics \
+    --logs-table   main.claude_telemetry.claude_otel_logs
+
+  # Disable just metrics (logs + traces still routed if previously enabled):
+  databricks-claude config otel disable --metrics
+
+  # Disable everything OTEL:
+  databricks-claude config otel disable
+
+  # Turn on local websearch workaround:
+  databricks-claude config websearch enable --backend duckduckgo
+
+  # First-run settings.json bootstrap:
+  databricks-claude config write --profile my-workspace
+
+  # Diagnostic dump:
+  databricks-claude config show
+
+Exit codes:
+  0   success
+  1   write/discovery failure
+  2   missing or unknown subcommand
+`
+
+const configOtelHelpTemplate = `Usage: databricks-claude config otel <enable|disable> [flags]
+
+Toggle OpenTelemetry signal export for Claude Code. Storage:
+  - Tables (metrics/logs/traces) are persisted to ~/.claude/.databricks-claude.json
+  - OTEL env keys (OTEL_EXPORTER_OTLP_*_ENDPOINT, CLAUDE_OTEL_UC_*_TABLE,
+    CLAUDE_CODE_ENABLE_TELEMETRY) are written into ~/.claude/settings.json's
+    env block.
+
+'config otel disable' clears settings.json keys but PRESERVES the state
+file so a subsequent 'config otel enable' can restore the table preferences.
+
+Subcommands:
+  enable    Write OTEL keys + tables (see 'config otel enable --help').
+  disable   Clear OTEL keys (see 'config otel disable --help').
+`
+
+const configOtelEnableHelpTemplate = `Usage: databricks-claude config otel enable [flags]
+
+Enable OTEL — writes OTEL env keys into ~/.claude/settings.json and persists
+the resolved table names to ~/.claude/.databricks-claude.json.
+
+Resolution chain per signal: explicit flag > state file > derive (logs from
+metrics) > unset. With no table flags and an empty state file, --metrics-table
+defaults to 'main.claude_telemetry.claude_otel_metrics' (matching the legacy
+'--otel' bare-toggle behavior).
+
+Flags:
+  --metrics-table string   Unity Catalog table for OTEL metrics (cat.schema.table)
+  --logs-table string      Unity Catalog table for OTEL logs   (cat.schema.table)
+  --traces                 Enable OTEL traces export (Claude Code beta)
+  --traces-table string    Unity Catalog table for OTEL traces (cat.schema.table)
+  --profile string         Databricks CLI profile (default: state > DEFAULT)
+  --port int               Proxy port (default: state > 49153)
+  --help, -h               Show this help message
+
+Examples:
+  # Enable with custom metrics + logs tables:
+  databricks-claude config otel enable \
+    --metrics-table main.telemetry.claude_otel_metrics \
+    --logs-table   main.telemetry.claude_otel_logs
+
+  # Enable with default tables (metrics-table inferred):
+  databricks-claude config otel enable
+
+  # Enable traces alongside metrics + logs:
+  databricks-claude config otel enable --traces --traces-table main.telemetry.claude_otel_traces
+`
+
+const configOtelDisableHelpTemplate = `Usage: databricks-claude config otel disable [flags]
+
+Clear OTEL env keys from ~/.claude/settings.json. State-file table
+preferences are PRESERVED — a subsequent 'config otel enable' will restore
+them. With no flags, ALL signal keys are cleared (plus CLAUDE_CODE_ENABLE_TELEMETRY).
+
+Flags:
+  --metrics    Clear only OTEL metrics keys (other signals untouched)
+  --logs       Clear only OTEL logs keys
+  --traces     Clear only OTEL traces keys
+  --help, -h   Show this help message
+
+Examples:
+  # Disable everything:
+  databricks-claude config otel disable
+
+  # Disable just metrics:
+  databricks-claude config otel disable --metrics
+
+  # Disable metrics + logs together (traces stay live):
+  databricks-claude config otel disable --metrics --logs
+`
+
+const configWebSearchHelpTemplate = `Usage: databricks-claude config websearch <enable|disable> [flags]
+
+Toggle local web_search / web_fetch fulfillment in the proxy. This is a
+workaround for the gap where Databricks FMAPI does not (yet) support
+Anthropic's native server-side tool fulfillment. Storage: state file only —
+websearch is a proxy-side feature controlled entirely by
+~/.claude/.databricks-claude.json. Settings.json is NOT touched.
+
+Subcommands:
+  enable    Set with_websearch=true (see 'config websearch enable --help').
+  disable   Set with_websearch=false (clears related state keys).
+`
+
+const configWebSearchEnableHelpTemplate = `Usage: databricks-claude config websearch enable [flags]
+
+Persist with_websearch=true to the state file so the proxy fulfills
+web_search / web_fetch tool calls locally on the next start. Reads
+backend / fetch-budget from flags and falls back to defaults.
+
+Flags:
+  --backend string        Search backend (duckduckgo|none)         [default: duckduckgo]
+  --fetch-budget int      Max bytes returned per web_fetch call    [default: 102400]
+  --help, -h              Show this help message
+
+Examples:
+  # Default (DuckDuckGo, 100 KB budget):
+  databricks-claude config websearch enable
+
+  # Disable scraping but keep web_fetch:
+  databricks-claude config websearch enable --backend none
+
+  # Bump the per-fetch byte budget:
+  databricks-claude config websearch enable --fetch-budget 204800
+`
+
+const configWebSearchDisableHelpTemplate = `Usage: databricks-claude config websearch disable
+
+Clear with_websearch from the state file (sets it to false). Backend +
+fetch-budget keys are also cleared so a future 'config websearch enable'
+re-applies the defaults. New behaviour vs. the legacy CLI (which had no
+explicit websearch disable flag).
+
+Flags:
+  --help, -h   Show this help message
+`
+
+const configWriteHelpTemplate = `Usage: databricks-claude config write [flags]
+
+Write the first-run ~/.claude/settings.json env block (proxy URL, model
+routing, custom headers, optional OTEL keys) and exit. No proxy startup,
+no port binding, no child process — purely a settings-bootstrap. Designed
+for MDM / fleet init scripts and as a cleaner alternative to the
+'--headless then Ctrl+C' workaround. Idempotent.
+
+This was the legacy --write-claude-config flag.
+
+Flags:
+  --profile string         Databricks CLI profile (default: state > DEFAULT)
+  --port int               Proxy port written into ANTHROPIC_BASE_URL (default: state > 49153)
+  --metrics-table string   OTEL metrics UC table (persisted to state)
+  --logs-table string      OTEL logs UC table    (persisted to state)
+  --traces                 Honor traces beta flag for OTEL traces export
+  --traces-table string    OTEL traces UC table  (persisted to state)
+  --with-websearch         Enable local websearch fulfillment (persisted to state)
+  --backend string         Web search backend (duckduckgo|none)
+  --fetch-budget int       Per-fetch byte budget for web_fetch
+  --help, -h               Show this help message
+
+Examples:
+  # Bootstrap with default profile + port:
+  databricks-claude config write
+
+  # MDM rollout — bake fleet-wide profile + workspace:
+  databricks-claude config write --profile databricks-ai-inference
+
+  # Bootstrap with OTEL routing AND websearch:
+  databricks-claude config write \
+    --metrics-table main.telemetry.claude_otel_metrics \
+    --logs-table   main.telemetry.claude_otel_logs \
+    --with-websearch
+`
+
+const configShowHelpTemplate = `Usage: databricks-claude config show [flags]
+
+Print the resolved configuration (token redacted) and exit. Read-only —
+zero writes to settings.json or the state file. Replaces the legacy
+--print-env flag.
+
+Resolves: profile, Databricks workspace host, AI Gateway URL,
+ANTHROPIC_AUTH_TOKEN (redacted), upstream claude binary, OTEL active flag,
+and any persisted OTEL UC tables.
+
+Flags:
+  --profile string   Databricks CLI profile (default: state > DEFAULT)
+  --port int         Port used to display the proxy URL (default: state > 49153)
+  --help, -h         Show this help message
+
+Example output:
+
+  databricks-claude configuration:
+    Profile:              DEFAULT
+    DATABRICKS_HOST:      https://adb-...azuredatabricks.net
+    ANTHROPIC_BASE_URL:   https://adb-.../ai-gateway/anthropic
+    ANTHROPIC_AUTH_TOKEN: dapi-***
+    Upstream binary:      /usr/local/bin/claude
+    OTEL enabled:         false
 `

--- a/config.go
+++ b/config.go
@@ -1,0 +1,638 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/IceRhymers/databricks-claude/internal/cmd"
+)
+
+// runConfigCommand implements the `databricks-claude config ...` dispatcher.
+// args is everything after the literal "config" token. Routes to the otel,
+// websearch, write, or show runner. Bare `config` (no args) prints help and
+// exits 2 — same convention as `desktop` with no action.
+//
+// The persistent-config editor was previously a sprawl of 14 root flags
+// (--otel*, --no-otel*, --write-claude-config, --print-env, --with-websearch
+// / --websearch-*); #172 consolidates them under this tree. Storage
+// semantics are byte-identical with the legacy paths — only the surface has
+// moved. The pure-function resolvers (resolveConfigOTEL,
+// resolveConfigWebSearch) make the orchestration matrix testable in
+// isolation; helper-level tests passing while composition is broken is the
+// known failure mode for this kind of refactor, and the matrix test in
+// config_test.go is the safety net.
+func runConfigCommand(args []string) {
+	if len(args) == 0 {
+		_ = cmd.Render(os.Stderr, configCommand, nil)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "otel":
+		runConfigOTEL(args[1:])
+	case "websearch":
+		runConfigWebSearch(args[1:])
+	case "write":
+		runConfigWrite(args[1:])
+	case "show":
+		runConfigShow(args[1:])
+	case "--help", "-h", "help":
+		_ = cmd.Render(os.Stdout, configCommand, nil)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-claude: unknown config subcommand %q\n\n", args[0])
+		_ = cmd.Render(os.Stderr, configCommand, nil)
+		os.Exit(1)
+	}
+}
+
+// configOTELResolution is the pure-function projection of the OTEL enable
+// resolution chain. Extracted so the orchestration matrix test (state
+// empty/populated × explicit table flags × derive-logs-from-metrics) can
+// drive it in isolation. Caller is responsible for the post-resolve
+// settings.json write.
+type configOTELResolution struct {
+	Profile        string
+	Port           int
+	ProxyURL       string
+	MetricsTable   string
+	LogsTable      string
+	TracesTable    string
+	OTELEnv        map[string]string // keys to write into settings.json env block
+	NewState       persistentState   // state to persist (callers gate the write on a mutated check)
+	StateMutated   bool              // true when NewState differs from the input saved state
+	TracesEnabled  bool              // mirrors --traces flag (for log lines / future use)
+}
+
+// resolveConfigOTEL performs the OTEL enable-side resolution that the legacy
+// --write-claude-config block did inline. Pure function: no I/O, no global
+// state. Drives the orchestration matrix test (#172 acceptance criterion).
+//
+// Resolution chain per signal: explicit flag > saved state > derive (logs
+// from metrics, only when metrics is set) > unset. With NO --metrics-table
+// flag AND empty state, we apply the same default the legacy --otel bare
+// toggle did: "main.claude_telemetry.claude_otel_metrics". This preserves
+// the issue-#172 behaviour-mapping note "preserve the
+// `else if ucMetricsTable == "" && a.OTEL` default-application from
+// main.go:595–597".
+//
+// otelEnv contains ONLY the OTEL keys (CLAUDE_OTEL_UC_*_TABLE, exporter
+// endpoints/headers/protocols, intervals, CLAUDE_CODE_ENABLE_TELEMETRY).
+// databricksFullSetupEnv() is intentionally NOT merged here — that is
+// `config write`'s job. Callers route otelEnv through bootstrapSettings,
+// which always (re)sets ANTHROPIC_BASE_URL to proxyURL — same as the legacy
+// --write-claude-config flow.
+//
+// applyMetricsDefault gates the bare-toggle metrics default. `config otel
+// enable` passes true: a bare invocation (no --metrics-table, empty state)
+// must enable OTEL with the legacy --otel default table, matching the old
+// `else if ucMetricsTable == "" && a.OTEL` branch. `config write` passes
+// FALSE: the legacy --write-claude-config block resolved tables strictly
+// flag → state → empty and NEVER applied the metrics default, so a
+// fresh-install `config write` with no flags writes only the model-routing
+// env block — it must NOT silently enable telemetry export to a UC table
+// the user never created (which would 400 at Databricks ingest).
+func resolveConfigOTEL(
+	saved persistentState,
+	port int,
+	proxyURL string,
+	metricsTableFlag string, metricsTableSet bool,
+	logsTableFlag string, logsTableSet bool,
+	tracesFlag bool,
+	tracesTableFlag string, tracesTableSet bool,
+	applyMetricsDefault bool,
+) configOTELResolution {
+	r := configOTELResolution{
+		Port:          port,
+		ProxyURL:      proxyURL,
+		MetricsTable:  saved.OtelMetricsTable,
+		LogsTable:     saved.OtelLogsTable,
+		TracesTable:   saved.OtelTracesTable,
+		NewState:      saved,
+		TracesEnabled: tracesFlag,
+	}
+
+	if metricsTableSet {
+		r.MetricsTable = metricsTableFlag
+	} else if r.MetricsTable == "" && applyMetricsDefault {
+		// Bare `config otel enable` (no --metrics-table, no state) inherits the
+		// legacy --otel default. Without this, an empty-state user invoking
+		// `config otel enable` with no flags would write nothing — the issue
+		// explicitly maps the bare toggle to "enable with default".
+		//
+		// `config write` passes applyMetricsDefault=false: the legacy
+		// --write-claude-config flow never applied this default, and applying
+		// it here would silently enable telemetry on a fresh install.
+		r.MetricsTable = "main.claude_telemetry.claude_otel_metrics"
+	}
+
+	if logsTableSet {
+		r.LogsTable = logsTableFlag
+	} else if r.LogsTable == "" && r.MetricsTable != "" {
+		r.LogsTable = deriveLogsTable(r.MetricsTable)
+	}
+
+	if tracesTableSet {
+		r.TracesTable = tracesTableFlag
+	}
+
+	// Persist explicitly-set tables to state (sentinel-guarded mutated-flag
+	// pattern — empty resolved values are NOT persisted, matching shouldPersistOTELTable).
+	mutated := false
+	if metricsTableSet && r.MetricsTable != "" && r.NewState.OtelMetricsTable != r.MetricsTable {
+		r.NewState.OtelMetricsTable = r.MetricsTable
+		mutated = true
+	}
+	if logsTableSet && r.LogsTable != "" && r.NewState.OtelLogsTable != r.LogsTable {
+		r.NewState.OtelLogsTable = r.LogsTable
+		mutated = true
+	}
+	if tracesTableSet && r.TracesTable != "" && r.NewState.OtelTracesTable != r.TracesTable {
+		r.NewState.OtelTracesTable = r.TracesTable
+		mutated = true
+	}
+	r.StateMutated = mutated
+
+	r.OTELEnv = buildOTELEnv(r.MetricsTable, r.LogsTable, r.TracesTable, proxyURL)
+	return r
+}
+
+// buildOTELEnv constructs the OTEL env keys to write into settings.json.
+// Mirrors main.go:844–875 (the normal-flow otelEnv build) and main.go:285–312
+// (the legacy --write-claude-config OTEL block) byte-for-byte. Each signal's
+// keys are emitted only when its UC table is configured (table-presence
+// semantics).
+func buildOTELEnv(metricsTable, logsTable, tracesTable, proxyURL string) map[string]string {
+	env := map[string]string{}
+	if metricsTable != "" {
+		env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = proxyURL + "/otel/v1/metrics"
+		env["OTEL_EXPORTER_OTLP_METRICS_HEADERS"] = "content-type=application/x-protobuf"
+		env["OTEL_METRICS_EXPORTER"] = "otlp"
+		env["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "http/protobuf"
+		env["OTEL_METRIC_EXPORT_INTERVAL"] = "10000"
+		env["CLAUDE_OTEL_UC_METRICS_TABLE"] = metricsTable
+	}
+	if logsTable != "" {
+		env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = proxyURL + "/otel/v1/logs"
+		env["OTEL_EXPORTER_OTLP_LOGS_HEADERS"] = "content-type=application/x-protobuf"
+		env["OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"] = "http/protobuf"
+		env["OTEL_LOGS_EXPORTER"] = "otlp"
+		env["OTEL_LOGS_EXPORT_INTERVAL"] = "5000"
+		env["CLAUDE_OTEL_UC_LOGS_TABLE"] = logsTable
+	}
+	if tracesTable != "" {
+		env["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "1"
+		env["OTEL_TRACES_EXPORTER"] = "otlp"
+		env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = proxyURL + "/otel/v1/traces"
+		env["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/protobuf"
+		env["OTEL_TRACES_EXPORT_INTERVAL"] = "5000"
+		env["CLAUDE_OTEL_UC_TRACES_TABLE"] = tracesTable
+	}
+	if metricsTable != "" || logsTable != "" || tracesTable != "" {
+		env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+	}
+	return env
+}
+
+// configWebSearchResolution is the pure-function projection of the
+// websearch enable/disable resolution. Mirrors configOTELResolution shape.
+type configWebSearchResolution struct {
+	NewState     persistentState
+	StateMutated bool
+}
+
+// resolveConfigWebSearch performs the websearch enable-side resolution.
+// Pure function. Storage: state file only — websearch is a proxy-side
+// feature with no settings.json key (the proxy reads with_websearch from
+// state on next start).
+//
+// `enable` semantics: with_websearch=true; flag values override state;
+// missing flags inherit existing state (NOT defaults — the defaults live in
+// the proxy's main.go startup block as the fallback when state is empty).
+// `disable` semantics: with_websearch=false AND clear backend/fetch-budget
+// so a future enable re-applies the proper defaults.
+func resolveConfigWebSearch(
+	saved persistentState,
+	enable bool,
+	backendFlag string, backendSet bool,
+	budgetFlag int, budgetSet bool,
+) configWebSearchResolution {
+	r := configWebSearchResolution{NewState: saved}
+
+	if !enable {
+		// Disable: zero-out everything related to websearch so a re-enable
+		// re-applies the defaults from runProxy. This is NEW behaviour
+		// relative to the legacy CLI (which had no explicit websearch
+		// disable flag); the issue body explicitly sanctions it.
+		mutated := false
+		if r.NewState.WithWebSearch {
+			r.NewState.WithWebSearch = false
+			mutated = true
+		}
+		if r.NewState.WebSearchBackend != "" {
+			r.NewState.WebSearchBackend = ""
+			mutated = true
+		}
+		if r.NewState.WebSearchFetchBudget != 0 {
+			r.NewState.WebSearchFetchBudget = 0
+			mutated = true
+		}
+		r.StateMutated = mutated
+		return r
+	}
+
+	// Enable: with_websearch=true; flag overrides state; otherwise preserve
+	// existing state. Sentinel-guard the persist: only write when something
+	// actually changed.
+	mutated := false
+	if !r.NewState.WithWebSearch {
+		r.NewState.WithWebSearch = true
+		mutated = true
+	}
+	if backendSet && r.NewState.WebSearchBackend != backendFlag {
+		r.NewState.WebSearchBackend = backendFlag
+		mutated = true
+	}
+	if budgetSet && r.NewState.WebSearchFetchBudget != budgetFlag {
+		r.NewState.WebSearchFetchBudget = budgetFlag
+		mutated = true
+	}
+	r.StateMutated = mutated
+	return r
+}
+
+// runConfigOTEL implements `databricks-claude config otel <enable|disable>`.
+func runConfigOTEL(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "databricks-claude: 'config otel' requires a subcommand: enable or disable")
+		_ = cmd.Render(os.Stderr, *configCommand.Subcommand("otel"), nil)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "enable":
+		runConfigOTELEnable(args[1:])
+	case "disable":
+		runConfigOTELDisable(args[1:])
+	case "--help", "-h", "help":
+		_ = cmd.Render(os.Stdout, *configCommand.Subcommand("otel"), nil)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-claude: unknown config otel subcommand %q\n\n", args[0])
+		_ = cmd.Render(os.Stderr, *configCommand.Subcommand("otel"), nil)
+		os.Exit(1)
+	}
+}
+
+func runConfigOTELEnable(args []string) {
+	node := configCommand.Subcommand("otel").Subcommand("enable")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	profile := r.Strings["profile"]
+	saved := loadState()
+	if profile == "" {
+		profile = saved.Profile
+	}
+	if profile == "" {
+		profile = "DEFAULT"
+	}
+
+	portFlag := atoiOrZero(r.Strings["port"])
+	port := resolvePort(portFlag, saved)
+	proxyURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// Validate the profile is reachable. Mirrors --write-claude-config's
+	// guard at main.go:240–243 — empty/unknown profile fails fast with an
+	// actionable error rather than writing a guaranteed-broken settings.json.
+	if _, err := DiscoverHost(profile, ""); err != nil {
+		log.Fatalf("databricks-claude: config otel enable: failed to discover host for profile %q: %v\n"+
+			"Run 'databricks auth login --profile %s' first", profile, err, profile)
+	}
+
+	res := resolveConfigOTEL(
+		saved,
+		port,
+		proxyURL,
+		r.Strings["metrics-table"], r.Set["metrics-table"],
+		r.Strings["logs-table"], r.Set["logs-table"],
+		r.Bools["traces"],
+		r.Strings["traces-table"], r.Set["traces-table"],
+		true, // config otel enable: bare invocation applies the legacy --otel metrics default
+	)
+
+	if res.StateMutated {
+		if err := saveState(res.NewState); err != nil {
+			log.Fatalf("databricks-claude: config otel enable: could not persist OTEL tables: %v", err)
+		}
+	}
+
+	if err := bootstrapSettings(portFlag, profile, proxyURL, res.OTELEnv); err != nil {
+		log.Fatalf("databricks-claude: config otel enable: %v", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "databricks-claude: OTEL enabled (profile=%s, base_url=%s, metrics=%s, logs=%s, traces=%s)\n",
+		profile, proxyURL, displayTableOrNone(res.MetricsTable), displayTableOrNone(res.LogsTable), displayTableOrNone(res.TracesTable))
+}
+
+func runConfigOTELDisable(args []string) {
+	node := configCommand.Subcommand("otel").Subcommand("disable")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("databricks-claude: cannot determine home dir: %v", err)
+	}
+	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
+
+	clearMetrics := r.Bools["metrics"]
+	clearLogs := r.Bools["logs"]
+	clearTraces := r.Bools["traces"]
+
+	// No flags = nuclear option (every OTEL key, including
+	// CLAUDE_CODE_ENABLE_TELEMETRY). Matches the legacy --no-otel.
+	if !clearMetrics && !clearLogs && !clearTraces {
+		if err := clearOTELKeys(settingsPath); err != nil {
+			log.Fatalf("databricks-claude: config otel disable: failed to clear OTEL keys: %v", err)
+		}
+		fmt.Fprintln(os.Stderr, "databricks-claude: OTEL keys cleared — OTEL disabled for future sessions (state file table preferences preserved)")
+		return
+	}
+
+	if clearMetrics {
+		if err := clearOTELKeysSubset(settingsPath, otelMetricsKeys); err != nil {
+			log.Fatalf("databricks-claude: config otel disable: failed to clear OTEL metrics keys: %v", err)
+		}
+		fmt.Fprintln(os.Stderr, "databricks-claude: OTEL metrics keys cleared")
+	}
+	if clearLogs {
+		if err := clearOTELKeysSubset(settingsPath, otelLogsKeys); err != nil {
+			log.Fatalf("databricks-claude: config otel disable: failed to clear OTEL logs keys: %v", err)
+		}
+		fmt.Fprintln(os.Stderr, "databricks-claude: OTEL logs keys cleared")
+	}
+	if clearTraces {
+		if err := clearOTELKeysSubset(settingsPath, otelTracesKeys); err != nil {
+			log.Fatalf("databricks-claude: config otel disable: failed to clear OTEL traces keys: %v", err)
+		}
+		fmt.Fprintln(os.Stderr, "databricks-claude: OTEL traces keys cleared")
+	}
+}
+
+// runConfigWebSearch implements `databricks-claude config websearch <enable|disable>`.
+func runConfigWebSearch(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "databricks-claude: 'config websearch' requires a subcommand: enable or disable")
+		_ = cmd.Render(os.Stderr, *configCommand.Subcommand("websearch"), nil)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "enable":
+		runConfigWebSearchEnable(args[1:])
+	case "disable":
+		runConfigWebSearchDisable(args[1:])
+	case "--help", "-h", "help":
+		_ = cmd.Render(os.Stdout, *configCommand.Subcommand("websearch"), nil)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-claude: unknown config websearch subcommand %q\n\n", args[0])
+		_ = cmd.Render(os.Stderr, *configCommand.Subcommand("websearch"), nil)
+		os.Exit(1)
+	}
+}
+
+func runConfigWebSearchEnable(args []string) {
+	node := configCommand.Subcommand("websearch").Subcommand("enable")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	saved := loadState()
+	budgetFlag, budgetSet := 0, false
+	if r.Set["fetch-budget"] {
+		raw := r.Strings["fetch-budget"]
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			log.Fatalf("databricks-claude: config websearch enable: --fetch-budget: %q is not an integer", raw)
+		}
+		budgetFlag = n
+		budgetSet = true
+	}
+
+	res := resolveConfigWebSearch(saved, true, r.Strings["backend"], r.Set["backend"], budgetFlag, budgetSet)
+	if res.StateMutated {
+		if err := saveState(res.NewState); err != nil {
+			log.Fatalf("databricks-claude: config websearch enable: could not persist websearch state: %v", err)
+		}
+	}
+
+	backend := res.NewState.WebSearchBackend
+	if backend == "" {
+		backend = "duckduckgo"
+	}
+	budget := res.NewState.WebSearchFetchBudget
+	if budget <= 0 {
+		budget = 100 * 1024
+	}
+	fmt.Fprintf(os.Stderr, "databricks-claude: websearch enabled (backend=%s, fetch-budget=%d). The proxy will fulfill web_search/web_fetch locally on its next start.\n", backend, budget)
+}
+
+func runConfigWebSearchDisable(args []string) {
+	node := configCommand.Subcommand("websearch").Subcommand("disable")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	saved := loadState()
+	res := resolveConfigWebSearch(saved, false, "", false, 0, false)
+	if res.StateMutated {
+		if err := saveState(res.NewState); err != nil {
+			log.Fatalf("databricks-claude: config websearch disable: could not persist websearch state: %v", err)
+		}
+	}
+	fmt.Fprintln(os.Stderr, "databricks-claude: websearch disabled (state file with_websearch=false; backend/fetch-budget cleared)")
+}
+
+// runConfigWrite implements `databricks-claude config write` — the legacy
+// --write-claude-config flow lifted into a subcommand. Bootstraps the full
+// settings.json env block (proxy URL, model routing, custom headers,
+// optional OTEL keys) and exits. No proxy startup, no port binding, no
+// child process. Idempotent.
+func runConfigWrite(args []string) {
+	node := configCommand.Subcommand("write")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	profile := r.Strings["profile"]
+	saved := loadState()
+	if profile == "" {
+		profile = saved.Profile
+	}
+	if profile == "" {
+		profile = "DEFAULT"
+	}
+
+	portFlag := atoiOrZero(r.Strings["port"])
+	port := resolvePort(portFlag, saved)
+	proxyURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	if _, err := DiscoverHost(profile, ""); err != nil {
+		log.Fatalf("databricks-claude: config write: failed to discover host for profile %q: %v\n"+
+			"Run 'databricks auth login --profile %s' first", profile, err, profile)
+	}
+
+	// OTEL resolution: re-use the same resolver as `config otel enable` so
+	// the persistence semantics (sentinel-guarded writes) are identical. Note
+	// that `config write` differs from `config otel enable` only in that it
+	// also merges databricksFullSetupEnv into the otelEnv map below.
+	otelRes := resolveConfigOTEL(
+		saved,
+		port,
+		proxyURL,
+		r.Strings["metrics-table"], r.Set["metrics-table"],
+		r.Strings["logs-table"], r.Set["logs-table"],
+		r.Bools["traces"],
+		r.Strings["traces-table"], r.Set["traces-table"],
+		false, // config write: legacy --write-claude-config never applied the metrics default
+	)
+	if otelRes.StateMutated {
+		if err := saveState(otelRes.NewState); err != nil {
+			log.Fatalf("databricks-claude: config write: could not persist OTEL tables: %v", err)
+		}
+		// Reload state so the websearch resolver sees the OTEL-side mutation
+		// for sentinel comparisons. Mirrors main.go:324 in the legacy
+		// --write-claude-config flow ("Reload state here so we pick up any
+		// OTEL writes from above").
+		saved = loadState()
+	}
+
+	// `config write` is the only path that has the bare-toggle "with_websearch"
+	// flag — there is no separate "fetch-budget" / "backend" knob without it
+	// here either, but they are accepted in the same parse since the issue's
+	// behaviour mapping requires it.
+	enable := saved.WithWebSearch
+	if r.Set["with-websearch"] {
+		enable = r.Bools["with-websearch"]
+	}
+	budgetFlag, budgetSet := 0, false
+	if r.Set["fetch-budget"] {
+		raw := r.Strings["fetch-budget"]
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			log.Fatalf("databricks-claude: config write: --fetch-budget: %q is not an integer", raw)
+		}
+		budgetFlag = n
+		budgetSet = true
+	}
+	wsRes := resolveConfigWebSearch(saved, enable, r.Strings["backend"], r.Set["backend"], budgetFlag, budgetSet)
+	if wsRes.StateMutated {
+		if err := saveState(wsRes.NewState); err != nil {
+			log.Fatalf("databricks-claude: config write: could not persist websearch state: %v", err)
+		}
+		saved = loadState()
+	}
+
+	// Compose the full env block. Same shape as main.go:285–315 in the legacy
+	// path: OTEL keys + databricksFullSetupEnv (model routing + custom headers).
+	envOut := map[string]string{}
+	for k, v := range otelRes.OTELEnv {
+		envOut[k] = v
+	}
+	for k, v := range databricksFullSetupEnv() {
+		envOut[k] = v
+	}
+
+	if err := bootstrapSettings(portFlag, profile, proxyURL, envOut); err != nil {
+		log.Fatalf("databricks-claude: config write: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "databricks-claude: wrote env block to ~/.claude/settings.json (profile=%s, base_url=%s, websearch=%t)\n",
+		profile, proxyURL, saved.WithWebSearch)
+}
+
+// runConfigShow implements `databricks-claude config show` — the legacy
+// --print-env flow lifted into a subcommand. Read-only diagnostic.
+func runConfigShow(args []string) {
+	node := configCommand.Subcommand("show")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	profile := r.Strings["profile"]
+	saved := loadState()
+	if profile == "" {
+		profile = saved.Profile
+	}
+	if profile == "" {
+		profile = "DEFAULT"
+	}
+
+	portFlag := atoiOrZero(r.Strings["port"])
+	port := resolvePort(portFlag, saved)
+
+	host, err := DiscoverHost(profile, "")
+	if err != nil {
+		log.Fatalf("databricks-claude: config show: failed to discover host for profile %q: %v\n"+
+			"Run 'databricks auth login --profile %s' first", profile, err, profile)
+	}
+	inferenceUpstream := ConstructGatewayURL(host)
+
+	tp := NewTokenProvider(profile, "")
+	token, err := tp.Token(context.Background())
+	if err != nil {
+		log.Fatalf("databricks-claude: config show: failed to fetch token for profile %q: %v", profile, err)
+	}
+
+	metricsTable := saved.OtelMetricsTable
+	logsTable := saved.OtelLogsTable
+	tracesTable := saved.OtelTracesTable
+	otelActive := metricsTable != "" || logsTable != "" || tracesTable != ""
+
+	// Reference port to avoid the unused-variable warning while keeping the
+	// resolution above for parity with --print-env's input set. handlePrintEnv
+	// does not consume port directly — it reads ANTHROPIC_BASE_URL from the
+	// constructed inferenceUpstream, which is the gateway URL not the proxy URL.
+	_ = port
+
+	handlePrintEnv(profile, host, inferenceUpstream, token, "", otelActive, metricsTable, logsTable, tracesTable)
+}
+
+// atoiOrZero parses s as a base-10 int. Returns 0 on parse failure so
+// resolvePort can fall back to state/default — the same tolerance the
+// hand-rolled --port parsing in parseArgs had pre-#172.
+func atoiOrZero(s string) int {
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// displayTableOrNone returns the literal table name or "(none)" when empty,
+// for the confirmation log line emitted by `config otel enable`.
+func displayTableOrNone(t string) string {
+	if t == "" {
+		return "(none)"
+	}
+	return t
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,681 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- #172 config tree parity tests ---
+
+// TestConfigCommandParity checks the top-level `config` node carries no
+// flags of its own (it's a pure dispatcher; subcommands carry the flag
+// surface). #170/#171 parity-test pattern: commit to a flag set, fail loud
+// on drift.
+func TestConfigCommandParity(t *testing.T) {
+	assertFlagSetEqual(t, "configCommand", configCommand, []string{})
+}
+
+func TestConfigOTELEnableParity(t *testing.T) {
+	otel := configCommand.Subcommand("otel")
+	if otel == nil {
+		t.Fatal("configCommand should have an `otel` subcommand")
+	}
+	enable := otel.Subcommand("enable")
+	if enable == nil {
+		t.Fatal("config otel should have an `enable` subcommand")
+	}
+	assertFlagSetEqual(t, "config otel enable", *enable, []string{
+		"metrics-table", "logs-table", "traces", "traces-table",
+		"profile", "port", "help",
+	})
+}
+
+func TestConfigOTELDisableParity(t *testing.T) {
+	otel := configCommand.Subcommand("otel")
+	if otel == nil {
+		t.Fatal("configCommand should have an `otel` subcommand")
+	}
+	disable := otel.Subcommand("disable")
+	if disable == nil {
+		t.Fatal("config otel should have a `disable` subcommand")
+	}
+	assertFlagSetEqual(t, "config otel disable", *disable, []string{
+		"metrics", "logs", "traces", "help",
+	})
+}
+
+func TestConfigWebSearchEnableParity(t *testing.T) {
+	ws := configCommand.Subcommand("websearch")
+	if ws == nil {
+		t.Fatal("configCommand should have a `websearch` subcommand")
+	}
+	enable := ws.Subcommand("enable")
+	if enable == nil {
+		t.Fatal("config websearch should have an `enable` subcommand")
+	}
+	assertFlagSetEqual(t, "config websearch enable", *enable, []string{
+		"backend", "fetch-budget", "help",
+	})
+}
+
+func TestConfigWebSearchDisableParity(t *testing.T) {
+	ws := configCommand.Subcommand("websearch")
+	if ws == nil {
+		t.Fatal("configCommand should have a `websearch` subcommand")
+	}
+	disable := ws.Subcommand("disable")
+	if disable == nil {
+		t.Fatal("config websearch should have a `disable` subcommand")
+	}
+	assertFlagSetEqual(t, "config websearch disable", *disable, []string{"help"})
+}
+
+func TestConfigWriteParity(t *testing.T) {
+	write := configCommand.Subcommand("write")
+	if write == nil {
+		t.Fatal("configCommand should have a `write` subcommand")
+	}
+	assertFlagSetEqual(t, "config write", *write, []string{
+		"profile", "port",
+		"metrics-table", "logs-table", "traces", "traces-table",
+		"with-websearch", "backend", "fetch-budget",
+		"help",
+	})
+}
+
+func TestConfigShowParity(t *testing.T) {
+	show := configCommand.Subcommand("show")
+	if show == nil {
+		t.Fatal("configCommand should have a `show` subcommand")
+	}
+	assertFlagSetEqual(t, "config show", *show, []string{"profile", "port", "help"})
+}
+
+// TestConfigHasNestedSubcommands asserts the otel/websearch/write/show
+// children are declared so completion can offer them nested. Mirrors
+// TestServeHasNestedSubcommands (#171). Drives the AC: "Help + completion
+// derived from the tree".
+func TestConfigHasNestedSubcommands(t *testing.T) {
+	want := []string{"otel", "websearch", "write", "show"}
+	got := make(map[string]bool, len(configCommand.Subcommands))
+	for _, s := range configCommand.Subcommands {
+		got[s.Name] = true
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("configCommand should have nested `%s` subcommand", w)
+		}
+	}
+}
+
+// TestConfigCompletionExposed verifies the root tree's recursive
+// CompletionSubcommands walk surfaces `config otel enable` / `config
+// websearch enable` etc. as nested completion entries. Drives the
+// completion-side of the issue AC.
+func TestConfigCompletionExposed(t *testing.T) {
+	subs := rootCommand.CompletionSubcommands()
+	var configSub *struct {
+		name string
+		kids []string
+	}
+	for _, s := range subs {
+		if s.Name == "config" {
+			c := struct {
+				name string
+				kids []string
+			}{name: s.Name}
+			for _, k := range s.Subcommands {
+				c.kids = append(c.kids, k.Name)
+			}
+			configSub = &c
+			break
+		}
+	}
+	if configSub == nil {
+		t.Fatal("rootCommand.CompletionSubcommands() missing `config`")
+	}
+	for _, want := range []string{"otel", "websearch", "write", "show"} {
+		found := false
+		for _, k := range configSub.kids {
+			if k == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("config completion missing nested child %q (got %v)", want, configSub.kids)
+		}
+	}
+}
+
+// --- #172 OTEL orchestration matrix test ---
+//
+// AC requirement: "Orchestration matrix test ported: state empty/populated
+// × enable/disable combinations × explicit table flags — assert the final
+// resolved (otel, metricsTable, logsTable, tracesTable) tuple."
+//
+// Drives the pure resolveConfigOTEL function. Helper-level tests passing
+// while composition is broken is the known failure mode for refactors of
+// this shape; this matrix covers the cross-product so a regression in any
+// branch of the resolver fails the suite loudly.
+
+func TestResolveConfigOTEL_OrchestrationMatrix(t *testing.T) {
+	const proxyURL = "http://127.0.0.1:49153"
+	const port = 49153
+
+	// emptyState mirrors a fresh-install user; populatedState mirrors a
+	// returning user with explicit prior table preferences.
+	emptyState := persistentState{}
+	populatedState := persistentState{
+		OtelMetricsTable: "main.team.metrics_prior",
+		OtelLogsTable:    "main.team.logs_prior",
+		OtelTracesTable:  "main.team.traces_prior",
+	}
+
+	type wantTuple struct {
+		metrics, logs, traces string
+		otelEnvHasMetrics     bool
+		otelEnvHasLogs        bool
+		otelEnvHasTraces      bool
+		otelEnvHasTelemetry   bool // CLAUDE_CODE_ENABLE_TELEMETRY
+		stateMetrics          string
+		stateLogs             string
+		stateTraces           string
+		stateMutated          bool
+	}
+
+	cases := []struct {
+		name             string
+		saved            persistentState
+		metricsFlag      string
+		metricsSet       bool
+		logsFlag         string
+		logsSet          bool
+		tracesBool       bool
+		tracesTableFlag  string
+		tracesTableSet   bool
+		applyDefault     bool
+		want             wantTuple
+	}{
+		{
+			name:         "empty state, no flags, applyDefault=true → applies legacy metrics default + derives logs",
+			saved:        emptyState,
+			applyDefault: true,
+			want: wantTuple{
+				metrics:             "main.claude_telemetry.claude_otel_metrics",
+				logs:                "main.claude_telemetry.claude_otel_logs",
+				otelEnvHasMetrics:   true,
+				otelEnvHasLogs:      true,
+				otelEnvHasTelemetry: true,
+				stateMetrics:        "",
+				stateLogs:           "",
+				stateMutated:        false,
+			},
+		},
+		{
+			// config write path: applyDefault=false. A fresh-install `config
+			// write` with no OTEL flags must resolve every table empty and emit
+			// an EMPTY otelEnv — the legacy --write-claude-config block never
+			// applied the metrics default, and doing so would silently enable
+			// telemetry export to a non-existent UC table.
+			name:         "empty state, no flags, applyDefault=false → no tables, empty otelEnv",
+			saved:        emptyState,
+			applyDefault: false,
+			want: wantTuple{
+				metrics:             "",
+				logs:                "",
+				traces:              "",
+				otelEnvHasMetrics:   false,
+				otelEnvHasLogs:      false,
+				otelEnvHasTraces:    false,
+				otelEnvHasTelemetry: false,
+				stateMetrics:        "",
+				stateLogs:           "",
+				stateMutated:        false,
+			},
+		},
+		{
+			name:         "empty state, --metrics-table only → derives logs, persists metrics",
+			saved:        emptyState,
+			metricsFlag:  "cat.s.m",
+			metricsSet:   true,
+			applyDefault: true,
+			want: wantTuple{
+				metrics:             "cat.s.m",
+				logs:                "cat.s.m_otel_logs",
+				otelEnvHasMetrics:   true,
+				otelEnvHasLogs:      true,
+				otelEnvHasTelemetry: true,
+				stateMetrics:        "cat.s.m",
+				stateMutated:        true,
+			},
+		},
+		{
+			// applyDefault=false but an explicit --metrics-table is still
+			// honoured — the gate only affects the bare-toggle default, not
+			// explicit flags. This is the `config write --metrics-table` path.
+			name:         "empty state, --metrics-table only, applyDefault=false → explicit flag still honoured",
+			saved:        emptyState,
+			metricsFlag:  "cat.s.m",
+			metricsSet:   true,
+			applyDefault: false,
+			want: wantTuple{
+				metrics:             "cat.s.m",
+				logs:                "cat.s.m_otel_logs",
+				otelEnvHasMetrics:   true,
+				otelEnvHasLogs:      true,
+				otelEnvHasTelemetry: true,
+				stateMetrics:        "cat.s.m",
+				stateMutated:        true,
+			},
+		},
+		{
+			name:         "empty state, both metrics and logs explicit → no derivation",
+			saved:        emptyState,
+			metricsFlag:  "cat.s.m",
+			metricsSet:   true,
+			logsFlag:     "cat.s.l",
+			logsSet:      true,
+			applyDefault: true,
+			want: wantTuple{
+				metrics:             "cat.s.m",
+				logs:                "cat.s.l",
+				otelEnvHasMetrics:   true,
+				otelEnvHasLogs:      true,
+				otelEnvHasTelemetry: true,
+				stateMetrics:        "cat.s.m",
+				stateLogs:           "cat.s.l",
+				stateMutated:        true,
+			},
+		},
+		{
+			name:            "empty state, traces flag + traces-table → traces-only",
+			saved:           emptyState,
+			tracesBool:      true,
+			tracesTableFlag: "cat.s.t",
+			tracesTableSet:  true,
+			applyDefault:    true,
+			want: wantTuple{
+				// metrics still inherits the legacy default in bare-toggle land,
+				// but here the user supplied traces explicitly — the resolver
+				// still applies the metrics default (matching legacy behavior).
+				metrics:             "main.claude_telemetry.claude_otel_metrics",
+				logs:                "main.claude_telemetry.claude_otel_logs",
+				traces:              "cat.s.t",
+				otelEnvHasMetrics:   true,
+				otelEnvHasLogs:      true,
+				otelEnvHasTraces:    true,
+				otelEnvHasTelemetry: true,
+				stateTraces:         "cat.s.t",
+				stateMutated:        true,
+			},
+		},
+		{
+			name:         "populated state, no flags → state values preserved",
+			saved:        populatedState,
+			applyDefault: true,
+			want: wantTuple{
+				metrics:             "main.team.metrics_prior",
+				logs:                "main.team.logs_prior",
+				traces:              "main.team.traces_prior",
+				otelEnvHasMetrics:   true,
+				otelEnvHasLogs:      true,
+				otelEnvHasTraces:    true,
+				otelEnvHasTelemetry: true,
+				stateMetrics:        "main.team.metrics_prior",
+				stateLogs:           "main.team.logs_prior",
+				stateTraces:         "main.team.traces_prior",
+				stateMutated:        false,
+			},
+		},
+		{
+			// Populated state + applyDefault=false: state values are still
+			// honoured (the gate only suppresses the bare-toggle DEFAULT, not
+			// state-derived values). This is the common `config write` path
+			// for a returning user.
+			name:         "populated state, no flags, applyDefault=false → state values still preserved",
+			saved:        populatedState,
+			applyDefault: false,
+			want: wantTuple{
+				metrics:             "main.team.metrics_prior",
+				logs:                "main.team.logs_prior",
+				traces:              "main.team.traces_prior",
+				otelEnvHasMetrics:   true,
+				otelEnvHasLogs:      true,
+				otelEnvHasTraces:    true,
+				otelEnvHasTelemetry: true,
+				stateMetrics:        "main.team.metrics_prior",
+				stateLogs:           "main.team.logs_prior",
+				stateTraces:         "main.team.traces_prior",
+				stateMutated:        false,
+			},
+		},
+		{
+			name:         "populated state, --metrics-table same as state → no mutation",
+			saved:        populatedState,
+			metricsFlag:  "main.team.metrics_prior",
+			metricsSet:   true,
+			applyDefault: true,
+			want: wantTuple{
+				metrics:             "main.team.metrics_prior",
+				logs:                "main.team.logs_prior",
+				traces:              "main.team.traces_prior",
+				otelEnvHasMetrics:   true,
+				otelEnvHasLogs:      true,
+				otelEnvHasTraces:    true,
+				otelEnvHasTelemetry: true,
+				stateMetrics:        "main.team.metrics_prior",
+				stateLogs:           "main.team.logs_prior",
+				stateTraces:         "main.team.traces_prior",
+				stateMutated:        false,
+			},
+		},
+		{
+			name:         "populated state, --metrics-table changes value → mutation",
+			saved:        populatedState,
+			metricsFlag:  "main.team.metrics_new",
+			metricsSet:   true,
+			applyDefault: true,
+			want: wantTuple{
+				metrics:             "main.team.metrics_new",
+				logs:                "main.team.logs_prior",
+				traces:              "main.team.traces_prior",
+				otelEnvHasMetrics:   true,
+				otelEnvHasLogs:      true,
+				otelEnvHasTraces:    true,
+				otelEnvHasTelemetry: true,
+				stateMetrics:        "main.team.metrics_new",
+				stateLogs:           "main.team.logs_prior",
+				stateTraces:         "main.team.traces_prior",
+				stateMutated:        true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := resolveConfigOTEL(tc.saved, port, proxyURL,
+				tc.metricsFlag, tc.metricsSet,
+				tc.logsFlag, tc.logsSet,
+				tc.tracesBool,
+				tc.tracesTableFlag, tc.tracesTableSet,
+				tc.applyDefault,
+			)
+
+			if res.MetricsTable != tc.want.metrics {
+				t.Errorf("MetricsTable: got %q, want %q", res.MetricsTable, tc.want.metrics)
+			}
+			if res.LogsTable != tc.want.logs {
+				t.Errorf("LogsTable: got %q, want %q", res.LogsTable, tc.want.logs)
+			}
+			if res.TracesTable != tc.want.traces {
+				t.Errorf("TracesTable: got %q, want %q", res.TracesTable, tc.want.traces)
+			}
+			if got, want := res.NewState.OtelMetricsTable, tc.want.stateMetrics; got != want {
+				t.Errorf("NewState.OtelMetricsTable: got %q, want %q", got, want)
+			}
+			if got, want := res.NewState.OtelLogsTable, tc.want.stateLogs; got != want {
+				t.Errorf("NewState.OtelLogsTable: got %q, want %q", got, want)
+			}
+			if got, want := res.NewState.OtelTracesTable, tc.want.stateTraces; got != want {
+				t.Errorf("NewState.OtelTracesTable: got %q, want %q", got, want)
+			}
+			if res.StateMutated != tc.want.stateMutated {
+				t.Errorf("StateMutated: got %v, want %v", res.StateMutated, tc.want.stateMutated)
+			}
+
+			// Env-block presence checks.
+			has := func(k string) bool { _, ok := res.OTELEnv[k]; return ok }
+			if got := has("CLAUDE_OTEL_UC_METRICS_TABLE"); got != tc.want.otelEnvHasMetrics {
+				t.Errorf("OTELEnv has metrics table: got %v, want %v (env=%v)", got, tc.want.otelEnvHasMetrics, res.OTELEnv)
+			}
+			if got := has("CLAUDE_OTEL_UC_LOGS_TABLE"); got != tc.want.otelEnvHasLogs {
+				t.Errorf("OTELEnv has logs table: got %v, want %v", got, tc.want.otelEnvHasLogs)
+			}
+			if got := has("CLAUDE_OTEL_UC_TRACES_TABLE"); got != tc.want.otelEnvHasTraces {
+				t.Errorf("OTELEnv has traces table: got %v, want %v", got, tc.want.otelEnvHasTraces)
+			}
+			if got := has("CLAUDE_CODE_ENABLE_TELEMETRY"); got != tc.want.otelEnvHasTelemetry {
+				t.Errorf("OTELEnv has telemetry toggle: got %v, want %v", got, tc.want.otelEnvHasTelemetry)
+			}
+		})
+	}
+}
+
+// TestResolveConfigOTEL_OnlyExplicitFlagsPersist asserts the sentinel-guard
+// invariant: a value derived from state (no explicit flag) must NOT be
+// re-persisted with a "mutated" flag. This is the issue-#149 footgun.
+func TestResolveConfigOTEL_OnlyExplicitFlagsPersist(t *testing.T) {
+	saved := persistentState{
+		OtelMetricsTable: "main.team.metrics_prior",
+	}
+	res := resolveConfigOTEL(saved, 49153, "http://127.0.0.1:49153",
+		"", false, // no metrics-table flag — derived from state
+		"", false,
+		false,
+		"", false,
+		true, // applyMetricsDefault — irrelevant here (state already has metrics), proves derive-from-state still no-mutates
+	)
+	if res.StateMutated {
+		t.Errorf("StateMutated must be false when no explicit flag was passed; resolver should not echo state-derived values back to state. NewState=%+v", res.NewState)
+	}
+}
+
+// --- #172 websearch resolver tests ---
+
+func TestResolveConfigWebSearch_EnableEmptyState(t *testing.T) {
+	res := resolveConfigWebSearch(persistentState{}, true, "", false, 0, false)
+	if !res.NewState.WithWebSearch {
+		t.Error("expected WithWebSearch=true after enable on empty state")
+	}
+	if !res.StateMutated {
+		t.Error("expected StateMutated=true (false→true)")
+	}
+}
+
+func TestResolveConfigWebSearch_EnableAlreadyEnabled(t *testing.T) {
+	res := resolveConfigWebSearch(persistentState{WithWebSearch: true}, true, "", false, 0, false)
+	if !res.NewState.WithWebSearch {
+		t.Error("expected WithWebSearch to stay true")
+	}
+	if res.StateMutated {
+		t.Error("expected StateMutated=false when already enabled and no other flags")
+	}
+}
+
+func TestResolveConfigWebSearch_EnableWithBackendChange(t *testing.T) {
+	saved := persistentState{WithWebSearch: true, WebSearchBackend: "duckduckgo"}
+	res := resolveConfigWebSearch(saved, true, "none", true, 0, false)
+	if res.NewState.WebSearchBackend != "none" {
+		t.Errorf("WebSearchBackend: got %q, want %q", res.NewState.WebSearchBackend, "none")
+	}
+	if !res.StateMutated {
+		t.Error("expected StateMutated=true after backend change")
+	}
+}
+
+// TestResolveConfigWebSearch_Disable_ClearsAllRelatedKeys is the
+// state-preservation test from the plan: a disable must clear backend +
+// fetch-budget too so a future enable re-applies defaults rather than
+// inheriting stale values.
+func TestResolveConfigWebSearch_Disable_ClearsAllRelatedKeys(t *testing.T) {
+	saved := persistentState{
+		WithWebSearch:        true,
+		WebSearchBackend:     "duckduckgo",
+		WebSearchFetchBudget: 204800,
+	}
+	res := resolveConfigWebSearch(saved, false, "", false, 0, false)
+	if res.NewState.WithWebSearch {
+		t.Error("expected WithWebSearch=false after disable")
+	}
+	if res.NewState.WebSearchBackend != "" {
+		t.Errorf("WebSearchBackend should be cleared on disable, got %q", res.NewState.WebSearchBackend)
+	}
+	if res.NewState.WebSearchFetchBudget != 0 {
+		t.Errorf("WebSearchFetchBudget should be cleared on disable, got %d", res.NewState.WebSearchFetchBudget)
+	}
+	if !res.StateMutated {
+		t.Error("expected StateMutated=true after disable")
+	}
+}
+
+func TestResolveConfigWebSearch_DisableNoOp(t *testing.T) {
+	res := resolveConfigWebSearch(persistentState{}, false, "", false, 0, false)
+	if res.StateMutated {
+		t.Error("expected StateMutated=false when already disabled and nothing to clear")
+	}
+}
+
+// --- #172 state-preservation invariant: `config otel disable` does NOT
+// touch the state file ---
+//
+// Drives the AC requirement: "Two-store semantics unchanged: config otel
+// disable touches runtime config only, preserves state-file table
+// preferences; re-enable restores them." This composition test runs
+// end-to-end against a tempdir HOME so the load/save semantics are
+// exercised in concert.
+func TestConfigOTELDisable_PreservesStateFileTables(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	origStatePath := statePath
+	statePath = func() string { return filepath.Join(tmpHome, ".claude", ".databricks-claude.json") }
+	defer func() { statePath = origStatePath }()
+
+	// Seed state with table preferences.
+	seed := persistentState{
+		OtelMetricsTable: "cat.team.metrics",
+		OtelLogsTable:    "cat.team.logs",
+		OtelTracesTable:  "cat.team.traces",
+	}
+	if err := saveState(seed); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+
+	// Seed settings.json with OTEL keys (mimics a previous `config otel
+	// enable` run).
+	settingsPath := filepath.Join(tmpHome, ".claude", "settings.json")
+	if err := bootstrapSettings(0, "DEFAULT", "http://127.0.0.1:49153", buildOTELEnv(seed.OtelMetricsTable, seed.OtelLogsTable, seed.OtelTracesTable, "http://127.0.0.1:49153")); err != nil {
+		t.Fatalf("bootstrapSettings: %v", err)
+	}
+
+	// Simulate `config otel disable` (nuclear option) by calling the
+	// underlying clearer directly — same call the runner makes.
+	if err := clearOTELKeys(settingsPath); err != nil {
+		t.Fatalf("clearOTELKeys: %v", err)
+	}
+
+	// Settings.json must no longer carry OTEL keys.
+	doc, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		t.Fatalf("readSettingsJSON: %v", err)
+	}
+	env, _ := doc["env"].(map[string]interface{})
+	for _, k := range []string{
+		"CLAUDE_CODE_ENABLE_TELEMETRY",
+		"CLAUDE_OTEL_UC_METRICS_TABLE",
+		"CLAUDE_OTEL_UC_LOGS_TABLE",
+		"CLAUDE_OTEL_UC_TRACES_TABLE",
+	} {
+		if _, present := env[k]; present {
+			t.Errorf("settings.json must not contain %q after config otel disable", k)
+		}
+	}
+
+	// State file MUST still carry the table preferences — re-enable should
+	// restore them.
+	got := loadState()
+	if got.OtelMetricsTable != "cat.team.metrics" {
+		t.Errorf("state.OtelMetricsTable: got %q, want preserved %q", got.OtelMetricsTable, "cat.team.metrics")
+	}
+	if got.OtelLogsTable != "cat.team.logs" {
+		t.Errorf("state.OtelLogsTable: got %q, want preserved %q", got.OtelLogsTable, "cat.team.logs")
+	}
+	if got.OtelTracesTable != "cat.team.traces" {
+		t.Errorf("state.OtelTracesTable: got %q, want preserved %q", got.OtelTracesTable, "cat.team.traces")
+	}
+
+	// Re-enable: resolveConfigOTEL with no flags should pick the state
+	// values straight back up — closing the loop on the AC. applyMetricsDefault
+	// is true here (the `config otel enable` path), but state is already
+	// populated so the bare-toggle default is never reached.
+	res := resolveConfigOTEL(got, 49153, "http://127.0.0.1:49153",
+		"", false, "", false, false, "", false, true,
+	)
+	if res.MetricsTable != "cat.team.metrics" {
+		t.Errorf("re-enable MetricsTable: got %q, want restored %q", res.MetricsTable, "cat.team.metrics")
+	}
+	if res.LogsTable != "cat.team.logs" {
+		t.Errorf("re-enable LogsTable: got %q, want restored %q", res.LogsTable, "cat.team.logs")
+	}
+	if res.TracesTable != "cat.team.traces" {
+		t.Errorf("re-enable TracesTable: got %q, want restored %q", res.TracesTable, "cat.team.traces")
+	}
+}
+
+// TestConfigOTELDisable_PerSignal exercises the per-signal --metrics /
+// --logs / --traces clears, asserting the other signals stay live.
+func TestConfigOTELDisable_PerSignal(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	origStatePath := statePath
+	statePath = func() string { return filepath.Join(tmpHome, ".claude", ".databricks-claude.json") }
+	defer func() { statePath = origStatePath }()
+
+	settingsPath := filepath.Join(tmpHome, ".claude", "settings.json")
+	otelEnv := buildOTELEnv("cat.t.m", "cat.t.l", "cat.t.tr", "http://127.0.0.1:49153")
+	if err := bootstrapSettings(0, "DEFAULT", "http://127.0.0.1:49153", otelEnv); err != nil {
+		t.Fatalf("bootstrapSettings: %v", err)
+	}
+
+	if err := clearOTELKeysSubset(settingsPath, otelMetricsKeys); err != nil {
+		t.Fatalf("clearOTELKeysSubset: %v", err)
+	}
+
+	doc, _ := readSettingsJSON(settingsPath)
+	env, _ := doc["env"].(map[string]interface{})
+
+	// Metrics keys MUST be gone.
+	for _, k := range otelMetricsKeys {
+		if _, present := env[k]; present {
+			t.Errorf("metrics key %q must be cleared", k)
+		}
+	}
+
+	// Logs + traces keys MUST still be present.
+	if _, ok := env["CLAUDE_OTEL_UC_LOGS_TABLE"]; !ok {
+		t.Error("logs table key should survive --metrics-only clear")
+	}
+	if _, ok := env["CLAUDE_OTEL_UC_TRACES_TABLE"]; !ok {
+		t.Error("traces table key should survive --metrics-only clear")
+	}
+}
+
+// TestConfigCommand_Help renders the configCommand Long body and asserts
+// the documented subcommand names appear. Light smoke on the help layer.
+func TestConfigCommand_Help(t *testing.T) {
+	var sb strings.Builder
+	if err := renderConfigForTest(&sb); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	out := sb.String()
+	for _, want := range []string{
+		"otel enable", "otel disable",
+		"websearch enable", "websearch disable",
+		"write", "show",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("config help missing %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// renderConfigForTest is a thin helper so the help test does not depend on
+// internal/cmd's exported Render signature — it just exercises the Long
+// template directly.
+func renderConfigForTest(sb *strings.Builder) error {
+	sb.WriteString(configCommand.Long)
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -35,45 +35,30 @@ import (
 var Version = "dev"
 
 // Args holds all parsed command-line arguments for databricks-claude.
+//
+// #172 removed the 14 "persistent config editor" fields (PrintEnv, OTEL,
+// OTELMetricsTable*, OTELLogsTable*, OTELTraces, OTELTracesTable*, NoOTEL*,
+// WriteClaudeConfig, WithWebSearch*, WebSearchBackend*, WebSearchFetchBudget*).
+// Their mutation paths now live under the `config` subcommand tree.
 type Args struct {
-	Profile                 string
-	Verbose                 bool
-	Version                 bool
-	ShowHelp                bool
-	PrintEnv                bool
-	OTEL                    bool
-	OTELMetricsTable        string
-	OTELMetricsTableSet     bool
-	OTELLogsTable           string
-	OTELLogsTableSet        bool
-	OTELTraces              bool
-	OTELTracesTable         string
-	OTELTracesTableSet      bool
-	Upstream                string
-	LogFile                 string
-	NoOTEL                  bool
-	NoOTELMetrics           bool
-	NoOTELLogs              bool
-	NoOTELTraces            bool
-	ProxyAPIKey             string
-	TLSCert                 string
-	TLSKey                  string
-	Port                    int
-	Headless                bool
-	WriteClaudeConfig       bool
-	IdleTimeout             time.Duration
-	InstallHooks            bool
-	UninstallHooks          bool
-	HeadlessEnsure          bool
-	HeadlessRelease         bool
-	NoUpdateCheck           bool
-	WithWebSearch           bool
-	WithWebSearchSet        bool
-	WebSearchBackend        string
-	WebSearchBackendSet     bool
-	WebSearchFetchBudget    int
-	WebSearchFetchBudgetSet bool
-	ClaudeArgs              []string
+	Profile         string
+	Verbose         bool
+	Version         bool
+	ShowHelp        bool
+	Upstream        string
+	LogFile         string
+	ProxyAPIKey     string
+	TLSCert         string
+	TLSKey          string
+	Port            int
+	Headless        bool
+	IdleTimeout     time.Duration
+	InstallHooks    bool
+	UninstallHooks  bool
+	HeadlessEnsure  bool
+	HeadlessRelease bool
+	NoUpdateCheck   bool
+	ClaudeArgs      []string
 }
 
 func main() {
@@ -153,6 +138,17 @@ func main() {
 		return
 	}
 
+	// `config` subcommand — persistent config editor (OTEL signals, websearch,
+	// settings.json env block, resolved-config diagnostic). Consolidates the
+	// 14 flags removed from the root in #172 — the flags that mutate state /
+	// settings.json for FUTURE runs rather than affecting the current
+	// invocation. The transparent-proxy launcher path below is intentionally
+	// flag-driven and bare; persistent state mutation lives behind this tree.
+	if len(os.Args) >= 2 && os.Args[1] == "config" {
+		runConfigCommand(os.Args[2:])
+		return
+	}
+
 	// Parse databricks-claude flags, passing everything else through to claude.
 	// Usage: databricks-claude [databricks-claude-flags] [--] [claude-args...]
 	// Unknown flags are forwarded to claude automatically.
@@ -220,184 +216,6 @@ func main() {
 			headlessRelease(port)
 		}
 		os.Exit(0)
-	}
-
-	// --- Write Claude config and exit (no proxy, no port bind, no child) ---
-	if a.WriteClaudeConfig {
-		wcProfile := a.Profile
-		if wcProfile == "" {
-			if saved := loadState(); saved.Profile != "" {
-				wcProfile = saved.Profile
-			}
-		}
-		if wcProfile == "" {
-			wcProfile = "DEFAULT"
-		}
-
-		wcPort := resolvePort(a.Port, loadState())
-		wcProxyURL := fmt.Sprintf("http://127.0.0.1:%d", wcPort)
-
-		if _, err := DiscoverHost(wcProfile, ""); err != nil {
-			log.Fatalf("databricks-claude: failed to discover host for profile %q: %v\nRun 'databricks auth login --profile %s' first",
-				wcProfile, err, wcProfile)
-		}
-
-		// Resolve OTEL tables: flag → state → empty.
-		wcState := loadState()
-		ucMetrics := wcState.OtelMetricsTable
-		ucLogs := wcState.OtelLogsTable
-		ucTraces := wcState.OtelTracesTable
-		if a.OTELMetricsTableSet {
-			ucMetrics = a.OTELMetricsTable
-		}
-		if a.OTELLogsTableSet {
-			ucLogs = a.OTELLogsTable
-		} else if ucLogs == "" && ucMetrics != "" {
-			ucLogs = deriveLogsTable(ucMetrics)
-		}
-		if a.OTELTracesTableSet {
-			ucTraces = a.OTELTracesTable
-		}
-
-		// Persist any newly-set table names.
-		{
-			mutated := false
-			if a.OTELMetricsTableSet && wcState.OtelMetricsTable != ucMetrics {
-				wcState.OtelMetricsTable = ucMetrics
-				mutated = true
-			}
-			if a.OTELLogsTableSet && wcState.OtelLogsTable != ucLogs {
-				wcState.OtelLogsTable = ucLogs
-				mutated = true
-			}
-			if a.OTELTracesTableSet && wcState.OtelTracesTable != ucTraces {
-				wcState.OtelTracesTable = ucTraces
-				mutated = true
-			}
-			if mutated {
-				if err := saveState(wcState); err != nil {
-					log.Fatalf("databricks-claude: could not persist OTEL tables: %v", err)
-				}
-			}
-		}
-
-		// Build otelEnv — always needsFullSetup (the whole point of this flag).
-		wcOtelEnv := map[string]string{}
-		if ucMetrics != "" {
-			wcOtelEnv["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = wcProxyURL + "/otel/v1/metrics"
-			wcOtelEnv["OTEL_EXPORTER_OTLP_METRICS_HEADERS"] = "content-type=application/x-protobuf"
-			wcOtelEnv["OTEL_METRICS_EXPORTER"] = "otlp"
-			wcOtelEnv["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "http/protobuf"
-			wcOtelEnv["OTEL_METRIC_EXPORT_INTERVAL"] = "10000"
-			wcOtelEnv["CLAUDE_OTEL_UC_METRICS_TABLE"] = ucMetrics
-		}
-		if ucLogs != "" {
-			wcOtelEnv["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = wcProxyURL + "/otel/v1/logs"
-			wcOtelEnv["OTEL_EXPORTER_OTLP_LOGS_HEADERS"] = "content-type=application/x-protobuf"
-			wcOtelEnv["OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"] = "http/protobuf"
-			wcOtelEnv["OTEL_LOGS_EXPORTER"] = "otlp"
-			wcOtelEnv["OTEL_LOGS_EXPORT_INTERVAL"] = "5000"
-			wcOtelEnv["CLAUDE_OTEL_UC_LOGS_TABLE"] = ucLogs
-		}
-		if ucTraces != "" {
-			wcOtelEnv["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "1"
-			wcOtelEnv["OTEL_TRACES_EXPORTER"] = "otlp"
-			wcOtelEnv["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = wcProxyURL + "/otel/v1/traces"
-			wcOtelEnv["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/protobuf"
-			wcOtelEnv["OTEL_TRACES_EXPORT_INTERVAL"] = "5000"
-			wcOtelEnv["CLAUDE_OTEL_UC_TRACES_TABLE"] = ucTraces
-		}
-		if ucMetrics != "" || ucLogs != "" || ucTraces != "" {
-			wcOtelEnv["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
-		}
-		for k, v := range databricksFullSetupEnv() {
-			wcOtelEnv[k] = v
-		}
-
-		// Resolve --with-websearch settings and persist to state so the
-		// daemon (and any subsequent wrapper invocation) picks them up.
-		// Websearch is a PROXY-side feature controlled by state, NOT by
-		// the settings.json env block — so no key is added to wcOtelEnv;
-		// the state file is the entire integration point. Mirrors the
-		// normal-startup persistence block. Reload state here so we pick
-		// up any OTEL writes from above.
-		wcWsState := loadState()
-		wcWithWebSearch := wcWsState.WithWebSearch
-		wcWsBackend := wcWsState.WebSearchBackend
-		wcWsBudget := wcWsState.WebSearchFetchBudget
-		if a.WithWebSearchSet {
-			wcWithWebSearch = a.WithWebSearch
-		}
-		if a.WebSearchBackendSet {
-			wcWsBackend = a.WebSearchBackend
-		}
-		if a.WebSearchFetchBudgetSet {
-			wcWsBudget = a.WebSearchFetchBudget
-		}
-		{
-			mutated := false
-			if a.WithWebSearchSet && wcWsState.WithWebSearch != wcWithWebSearch {
-				wcWsState.WithWebSearch = wcWithWebSearch
-				mutated = true
-			}
-			if a.WebSearchBackendSet && wcWsState.WebSearchBackend != wcWsBackend {
-				wcWsState.WebSearchBackend = wcWsBackend
-				mutated = true
-			}
-			if a.WebSearchFetchBudgetSet && wcWsState.WebSearchFetchBudget != wcWsBudget {
-				wcWsState.WebSearchFetchBudget = wcWsBudget
-				mutated = true
-			}
-			if mutated {
-				if err := saveState(wcWsState); err != nil {
-					log.Fatalf("databricks-claude: could not persist websearch state: %v", err)
-				}
-			}
-		}
-
-		if err := bootstrapSettings(a.Port, wcProfile, wcProxyURL, wcOtelEnv); err != nil {
-			log.Fatalf("databricks-claude: --write-claude-config: %v", err)
-		}
-		fmt.Fprintf(os.Stderr, "databricks-claude: wrote env block to ~/.claude/settings.json (profile=%s, base_url=%s, websearch=%t)\n", wcProfile, wcProxyURL, wcWithWebSearch)
-		os.Exit(0)
-	}
-
-	// --no-otel and --no-otel-{metrics,logs,traces}: clear persisted OTEL keys
-	// from settings.json. Per-signal flags clear only that signal; --no-otel
-	// is the nuclear option that clears every signal plus the telemetry toggle.
-	if a.NoOTEL || a.NoOTELMetrics || a.NoOTELLogs || a.NoOTELTraces {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			log.Fatalf("databricks-claude: cannot determine home dir: %v", err)
-		}
-		settingsPathForClear := filepath.Join(homeDir, ".claude", "settings.json")
-		if a.NoOTEL {
-			if err := clearOTELKeys(settingsPathForClear); err != nil {
-				log.Fatalf("databricks-claude: failed to clear OTEL keys: %v", err)
-			}
-			fmt.Fprintln(os.Stderr, "databricks-claude: OTEL keys cleared — OTEL disabled for future sessions")
-		} else {
-			if a.NoOTELMetrics {
-				if err := clearOTELKeysSubset(settingsPathForClear, otelMetricsKeys); err != nil {
-					log.Fatalf("databricks-claude: failed to clear OTEL metrics keys: %v", err)
-				}
-				fmt.Fprintln(os.Stderr, "databricks-claude: OTEL metrics keys cleared")
-			}
-			if a.NoOTELLogs {
-				if err := clearOTELKeysSubset(settingsPathForClear, otelLogsKeys); err != nil {
-					log.Fatalf("databricks-claude: failed to clear OTEL logs keys: %v", err)
-				}
-				fmt.Fprintln(os.Stderr, "databricks-claude: OTEL logs keys cleared")
-			}
-			if a.NoOTELTraces {
-				if err := clearOTELKeysSubset(settingsPathForClear, otelTracesKeys); err != nil {
-					log.Fatalf("databricks-claude: failed to clear OTEL traces keys: %v", err)
-				}
-				fmt.Fprintln(os.Stderr, "databricks-claude: OTEL traces keys cleared")
-			}
-		}
-		// Continue — flags only clear persisted state; other flags on the same
-		// invocation can still re-enable specific signals.
 	}
 
 	// --- Resolve config from settings.json ---
@@ -522,24 +340,9 @@ func main() {
 		ucTracesTable = tableState.OtelTracesTable
 	}
 
-	// --no-otel-{signal} disables the signal for this session. Zero out any
-	// table value that the state-file fallback above may have populated —
-	// the flag wins over persisted state (but the state file is left intact
-	// so the next --otel invocation can pick the tables back up).
-	if a.NoOTEL || a.NoOTELMetrics {
-		ucMetricsTable = ""
-	}
-	if a.NoOTEL || a.NoOTELLogs {
-		ucLogsTable = ""
-	}
-	if a.NoOTEL || a.NoOTELTraces {
-		ucTracesTable = ""
-	}
-
 	// --- Seed token cache ---
 	tp := NewTokenProvider(resolvedProfile, "")
-	initialToken, err := tp.Token(context.Background())
-	if err != nil {
+	if _, err := tp.Token(context.Background()); err != nil {
 		log.Fatalf("databricks-claude: failed to fetch initial token for profile %q: %v", resolvedProfile, err)
 	}
 
@@ -584,82 +387,26 @@ func main() {
 		otelUpstream = inferenceUpstream
 	}
 
-	// OTEL table resolution follows table-presence semantics: a signal's env
-	// vars are only emitted when its UC table is configured (flag, persisted
-	// settings.json, or — for metrics/logs — the legacy --otel default).
-	//
-	// Metrics table: --otel-metrics-table > persisted > --otel default. Without
-	// any of those, ucMetricsTable stays empty and metrics env vars are skipped.
-	if a.OTELMetricsTableSet {
-		ucMetricsTable = a.OTELMetricsTable
-	} else if ucMetricsTable == "" && a.OTEL {
-		ucMetricsTable = a.OTELMetricsTable
-	}
-
-	// Logs table: --otel-logs-table > persisted > derive-from-metrics (only
-	// when metrics is itself configured). Without any of those it stays empty.
-	if a.OTELLogsTableSet {
-		ucLogsTable = a.OTELLogsTable
-	} else if ucLogsTable == "" && ucMetricsTable != "" {
-		ucLogsTable = deriveLogsTable(ucMetricsTable)
-	}
-
-	// Traces table: --otel-traces-table > persisted. No default — traces are
-	// opt-in via --otel-traces / --otel-traces-table.
-	if a.OTELTracesTableSet {
-		ucTracesTable = a.OTELTracesTable
-	}
-	// If --otel-traces is passed but no table is configured (neither flag nor
-	// persisted), traces is silently skipped — see the env-injection block.
-	_ = a.OTELTraces
-
 	// --- Resolve port for downstream binding ---
 	port := resolvePort(a.Port, loadState())
 
-	// --- Print env and exit if requested ---
-	// This exit is intentionally before any state or settings.json writes so
-	// --print-env remains a read-only diagnostic (no side effects).
-	if a.PrintEnv {
-		otelActive := ucMetricsTable != "" || ucLogsTable != "" || ucTracesTable != ""
-		handlePrintEnv(resolvedProfile, databricksHost, inferenceUpstream, initialToken, a.Upstream, otelActive, ucMetricsTable, ucLogsTable, ucTracesTable)
-		os.Exit(0)
-	}
-
-	// Persist OTel table names to the state file so they survive --no-otel.
-	// We write when an explicit --otel-*-table flag was given, or when a table
-	// was found in settings.json but hasn't been migrated to state yet.
-	// Uses tableState (loaded above for fallback) directly to avoid a second
-	// loadState call; bootstrapSettings below will do its own fresh load.
+	// Migrate OTEL tables that exist in settings.json but not yet in the state
+	// file. The flag-driven mutation paths moved to `config otel enable` in
+	// #172, but the running proxy still needs to keep state in sync with
+	// whatever it reads from settings.json — so a settings.json-only OTEL
+	// config (from a pre-#172 install) gets migrated forward on first run.
 	{
-		metricsToSave := ""
-		logsToSave := ""
-		tracesToSave := ""
-		if a.OTELMetricsTableSet {
-			metricsToSave = ucMetricsTable
-		} else if metricsFromSettings != "" && tableState.OtelMetricsTable == "" {
-			metricsToSave = metricsFromSettings
-		}
-		if a.OTELLogsTableSet {
-			logsToSave = ucLogsTable
-		} else if logsFromSettings != "" && tableState.OtelLogsTable == "" {
-			logsToSave = logsFromSettings
-		}
-		if a.OTELTracesTableSet {
-			tracesToSave = ucTracesTable
-		} else if tracesFromSettings != "" && tableState.OtelTracesTable == "" {
-			tracesToSave = tracesFromSettings
-		}
 		mutated := false
-		if metricsToSave != "" && tableState.OtelMetricsTable != metricsToSave {
-			tableState.OtelMetricsTable = metricsToSave
+		if metricsFromSettings != "" && tableState.OtelMetricsTable == "" {
+			tableState.OtelMetricsTable = metricsFromSettings
 			mutated = true
 		}
-		if logsToSave != "" && tableState.OtelLogsTable != logsToSave {
-			tableState.OtelLogsTable = logsToSave
+		if logsFromSettings != "" && tableState.OtelLogsTable == "" {
+			tableState.OtelLogsTable = logsFromSettings
 			mutated = true
 		}
-		if tracesToSave != "" && tableState.OtelTracesTable != tracesToSave {
-			tableState.OtelTracesTable = tracesToSave
+		if tracesFromSettings != "" && tableState.OtelTracesTable == "" {
+			tableState.OtelTracesTable = tracesFromSettings
 			mutated = true
 		}
 		if mutated {
@@ -674,48 +421,20 @@ func main() {
 		log.Fatalf("databricks-claude: %v", err)
 	}
 
-	// --- Resolve --with-websearch (workaround) settings ---
-	// Resolution chain: flag (if set) > saved state > default. Persist any
-	// flag value back to state so users only opt in once. Mirrors the
-	// OTEL-table persistence pattern.
+	// --- Read --with-websearch (workaround) settings from state ---
+	// #172 moved websearch flag mutation behind `config websearch enable`.
+	// The running proxy still reads with_websearch / backend / fetch-budget
+	// from the state file every start so previously-enabled installs keep
+	// working without code changes.
 	wsState := loadState()
 	withWebSearch := wsState.WithWebSearch
 	wsBackend := wsState.WebSearchBackend
 	wsBudget := wsState.WebSearchFetchBudget
-	if a.WithWebSearchSet {
-		withWebSearch = a.WithWebSearch
-	}
-	if a.WebSearchBackendSet {
-		wsBackend = a.WebSearchBackend
-	}
-	if a.WebSearchFetchBudgetSet {
-		wsBudget = a.WebSearchFetchBudget
-	}
 	if wsBackend == "" {
 		wsBackend = "duckduckgo"
 	}
 	if wsBudget <= 0 {
 		wsBudget = 100 * 1024
-	}
-	{
-		mutated := false
-		if a.WithWebSearchSet && wsState.WithWebSearch != withWebSearch {
-			wsState.WithWebSearch = withWebSearch
-			mutated = true
-		}
-		if a.WebSearchBackendSet && wsState.WebSearchBackend != wsBackend {
-			wsState.WebSearchBackend = wsBackend
-			mutated = true
-		}
-		if a.WebSearchFetchBudgetSet && wsState.WebSearchFetchBudget != wsBudget {
-			wsState.WebSearchFetchBudget = wsBudget
-			mutated = true
-		}
-		if mutated {
-			if err := saveState(wsState); err != nil {
-				log.Printf("databricks-claude: warning: could not persist websearch state: %v", err)
-			}
-		}
 	}
 
 	// Build the websearch backend (if enabled) and print the workaround warning.
@@ -962,16 +681,21 @@ func envBlock(doc map[string]interface{}) map[string]interface{} {
 }
 
 // parseArgs separates databricks-claude flags from claude flags.
-// databricks-claude owns: --profile, --verbose/-v, --log-file, --version,
-// --otel, --otel-metrics-table, --otel-logs-table, --otel-traces,
-// --otel-traces-table, --no-otel, --no-otel-metrics, --no-otel-logs,
-// --no-otel-traces, --proxy-api-key, --tls-cert, --tls-key.
+// databricks-claude owns: --profile, --port, --verbose/-v, --version, --help,
+// --upstream, --log-file, --proxy-api-key, --tls-cert, --tls-key, --headless,
+// --idle-timeout, --install-hooks, --uninstall-hooks, --headless-ensure,
+// --headless-release, --no-update-check.
 // Everything else (including unknown flags like --debug) passes through to claude.
 // An explicit "--" separator is supported but not required.
+//
+// #172 removed the 14 "persistent config editor" flags — they live behind
+// the `config` subcommand tree now (config otel enable|disable, config
+// websearch enable|disable, config write, config show). Old flags are
+// removed, NOT aliased: `databricks-claude --otel` now passes `--otel`
+// through to claude as an unknown flag.
 func parseArgs(args []string) (*Args, error) {
 	a := &Args{
-		OTELMetricsTable: "main.claude_telemetry.claude_otel_metrics", // default
-		IdleTimeout:      30 * time.Minute,                            // default
+		IdleTimeout: 30 * time.Minute, // default
 	}
 
 	// knownFlags is defined at package level in completion_flags.go,
@@ -1018,24 +742,6 @@ func parseArgs(args []string) (*Args, error) {
 						i++
 						a.Profile = args[i]
 					}
-				case "--otel-metrics-table":
-					if value != "" {
-						a.OTELMetricsTable = value
-						a.OTELMetricsTableSet = true
-					} else if i+1 < len(args) {
-						i++
-						a.OTELMetricsTable = args[i]
-						a.OTELMetricsTableSet = true
-					}
-				case "--otel-logs-table":
-					if value != "" {
-						a.OTELLogsTable = value
-						a.OTELLogsTableSet = true
-					} else if i+1 < len(args) {
-						i++
-						a.OTELLogsTable = args[i]
-						a.OTELLogsTableSet = true
-					}
 				case "--upstream":
 					if value != "" {
 						a.Upstream = value
@@ -1056,29 +762,6 @@ func parseArgs(args []string) (*Args, error) {
 					a.Version = true
 				case "--help":
 					a.ShowHelp = true
-				case "--print-env":
-					a.PrintEnv = true
-				case "--otel":
-					a.OTEL = true
-				case "--otel-traces":
-					a.OTELTraces = true
-				case "--otel-traces-table":
-					if value != "" {
-						a.OTELTracesTable = value
-						a.OTELTracesTableSet = true
-					} else if i+1 < len(args) {
-						i++
-						a.OTELTracesTable = args[i]
-						a.OTELTracesTableSet = true
-					}
-				case "--no-otel":
-					a.NoOTEL = true
-				case "--no-otel-metrics":
-					a.NoOTELMetrics = true
-				case "--no-otel-logs":
-					a.NoOTELLogs = true
-				case "--no-otel-traces":
-					a.NoOTELTraces = true
 				case "--proxy-api-key":
 					if value != "" {
 						a.ProxyAPIKey = value
@@ -1109,8 +792,6 @@ func parseArgs(args []string) (*Args, error) {
 					}
 				case "--headless":
 					a.Headless = true
-				case "--write-claude-config":
-					a.WriteClaudeConfig = true
 				case "--install-hooks":
 					a.InstallHooks = true
 				case "--uninstall-hooks":
@@ -1121,36 +802,6 @@ func parseArgs(args []string) (*Args, error) {
 					a.HeadlessRelease = true
 				case "--no-update-check":
 					a.NoUpdateCheck = true
-				case "--with-websearch":
-					a.WithWebSearch = true
-					a.WithWebSearchSet = true
-					// Allow optional explicit value: --with-websearch=true|false
-					if value != "" {
-						a.WithWebSearch = (value == "1" || strings.EqualFold(value, "true") || strings.EqualFold(value, "yes"))
-					}
-				case "--websearch-backend":
-					if value != "" {
-						a.WebSearchBackend = value
-						a.WebSearchBackendSet = true
-					} else if i+1 < len(args) {
-						i++
-						a.WebSearchBackend = args[i]
-						a.WebSearchBackendSet = true
-					}
-				case "--websearch-fetch-budget":
-					raw := value
-					if raw == "" && i+1 < len(args) {
-						i++
-						raw = args[i]
-					}
-					if raw != "" {
-						if n, err := strconv.Atoi(raw); err == nil {
-							a.WebSearchFetchBudget = n
-							a.WebSearchFetchBudgetSet = true
-						} else {
-							return nil, fmt.Errorf("--websearch-fetch-budget: %q is not an integer", raw)
-						}
-					}
 				case "--idle-timeout":
 					raw := value
 					if raw == "" && i+1 < len(args) {

--- a/main_test.go
+++ b/main_test.go
@@ -32,7 +32,7 @@ func TestParseArgs_HelpLong(t *testing.T) {
 	if !a.ShowHelp {
 		t.Error("expected showHelp=true for --help")
 	}
-	if a.Profile != "" || a.Verbose || a.Version || a.PrintEnv || a.OTEL || a.Upstream != "" || a.LogFile != "" || a.NoOTEL || len(a.ClaudeArgs) != 0 {
+	if a.Profile != "" || a.Verbose || a.Version || a.Upstream != "" || a.LogFile != "" || len(a.ClaudeArgs) != 0 {
 		t.Error("unexpected non-default values alongside --help")
 	}
 }
@@ -57,10 +57,47 @@ func TestParseArgs_SeparatorForwardsHelp(t *testing.T) {
 	}
 }
 
-func TestParseArgs_PrintEnv(t *testing.T) {
-	a, _ := parseArgs([]string{"--print-env"})
-	if !a.PrintEnv {
-		t.Error("expected printEnv=true for --print-env")
+// TestParseArgs_RemovedFlagsPassThrough confirms #172's "removed, not
+// aliased" contract: legacy persistent-config flags now forward to claude
+// as unknown args, no Args fields are populated for them.
+func TestParseArgs_RemovedFlagsPassThrough(t *testing.T) {
+	removed := []string{
+		"--print-env",
+		"--otel",
+		"--otel-metrics-table", "x",
+		"--otel-logs-table", "y",
+		"--otel-traces",
+		"--otel-traces-table", "z",
+		"--no-otel",
+		"--no-otel-metrics",
+		"--no-otel-logs",
+		"--no-otel-traces",
+		"--write-claude-config",
+		"--with-websearch",
+		"--websearch-backend", "duckduckgo",
+		"--websearch-fetch-budget", "1024",
+	}
+	a, err := parseArgs(removed)
+	if err != nil {
+		t.Fatalf("parseArgs returned error for legacy flags (must pass through, not error): %v", err)
+	}
+	// Every removed flag should be in ClaudeArgs (passthrough).
+	for _, want := range []string{
+		"--print-env", "--otel", "--otel-metrics-table", "--otel-logs-table",
+		"--otel-traces", "--otel-traces-table", "--no-otel", "--no-otel-metrics",
+		"--no-otel-logs", "--no-otel-traces", "--write-claude-config",
+		"--with-websearch", "--websearch-backend", "--websearch-fetch-budget",
+	} {
+		found := false
+		for _, ca := range a.ClaudeArgs {
+			if ca == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q to forward to ClaudeArgs (removed in #172, not aliased), got ClaudeArgs=%v", want, a.ClaudeArgs)
+		}
 	}
 }
 
@@ -113,172 +150,10 @@ func TestParseArgs_Upstream(t *testing.T) {
 	}
 }
 
-func TestParseArgs_Otel(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel"})
-	if !a.OTEL {
-		t.Error("expected otel=true for --otel")
-	}
-}
-
-func TestParseArgs_OtelMetricsTableOverride(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel-metrics-table", "main.default.otel"})
-	if !a.OTELMetricsTableSet {
-		t.Error("expected metricsTableSet=true when --otel-metrics-table is passed")
-	}
-	if a.OTELMetricsTable != "main.default.otel" {
-		t.Errorf("expected metricsTable=%q, got %q", "main.default.otel", a.OTELMetricsTable)
-	}
-}
-
-func TestParseArgs_OtelMetricsTableDefault(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel"})
-	if a.OTELMetricsTableSet {
-		t.Error("expected metricsTableSet=false when --otel-metrics-table is not passed")
-	}
-	if a.OTELMetricsTable != "main.claude_telemetry.claude_otel_metrics" {
-		t.Errorf("expected default metricsTable, got %q", a.OTELMetricsTable)
-	}
-}
-
-func TestParseArgs_OtelMetricsTableEquals(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel-metrics-table=my.catalog.table"})
-	if !a.OTELMetricsTableSet {
-		t.Error("expected metricsTableSet=true for --otel-metrics-table=value")
-	}
-	if a.OTELMetricsTable != "my.catalog.table" {
-		t.Errorf("expected metricsTable=%q, got %q", "my.catalog.table", a.OTELMetricsTable)
-	}
-}
-
-func TestParseArgs_OtelLogsTableOverride(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel-logs-table", "main.default.my_logs"})
-	if !a.OTELLogsTableSet {
-		t.Error("expected logsTableSet=true when --otel-logs-table is passed")
-	}
-	if a.OTELLogsTable != "main.default.my_logs" {
-		t.Errorf("expected logsTable=%q, got %q", "main.default.my_logs", a.OTELLogsTable)
-	}
-}
-
-func TestParseArgs_OtelLogsTableDefault(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel"})
-	if a.OTELLogsTableSet {
-		t.Error("expected logsTableSet=false when --otel-logs-table is not passed")
-	}
-	if a.OTELLogsTable != "" {
-		t.Errorf("expected empty logsTable default, got %q", a.OTELLogsTable)
-	}
-}
-
-func TestParseArgs_OtelLogsTableEquals(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel-logs-table=my.catalog.logs"})
-	if !a.OTELLogsTableSet {
-		t.Error("expected logsTableSet=true for --otel-logs-table=value")
-	}
-	if a.OTELLogsTable != "my.catalog.logs" {
-		t.Errorf("expected logsTable=%q, got %q", "my.catalog.logs", a.OTELLogsTable)
-	}
-}
-
-func TestParseArgs_BothOtelTables(t *testing.T) {
-	a, _ := parseArgs([]string{
-		"--otel-metrics-table", "cat.schema.metrics",
-		"--otel-logs-table", "cat.schema.logs",
-	})
-	if !a.OTELMetricsTableSet || !a.OTELLogsTableSet {
-		t.Error("expected both table flags to be set")
-	}
-	if a.OTELMetricsTable != "cat.schema.metrics" {
-		t.Errorf("metricsTable=%q, want cat.schema.metrics", a.OTELMetricsTable)
-	}
-	if a.OTELLogsTable != "cat.schema.logs" {
-		t.Errorf("logsTable=%q, want cat.schema.logs", a.OTELLogsTable)
-	}
-}
-
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
 	a, _ := parseArgs([]string{"--unknown"})
 	if len(a.ClaudeArgs) != 1 || a.ClaudeArgs[0] != "--unknown" {
 		t.Errorf("expected claudeArgs=[\"--unknown\"], got %v", a.ClaudeArgs)
-	}
-}
-
-func TestParseArgs_WithWebSearch(t *testing.T) {
-	a, err := parseArgs([]string{"--with-websearch"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !a.WithWebSearch {
-		t.Errorf("expected WithWebSearch=true")
-	}
-	if !a.WithWebSearchSet {
-		t.Errorf("expected WithWebSearchSet=true when --with-websearch is passed")
-	}
-}
-
-func TestParseArgs_WithWebSearchDefault(t *testing.T) {
-	a, _ := parseArgs([]string{})
-	if a.WithWebSearch {
-		t.Errorf("expected WithWebSearch=false by default")
-	}
-	if a.WithWebSearchSet {
-		t.Errorf("expected WithWebSearchSet=false when --with-websearch is not passed")
-	}
-}
-
-func TestParseArgs_WebSearchBackend(t *testing.T) {
-	a, err := parseArgs([]string{"--websearch-backend", "duckduckgo"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if a.WebSearchBackend != "duckduckgo" {
-		t.Errorf("expected WebSearchBackend=duckduckgo, got %q", a.WebSearchBackend)
-	}
-	if !a.WebSearchBackendSet {
-		t.Errorf("expected WebSearchBackendSet=true")
-	}
-}
-
-func TestParseArgs_WebSearchBackendEquals(t *testing.T) {
-	a, _ := parseArgs([]string{"--websearch-backend=none"})
-	if a.WebSearchBackend != "none" {
-		t.Errorf("expected WebSearchBackend=none, got %q", a.WebSearchBackend)
-	}
-	if !a.WebSearchBackendSet {
-		t.Errorf("expected WebSearchBackendSet=true")
-	}
-}
-
-func TestParseArgs_WebSearchFetchBudget(t *testing.T) {
-	a, err := parseArgs([]string{"--websearch-fetch-budget", "204800"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if a.WebSearchFetchBudget != 204800 {
-		t.Errorf("expected WebSearchFetchBudget=204800, got %d", a.WebSearchFetchBudget)
-	}
-	if !a.WebSearchFetchBudgetSet {
-		t.Errorf("expected WebSearchFetchBudgetSet=true")
-	}
-}
-
-func TestParseArgs_WebSearchFetchBudgetEquals(t *testing.T) {
-	a, _ := parseArgs([]string{"--websearch-fetch-budget=51200"})
-	if a.WebSearchFetchBudget != 51200 {
-		t.Errorf("expected WebSearchFetchBudget=51200, got %d", a.WebSearchFetchBudget)
-	}
-}
-
-func TestParseArgs_AllWebSearchFlagsTogether(t *testing.T) {
-	a, _ := parseArgs([]string{"--with-websearch", "--websearch-backend", "duckduckgo", "--websearch-fetch-budget", "65536"})
-	if !a.WithWebSearch {
-		t.Errorf("expected WithWebSearch=true")
-	}
-	if a.WebSearchBackend != "duckduckgo" {
-		t.Errorf("expected WebSearchBackend=duckduckgo, got %q", a.WebSearchBackend)
-	}
-	if a.WebSearchFetchBudget != 65536 {
-		t.Errorf("expected WebSearchFetchBudget=65536, got %d", a.WebSearchFetchBudget)
 	}
 }
 
@@ -287,7 +162,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 	if a.Profile != "" {
 		t.Errorf("expected empty profile, got %q", a.Profile)
 	}
-	if a.Verbose || a.Version || a.ShowHelp || a.PrintEnv || a.OTEL || a.NoOTEL {
+	if a.Verbose || a.Version || a.ShowHelp {
 		t.Error("expected all bool flags false for empty args")
 	}
 	if a.Upstream != "" {
@@ -298,10 +173,6 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 	}
 	if len(a.ClaudeArgs) != 0 {
 		t.Errorf("expected no claudeArgs, got %v", a.ClaudeArgs)
-	}
-	// OTELMetricsTable should have the default value
-	if a.OTELMetricsTable == "" {
-		t.Error("expected non-empty default otelMetricsTable")
 	}
 }
 
@@ -342,137 +213,6 @@ func TestParseArgs_HeadlessWithOtherFlags(t *testing.T) {
 	}
 }
 
-func TestParseArgs_NoOtel(t *testing.T) {
-	a, _ := parseArgs([]string{"--no-otel"})
-	if !a.NoOTEL {
-		t.Error("expected noOtel=true for --no-otel")
-	}
-	if a.OTEL {
-		t.Error("expected otel=false when only --no-otel given")
-	}
-	if len(a.ClaudeArgs) != 0 {
-		t.Errorf("expected no claudeArgs, got %v", a.ClaudeArgs)
-	}
-}
-
-func TestParseArgs_NoOtelAndOtel(t *testing.T) {
-	a, _ := parseArgs([]string{"--no-otel", "--otel"})
-	if !a.NoOTEL {
-		t.Error("expected noOtel=true")
-	}
-	if !a.OTEL {
-		t.Error("expected otel=true (both flags can coexist; main() handles precedence)")
-	}
-}
-
-func TestParseArgs_NoOtelWithPassthrough(t *testing.T) {
-	a, _ := parseArgs([]string{"--no-otel", "somearg"})
-	if !a.NoOTEL {
-		t.Error("expected noOtel=true")
-	}
-	if len(a.ClaudeArgs) != 1 || a.ClaudeArgs[0] != "somearg" {
-		t.Errorf("expected claudeArgs=[\"somearg\"], got %v", a.ClaudeArgs)
-	}
-}
-
-func TestParseArgs_OtelUnaffectedByNoOtel(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel"})
-	if !a.OTEL {
-		t.Error("expected otel=true for --otel")
-	}
-	if a.NoOTEL {
-		t.Error("expected noOtel=false when only --otel given")
-	}
-}
-
-// --- per-signal no-otel-* flag tests ---
-
-func TestParseArgs_NoOtelMetrics(t *testing.T) {
-	a, _ := parseArgs([]string{"--no-otel-metrics"})
-	if !a.NoOTELMetrics {
-		t.Error("expected noOtelMetrics=true for --no-otel-metrics")
-	}
-	if a.NoOTELLogs || a.NoOTELTraces {
-		t.Error("expected noOtelLogs/noOtelTraces=false when only --no-otel-metrics given")
-	}
-}
-
-func TestParseArgs_NoOtelLogs(t *testing.T) {
-	a, _ := parseArgs([]string{"--no-otel-logs"})
-	if !a.NoOTELLogs {
-		t.Error("expected noOtelLogs=true for --no-otel-logs")
-	}
-	if a.NoOTELMetrics || a.NoOTELTraces {
-		t.Error("expected noOtelMetrics/noOtelTraces=false when only --no-otel-logs given")
-	}
-}
-
-func TestParseArgs_NoOtelTraces(t *testing.T) {
-	a, _ := parseArgs([]string{"--no-otel-traces"})
-	if !a.NoOTELTraces {
-		t.Error("expected noOtelTraces=true for --no-otel-traces")
-	}
-	if a.NoOTELMetrics || a.NoOTELLogs {
-		t.Error("expected noOtelMetrics/noOtelLogs=false when only --no-otel-traces given")
-	}
-}
-
-// --- --otel-traces flag tests ---
-
-func TestParseArgs_OtelTraces(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel-traces"})
-	if !a.OTELTraces {
-		t.Error("expected otelTraces=true for --otel-traces")
-	}
-}
-
-func TestParseArgs_OtelTracesTableOverride(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel-traces-table", "main.default.traces"})
-	if !a.OTELTracesTableSet {
-		t.Error("expected tracesTableSet=true when --otel-traces-table is passed")
-	}
-	if a.OTELTracesTable != "main.default.traces" {
-		t.Errorf("expected tracesTable=%q, got %q", "main.default.traces", a.OTELTracesTable)
-	}
-}
-
-func TestParseArgs_OtelTracesTableEquals(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel-traces-table=my.catalog.traces"})
-	if !a.OTELTracesTableSet {
-		t.Error("expected tracesTableSet=true for --otel-traces-table=value")
-	}
-	if a.OTELTracesTable != "my.catalog.traces" {
-		t.Errorf("expected tracesTable=%q, got %q", "my.catalog.traces", a.OTELTracesTable)
-	}
-}
-
-func TestParseArgs_OtelTracesTableDefault(t *testing.T) {
-	// --otel-traces alone (no table) should not auto-populate a default table —
-	// traces only activate when an explicit --otel-traces-table is provided.
-	a, _ := parseArgs([]string{"--otel-traces"})
-	if !a.OTELTraces {
-		t.Error("expected otelTraces=true")
-	}
-	if a.OTELTracesTableSet {
-		t.Error("expected tracesTableSet=false without --otel-traces-table")
-	}
-	if a.OTELTracesTable != "" {
-		t.Errorf("expected empty tracesTable default, got %q", a.OTELTracesTable)
-	}
-}
-
-// TestParseArgs_TracesStandalone verifies that --otel-traces-table works
-// without --otel — traces is a standalone signal.
-func TestParseArgs_TracesStandalone(t *testing.T) {
-	a, _ := parseArgs([]string{"--otel-traces-table", "cat.schema.traces"})
-	if a.OTEL {
-		t.Error("expected otel=false when only --otel-traces-table given")
-	}
-	if !a.OTELTracesTableSet || a.OTELTracesTable != "cat.schema.traces" {
-		t.Errorf("expected tracesTable=cat.schema.traces (set), got %q (set=%v)", a.OTELTracesTable, a.OTELTracesTableSet)
-	}
-}
-
 // Table-driven comprehensive test for parseArgs.
 func TestParseArgs_Table(t *testing.T) {
 	type result struct {
@@ -480,8 +220,6 @@ func TestParseArgs_Table(t *testing.T) {
 		verbose   bool
 		version   bool
 		showHelp  bool
-		printEnv  bool
-		otel      bool
 		upstream  string
 		logFile   string
 		claudeLen int
@@ -501,11 +239,6 @@ func TestParseArgs_Table(t *testing.T) {
 			name: "-h sets showHelp",
 			args: []string{"-h"},
 			want: result{showHelp: true},
-		},
-		{
-			name: "--print-env sets printEnv",
-			args: []string{"--print-env"},
-			want: result{printEnv: true},
 		},
 		{
 			name: "--version sets version",
@@ -548,11 +281,6 @@ func TestParseArgs_Table(t *testing.T) {
 			want: result{upstream: "/path/to/claude"},
 		},
 		{
-			name: "--otel sets otel",
-			args: []string{"--otel"},
-			want: result{otel: true},
-		},
-		{
 			name: "unknown flag passes through",
 			args: []string{"--unknown"},
 			want: result{claudeLen: 1},
@@ -587,12 +315,6 @@ func TestParseArgs_Table(t *testing.T) {
 			}
 			if a.ShowHelp != tc.want.showHelp {
 				t.Errorf("showHelp: got %v, want %v", a.ShowHelp, tc.want.showHelp)
-			}
-			if a.PrintEnv != tc.want.printEnv {
-				t.Errorf("printEnv: got %v, want %v", a.PrintEnv, tc.want.printEnv)
-			}
-			if a.OTEL != tc.want.otel {
-				t.Errorf("otel: got %v, want %v", a.OTEL, tc.want.otel)
 			}
 			if a.Upstream != tc.want.upstream {
 				t.Errorf("upstream: got %q, want %q", a.Upstream, tc.want.upstream)
@@ -712,12 +434,21 @@ func TestHandleHelp_ContainsDatabricksClaude(t *testing.T) {
 	}
 }
 
-func TestHandleHelp_ContainsPrintEnvFlag(t *testing.T) {
+// TestHandleHelp_DoesNotContainRemovedFlags is the inverse: post-#172 the
+// 14 persistent-config flags MUST NOT appear in root help. Old flags moved
+// behind `config <subcommand>`.
+func TestHandleHelp_DoesNotContainRemovedFlags(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp()
 	})
-	if !strings.Contains(out, "--print-env") {
-		t.Errorf("expected help output to contain '--print-env', got:\n%s", out)
+	for _, flag := range []string{
+		"--print-env", "--otel", "--no-otel", "--no-otel-metrics", "--no-otel-logs", "--no-otel-traces",
+		"--otel-metrics-table", "--otel-logs-table", "--otel-traces", "--otel-traces-table",
+		"--write-claude-config", "--with-websearch", "--websearch-backend", "--websearch-fetch-budget",
+	} {
+		if strings.Contains(out, flag) {
+			t.Errorf("removed flag %q must not appear in root help (#172), got:\n%s", flag, out)
+		}
 	}
 }
 
@@ -725,11 +456,22 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp()
 	})
-	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--otel", "--otel-metrics-table", "--otel-logs-table", "--headless", "--idle-timeout", "--version", "--help"}
+	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--headless", "--idle-timeout", "--version", "--help"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)
 		}
+	}
+}
+
+// TestHandleHelp_AdvertisesConfigSubcommand asserts the root help points
+// users at the `config` subcommand tree where the legacy flags moved.
+func TestHandleHelp_AdvertisesConfigSubcommand(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp()
+	})
+	if !strings.Contains(out, "config <subcommand>") {
+		t.Errorf("expected root help to advertise 'config <subcommand>', got:\n%s", out)
 	}
 }
 
@@ -1238,146 +980,18 @@ func TestIdleTimeout_ZeroDisables(t *testing.T) {
 	}
 }
 
-// --- --write-claude-config flag tests ---
+// --- `config write` (was --write-claude-config) integration tests ---
 
-func TestParseArgs_WriteClaudeConfig(t *testing.T) {
-	a, err := parseArgs([]string{"--write-claude-config"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !a.WriteClaudeConfig {
-		t.Error("expected WriteClaudeConfig=true for --write-claude-config")
-	}
-	// Must not set any other early-exit flags.
-	if a.ShowHelp || a.Version || a.PrintEnv || a.InstallHooks || a.Headless {
-		t.Error("unexpected non-default values alongside --write-claude-config")
-	}
-	if len(a.ClaudeArgs) != 0 {
-		t.Errorf("expected no claude passthrough args, got %v", a.ClaudeArgs)
-	}
-}
-
-func TestParseArgs_WriteClaudeConfig_WithProfile(t *testing.T) {
-	a, err := parseArgs([]string{"--write-claude-config", "--profile", "foo"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !a.WriteClaudeConfig {
-		t.Error("expected WriteClaudeConfig=true")
-	}
-	if a.Profile != "foo" {
-		t.Errorf("expected Profile=foo, got %q", a.Profile)
-	}
-}
-
-func TestParseArgs_WriteClaudeConfig_WithWebSearch(t *testing.T) {
-	a, err := parseArgs([]string{"--write-claude-config", "--with-websearch", "--websearch-backend", "duckduckgo", "--websearch-fetch-budget", "204800"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !a.WriteClaudeConfig {
-		t.Error("expected WriteClaudeConfig=true")
-	}
-	if !a.WithWebSearchSet || !a.WithWebSearch {
-		t.Errorf("expected WithWebSearch=true (Set=%v, Val=%v)", a.WithWebSearchSet, a.WithWebSearch)
-	}
-	if !a.WebSearchBackendSet || a.WebSearchBackend != "duckduckgo" {
-		t.Errorf("expected WebSearchBackend=duckduckgo (Set=%v, Val=%q)", a.WebSearchBackendSet, a.WebSearchBackend)
-	}
-	if !a.WebSearchFetchBudgetSet || a.WebSearchFetchBudget != 204800 {
-		t.Errorf("expected WebSearchFetchBudget=204800 (Set=%v, Val=%d)", a.WebSearchFetchBudgetSet, a.WebSearchFetchBudget)
-	}
-}
-
-// TestWriteClaudeConfig_PersistsWebSearchState verifies that the resolution
-// + persistence block for --with-websearch in the --write-claude-config
-// branch writes to ~/.claude/.databricks-claude.json so the daemon picks up
-// the websearch opt-in on its next start. Websearch is a proxy-side feature
-// controlled entirely by state — it does NOT add a key to settings.json env.
-// Drives the same block the live code path uses.
-func TestWriteClaudeConfig_PersistsWebSearchState(t *testing.T) {
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
-
-	origStatePath := statePath
-	statePath = func() string { return filepath.Join(tmpHome, ".claude", ".databricks-claude.json") }
-	defer func() { statePath = origStatePath }()
-
-	a := &Args{
-		WithWebSearch:           true,
-		WithWebSearchSet:        true,
-		WebSearchBackend:        "duckduckgo",
-		WebSearchBackendSet:     true,
-		WebSearchFetchBudget:    204800,
-		WebSearchFetchBudgetSet: true,
-	}
-
-	// Mirror the resolution+persistence shape inside the --write-claude-config
-	// branch. Any regression here that drops one of the three writes will be
-	// caught by the per-field assertions below.
-	wsState := loadState()
-	withWebSearch := wsState.WithWebSearch
-	wsBackend := wsState.WebSearchBackend
-	wsBudget := wsState.WebSearchFetchBudget
-	if a.WithWebSearchSet {
-		withWebSearch = a.WithWebSearch
-	}
-	if a.WebSearchBackendSet {
-		wsBackend = a.WebSearchBackend
-	}
-	if a.WebSearchFetchBudgetSet {
-		wsBudget = a.WebSearchFetchBudget
-	}
-	mutated := false
-	if a.WithWebSearchSet && wsState.WithWebSearch != withWebSearch {
-		wsState.WithWebSearch = withWebSearch
-		mutated = true
-	}
-	if a.WebSearchBackendSet && wsState.WebSearchBackend != wsBackend {
-		wsState.WebSearchBackend = wsBackend
-		mutated = true
-	}
-	if a.WebSearchFetchBudgetSet && wsState.WebSearchFetchBudget != wsBudget {
-		wsState.WebSearchFetchBudget = wsBudget
-		mutated = true
-	}
-	if mutated {
-		if err := saveState(wsState); err != nil {
-			t.Fatalf("saveState failed: %v", err)
-		}
-	}
-
-	got := loadState()
-	if !got.WithWebSearch {
-		t.Error("expected state.WithWebSearch=true after persist")
-	}
-	if got.WebSearchBackend != "duckduckgo" {
-		t.Errorf("state.WebSearchBackend: got %q, want %q", got.WebSearchBackend, "duckduckgo")
-	}
-	if got.WebSearchFetchBudget != 204800 {
-		t.Errorf("state.WebSearchFetchBudget: got %d, want 204800", got.WebSearchFetchBudget)
-	}
-}
-
-func TestHandleHelp_AdvertisesWriteClaudeConfig(t *testing.T) {
-	out := captureStdout(func() {
-		handleHelp()
-	})
-	if !strings.Contains(out, "--write-claude-config") {
-		t.Errorf("expected help output to contain '--write-claude-config', got:\n%s", out)
-	}
-}
-
-// TestWriteClaudeConfig_BootstrapWritesFullEnvBlock verifies that the
-// bootstrapSettings + ensureConfig write path used by --write-claude-config
+// TestConfigWrite_BootstrapWritesFullEnvBlock verifies that the
+// bootstrapSettings + ensureConfig write path used by `config write`
 // produces the full needsFullSetup key set without requiring the Databricks CLI.
 //
 // Drives against databricksFullSetupEnv() — the single source of truth used
-// by BOTH the --write-claude-config branch and the normal-startup
-// needsFullSetup block. A regression that deletes any model key, the custom
-// header, or the experimental-betas line from the helper fails this test
-// regardless of which call site is exercised.
-func TestWriteClaudeConfig_BootstrapWritesFullEnvBlock(t *testing.T) {
+// by BOTH the `config write` runner and the normal-startup needsFullSetup
+// block. A regression that deletes any model key, the custom header, or the
+// experimental-betas line from the helper fails this test regardless of
+// which call site is exercised.
+func TestConfigWrite_BootstrapWritesFullEnvBlock(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
@@ -1464,9 +1078,9 @@ func TestDatabricksFullSetupEnv_KeyCoverage(t *testing.T) {
 	}
 }
 
-// TestWriteClaudeConfig_MissingModelKeys confirms that omitting the needsFullSetup
+// TestConfigWrite_MissingModelKeys confirms that omitting the needsFullSetup
 // keys from otelEnv (passing nil) means model keys are absent — the negative control.
-func TestWriteClaudeConfig_MissingModelKeys(t *testing.T) {
+func TestConfigWrite_MissingModelKeys(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
@@ -1532,15 +1146,14 @@ func TestKnownFlagsCoverAllFlagDefs(t *testing.T) {
 //
 // We feed parseArgs a single `--<name>` token (with a type-appropriate
 // value for TakesArg flags so parsers that validate their input — e.g.
-// --idle-timeout, --websearch-fetch-budget — don't reject the synthetic
-// case). For non-TakesArg flags the token is sufficient on its own.
+// --idle-timeout — don't reject the synthetic case). For non-TakesArg
+// flags the token is sufficient on its own.
 func TestRootTreeFlagsAreParseRecognised(t *testing.T) {
 	// Type-appropriate synthetic values for flags whose parser validates
 	// the argument. Anything not listed gets the default "synthetic".
 	syntheticValues := map[string]string{
-		"port":                   "12345",
-		"idle-timeout":           "1s",
-		"websearch-fetch-budget": "1024",
+		"port":         "12345",
+		"idle-timeout": "1s",
 	}
 	for _, f := range rootCommand.AllFlags() {
 		name := "--" + f.Name


### PR DESCRIPTION
## What

Consolidates the 14 "persistent config editor" root flags into a `config` subcommand tree. Implements #172 (part of #169's CLI command-tree restructure). Targets the `feat/cli-command-tree` integration branch.

**Breaking change** — old flags are **removed, not aliased** (they now pass through to `claude` as unknowns). Acceptable per #169 — no user base yet.

### New surface

```
config otel enable  [--metrics-table T] [--logs-table T] [--traces] [--traces-table T]
config otel disable [--metrics] [--logs] [--traces]      # no flags = disable all
config websearch enable  [--backend duckduckgo|none] [--fetch-budget N]
config websearch disable
config write                                             # was --write-claude-config
config show                                              # was --print-env
```

### Flag mapping

| Removed root flag(s) | Replacement |
|---|---|
| `--otel` / `--otel-*-table` | `config otel enable [...]` |
| `--no-otel` / `--no-otel-{metrics,logs,traces}` | `config otel disable [...]` |
| `--with-websearch` / `--websearch-*` | `config websearch enable [...]` |
| `--write-claude-config` | `config write` |
| `--print-env` | `config show` |

`config websearch disable` is new behaviour (the legacy CLI had no explicit websearch disable) — sanctioned by the issue.

## Storage semantics — unchanged

Pure surface reshape. The two-store model (settings.json env block vs `.databricks-claude.json` state file), sentinel-guarded writers, `config otel disable` preserving state-file table preferences, and active OTEL-section removal are all byte-identical with the legacy paths. The existing logic blocks were extracted into a new `config.go` runner; the running proxy still routes OTEL from state on every start (only the *flag-driven mutation* paths moved).

## Design

- `config.go` — dispatcher + two pure resolvers (`resolveConfigOTEL`, `resolveConfigWebSearch`) + runners. Pure functions so the orchestration matrix is testable in isolation — the known failure mode for this refactor shape is helper-level tests passing while composition is broken.
- `commands.go` — `configCommand` tree node with nested `otel`/`websearch` sub-trees; nested shell completion auto-derives from the recursive `CompletionSubcommands()` walk.
- The parity tests (`TestRootTreeFlagsAreParseRecognised` / `TestParseArgsCasesAreDeclaredInRootTree`) enforce that every removed flag was removed from **both** `commands.go` and the `parseArgs` switch.

## Review fix applied

Cross-lane review (done in-controller-context — `delegate_task` reviewers time out on diffs this size, per the wrappers skill) caught **1 MAJOR**:

`config write` reused `resolveConfigOTEL`, which unconditionally applied the legacy `--otel` bare-toggle metrics default (`main.claude_telemetry.claude_otel_metrics`) on empty state. But the legacy `--write-claude-config` block resolved tables strictly `flag → state → empty` and **never** applied that default — so a fresh-install `config write` with no flags would have silently enabled OTEL telemetry export to a UC table the user never created (→ Databricks ingest 400s). **Behavior regression.**

Fix: added an `applyMetricsDefault bool` param to `resolveConfigOTEL` — `config otel enable` passes `true` (bare toggle = enable-with-default, matching old `--otel`), `config write` passes `false` (matching old `--write-claude-config`). The matrix test gained 3 `applyDefault=false` cases that lock the fix; verified bidirectionally — the new "empty state, applyDefault=false → empty otelEnv" case would fail against the pre-fix ungated branch.

## Verification

- `go build ./... && go vet ./... && go test ./...` — all 18 packages green
- `databricks-claude --help` — 0 occurrences of the 14 removed flags
- `config --help` / `config otel --help` render from the tree
- Orchestration matrix test (AC): 11 cases — state empty/populated × enable/disable × explicit flags × `applyMetricsDefault`
- `config otel disable` state-preservation test (AC): disable clears settings.json keys, state-file tables survive, re-enable restores them
- Nested-completion test: `config` with `otel`/`websearch`/`write`/`show` children

## Notes / NIT

- `config otel enable` routes through `bootstrapSettings`/`ensureConfig`, which always (re)sets `ANTHROPIC_BASE_URL` — same as the legacy `--write-claude-config` did. Intentional, not a regression.

Part of #169. Closes #172.
