### PR TITLE
feat!: consolidate hooks lifecycle flags under a `hooks` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ There are three ways to use `databricks-claude`. Most people want **session hook
 
 | Primary client | Recommended setup |
 |----------------|-------------------|
-| CLI Claude Code, VS Code extension, JetBrains plugin | **Session hooks** — `databricks-claude --install-hooks --profile <name>`. |
+| CLI Claude Code, VS Code extension, JetBrains plugin | **Session hooks** — `databricks-claude hooks install --profile <name>`. |
 | Claude Desktop (chat UI and/or embedded Claude Code) | **Mobileconfig** — `databricks-claude desktop generate-config` + install in System Settings. |
 | Both | Install both. They coexist without conflict. |
 | One-off / scripted invocations | Use the [raw wrapper](#cli-usage) directly. |
@@ -102,18 +102,18 @@ Install hooks so every Claude Code session auto-starts the proxy on startup and 
 ### Install
 
 ```bash
-databricks-claude --install-hooks --profile <name>
+databricks-claude hooks install --profile <name>
 ```
 
 This is one-step setup: it persists your profile/port, writes `ANTHROPIC_BASE_URL` to `~/.claude/settings.json`, and registers the SessionStart and SessionEnd hooks. No prior `databricks-claude` invocation needed. Re-running is idempotent.
 
-- **SessionStart** — calls `databricks-claude --headless-ensure` on session startup: starts the proxy if it isn't already running.
-- **SessionEnd** — calls `databricks-claude --headless-release` on session end: decrements the refcount; proxy exits when the last session closes.
+- **SessionStart** — calls `databricks-claude hooks session-start` on session startup: starts the proxy if it isn't already running. (Hook-invoked internal — not intended to run by hand.)
+- **SessionEnd** — calls `databricks-claude hooks session-end` on session end: decrements the refcount; proxy exits when the last session closes. (Hook-invoked internal.)
 
 ### Uninstall
 
 ```bash
-databricks-claude --uninstall-hooks
+databricks-claude hooks uninstall
 ```
 
 Removes only the databricks-claude hook entries. Other hooks in your settings are untouched.
@@ -578,6 +578,31 @@ databricks-claude setup --profile databricks-ai-inference --force
 
 `setup` is the same auth flow the credential helper uses for daily token recovery — running it proactively in a fleet init script keeps users from seeing the recovery browser tab on their first Claude Desktop launch.
 
+## hooks Subcommand
+
+Session-hook deployment mode for Claude Code. Installs SessionStart/SessionEnd hook entries into `~/.claude/settings.json` that spin a refcount-managed proxy up on session start and tear it down on session end — so `claude` "just works" against your Databricks workspace without manually launching `databricks-claude` each time. See [Session Hooks (recommended)](#session-hooks-recommended) for the user-facing onboarding.
+
+```bash
+# First-time install:
+databricks-claude hooks install --profile <name>
+
+# Remove the hook entries (e.g. before switching to the long-lived `serve` daemon):
+databricks-claude hooks uninstall
+```
+
+`hooks install` is one-step setup: it persists `--profile` / `--port` to the state file, writes a placeholder `ANTHROPIC_BASE_URL` into `~/.claude/settings.json` (the SessionStart hook overwrites it with the discovered AI Gateway URL on first run), and registers the SessionStart and SessionEnd entries. Idempotent — re-running after upgrades is safe and produces no duplicates.
+
+`hooks uninstall` removes only the databricks-claude hook entries; other hooks in your settings are untouched. Tolerates "not installed" (no-op when no databricks-claude hooks are present).
+
+| Subcommand | Purpose |
+|------|---------|
+| `hooks install` | Install SessionStart/SessionEnd hooks AND perform first-run env bootstrap. Accepts `--profile P` / `--port N`. |
+| `hooks uninstall` | Remove databricks-claude hooks from `~/.claude/settings.json`. |
+| `hooks session-start` | **Hook-invoked internal.** Refcount-acquire + spawn the proxy if not already healthy. Called by the SessionStart hook JSON; not intended to be invoked directly. |
+| `hooks session-end` | **Hook-invoked internal.** POST `/shutdown` to decrement the refcount; proxy exits when the last session ends. Called by the SessionEnd hook JSON; not intended to be invoked directly. |
+
+The hooks deployment mode is unchanged behaviorally from earlier releases — the proxy still spins up on SessionStart and tears down on SessionEnd. Only the surface moved: prior to this release the same actions were `databricks-claude --install-hooks` / `--uninstall-hooks` / `--headless-ensure` / `--headless-release`. The old root flags have been **removed** (not aliased) and the generated hook JSON now invokes the new subcommand names. No back-compat for already-installed hooks; re-run `hooks install` to refresh the entries.
+
 ## serve Subcommand
 
 Long-lived daemon that serves **both Claude Code and Claude Desktop** with persistent Databricks OAuth. A third deployment mode alongside the per-session CLI wrapper (`databricks-claude claude …`) and SessionStart hooks — useful when you want a single OAuth-refreshing proxy that survives across sessions.
@@ -733,7 +758,7 @@ The write is idempotent — `ensureConfig` short-circuits when the env block alr
 - **Re-bootstrap when model names drift.** If you upgrade `databricks-claude` and the project ships new default model names, re-run `databricks-claude config write` once to refresh them. The bootstrap is idempotent and only writes keys that differ.
 - **OTEL tables persist to state.** Run `databricks-claude serve --otel-metrics-table foo --otel-logs-table bar` once; the daemon (or its installed service) picks them up from `~/.claude/.databricks-claude.json` on every restart thereafter.
 - **Don't run the CLI wrapper (`databricks-claude claude …`) at the same time as the daemon for the same workspace.** Pick one deployment mode per workspace; mixing both means two proxies fighting over the same port and settings block.
-- **Hooks coexist cleanly.** If you've also installed SessionStart hooks (`databricks-claude --install-hooks`), they probe the daemon's `/health` and no-op when it's running, falling back to per-session proxy only if the daemon is down.
+- **Hooks coexist cleanly.** If you've also installed SessionStart hooks (`databricks-claude hooks install`), they probe the daemon's `/health` and no-op when it's running, falling back to per-session proxy only if the daemon is down.
 
 To stop using the daemon, run `databricks-claude serve uninstall` and remove the `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` lines from `~/.claude/settings.json` (or delete the whole `env` block if you don't use Claude Code anymore).
 

--- a/commands.go
+++ b/commands.go
@@ -82,10 +82,6 @@ var rootCommand = cmd.Command{
 		{Name: "headless", Description: "Start proxy without launching claude (for IDE extensions or hooks)"},
 		{Name: "idle-timeout", Description: "Idle timeout for headless mode (default: 30m; 0 disables; use e.g. 30s, 5m, 1h)", TakesArg: true,
 			Default: "30m"},
-		{Name: "install-hooks", Description: "Install SessionStart/Stop hooks into ~/.claude/settings.json"},
-		{Name: "uninstall-hooks", Description: "Remove databricks-claude hooks from ~/.claude/settings.json"},
-		{Name: "headless-ensure", Description: "Start proxy if not running — called by the SessionStart hook"},
-		{Name: "headless-release", Description: "Decrement proxy refcount — called by the Stop hook"},
 		{Name: "no-update-check", Description: "Skip the automatic update check on startup",
 			EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
 		// NOTE: --daemon and --daemon-fake-key are *desktop generate-config*
@@ -119,6 +115,7 @@ var rootCommand = cmd.Command{
 		desktopCommand,
 		setupCommand,
 		configCommand,
+		hooksCommand,
 		serveCommand,
 	},
 }
@@ -246,13 +243,7 @@ Databricks-Claude Flags:
   --tls-key string             Path to TLS private key file (requires --tls-cert)
   --port int                   Fixed proxy port (default: 49153, saved to state)
   --headless                   Start proxy without launching claude (for IDE extensions)
-  --headless-ensure            Start proxy if not running (called by SessionStart hook)
-  --headless-release           Decrement proxy refcount (called by Stop hook)
   --idle-timeout duration      Idle timeout for headless mode (default 30m, 0 disables; use e.g. 30s, 5m, 1h)
-  --install-hooks              Install SessionStart/SessionEnd hooks AND perform first-run
-                               env setup (idempotent). Accepts --profile and --port to
-                               persist them; no prior databricks-claude invocation needed.
-  --uninstall-hooks            Remove databricks-claude hooks from ~/.claude/settings.json
   --no-update-check            Skip the automatic update check on startup
   --version                    Print version and exit
   --help, -h                   Show this help message
@@ -274,6 +265,16 @@ Subcommands:
                                  config write                    Bootstrap settings.json
                                  config show                     Print resolved config
                                Run 'databricks-claude config --help' for details.
+  hooks <subcommand>           Session-hook deployment mode. install/uninstall manage
+                               the SessionStart/SessionEnd entries in
+                               ~/.claude/settings.json; session-start/session-end are
+                               hook-invoked refcount-managed proxy lifecycle internals
+                               (consolidated off the root flag namespace in #173).
+                                 hooks install                   Install hooks + bootstrap
+                                 hooks uninstall                 Remove hooks
+                                 hooks session-start             (hook-invoked internal)
+                                 hooks session-end               (hook-invoked internal)
+                               Run 'databricks-claude hooks --help' for details.
   serve [install|uninstall|status|flags]
                                Long-lived daemon serving Claude Code and Claude
                                Desktop with persistent Databricks OAuth. Owns
@@ -942,4 +943,175 @@ Example output:
     ANTHROPIC_AUTH_TOKEN: dapi-***
     Upstream binary:      /usr/local/bin/claude
     OTEL enabled:         false
+`
+
+// hooksCommand declares the `hooks` subcommand tree introduced in #173.
+// Consolidates the 4 hooks-lifecycle root flags (--install-hooks,
+// --uninstall-hooks, --headless-ensure, --headless-release) under a
+// discoverable subcommand. install/uninstall manage the
+// SessionStart/SessionEnd entries in ~/.claude/settings.json;
+// session-start/session-end are hook-invoked refcount-managed proxy
+// lifecycle internals (formerly --headless-ensure / --headless-release).
+//
+// Tree shape:
+//
+//	hooks
+//	├── install        [--profile P] [--port N]
+//	├── uninstall
+//	├── session-start  [--port N]   (hook-invoked internal)
+//	└── session-end    [--port N]   (hook-invoked internal)
+//
+// The hook-install logic (installHooks/uninstallHooks in hooks.go), the
+// first-run bootstrap (bootstrapSettings), and the refcount-managed
+// proxy lifecycle (headlessEnsure/headlessRelease) are unchanged
+// behaviorally — they move behind tree commands and the generated hook
+// JSON is rewritten to invoke the new command names. No back-compat for
+// already-installed hooks (none deployed); a clean prefix swap on the
+// detector keeps idempotent re-install + uninstall correct.
+var hooksCommand = cmd.Command{
+	Name:  "hooks",
+	Short: "Session-hook deployment mode: install/uninstall + lifecycle internals",
+	Long:  hooksHelpTemplate,
+	Subcommands: []cmd.Command{
+		{
+			Name:  "install",
+			Short: "Install SessionStart/SessionEnd hooks + first-run env bootstrap",
+			Long:  hooksInstallHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "profile", Description: "Databricks CLI profile to persist (default: DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+				{Name: "port", Description: "Proxy listen port to persist (default: 49153)", TakesArg: true, StateKey: "port", Default: "49153"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "uninstall",
+			Short: "Remove databricks-claude hooks from ~/.claude/settings.json",
+			Long:  hooksUninstallHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "session-start",
+			Short: "Start proxy if not running (invoked by the SessionStart hook — internal)",
+			Long:  hooksSessionStartHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "port", Description: "Proxy listen port (default: saved state > 49153)", TakesArg: true, StateKey: "port", Default: "49153"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "session-end",
+			Short: "Decrement proxy refcount (invoked by the SessionEnd hook — internal)",
+			Long:  hooksSessionEndHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "port", Description: "Proxy listen port (default: saved state > 49153)", TakesArg: true, StateKey: "port", Default: "49153"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+	},
+}
+
+const hooksHelpTemplate = `Usage: databricks-claude hooks <subcommand> [flags]
+
+Session-hook deployment mode for Claude Code. Installs hook entries into
+~/.claude/settings.json that spin a refcount-managed proxy up on
+SessionStart and tear it down on SessionEnd — making 'databricks-claude'
+auto-launch with every claude session without a long-lived daemon.
+
+Subcommands:
+  install        Install SessionStart/SessionEnd hooks AND perform
+                 first-run env bootstrap (idempotent). Accepts --profile
+                 and --port to persist them; no prior databricks-claude
+                 invocation needed.
+  uninstall      Remove databricks-claude hooks from
+                 ~/.claude/settings.json. Tolerates "not installed".
+  session-start  Hook-invoked internal: starts the proxy if it isn't
+                 already running, increments the per-port refcount.
+                 Called by the SessionStart hook JSON written by
+                 'hooks install'. Not intended to be invoked directly.
+  session-end    Hook-invoked internal: decrements the per-port refcount.
+                 The proxy exits when the last session ends. Called by
+                 the SessionEnd hook JSON written by 'hooks install'.
+                 Not intended to be invoked directly.
+
+Run 'databricks-claude hooks <subcommand> --help' for per-subcommand flags.
+
+Examples:
+  # First-time install on a developer machine:
+  databricks-claude hooks install --profile databricks-ai-inference
+
+  # Remove hooks (e.g. when switching to the long-lived 'serve' daemon):
+  databricks-claude hooks uninstall
+
+Exit codes:
+  0   success
+  1   write/discovery failure
+  2   missing or unknown subcommand
+`
+
+const hooksInstallHelpTemplate = `Usage: databricks-claude hooks install [flags]
+
+Install SessionStart and SessionEnd hooks into ~/.claude/settings.json
+and perform a first-run env bootstrap so users no longer need to invoke
+databricks-claude once before installing hooks. Idempotent — safe to
+re-run after upgrades.
+
+The bootstrap writes ANTHROPIC_BASE_URL=http://127.0.0.1:<port> as a
+placeholder; the SessionStart hook ('hooks session-start') overwrites
+it with the discovered AI Gateway URL on first run.
+
+Generated hook JSON:
+  SessionStart → "databricks-claude hooks session-start"
+  SessionEnd   → "databricks-claude hooks session-end"
+
+Flags:
+  --profile string   Databricks CLI profile to persist (default: DEFAULT)
+  --port int         Proxy listen port to persist (default: 49153)
+  --help, -h         Show this help message
+
+Examples:
+  # First-time install on a developer machine:
+  databricks-claude hooks install --profile databricks-ai-inference
+
+  # Re-install after upgrade (idempotent):
+  databricks-claude hooks install
+`
+
+const hooksUninstallHelpTemplate = `Usage: databricks-claude hooks uninstall
+
+Remove databricks-claude SessionStart/SessionEnd hook entries from
+~/.claude/settings.json. Tolerates "not installed" — safe to run when no
+hooks are present.
+
+Flags:
+  --help, -h   Show this help message
+`
+
+const hooksSessionStartHelpTemplate = `Usage: databricks-claude hooks session-start [flags]
+
+Hook-invoked internal: start the proxy if not already running and
+increment the per-port refcount. Called by the SessionStart hook JSON
+written by 'hooks install'. Not intended to be invoked directly by end
+users.
+
+Replaces the legacy --headless-ensure root flag.
+
+Flags:
+  --port int   Proxy listen port (default: saved state > 49153)
+  --help, -h   Show this help message
+`
+
+const hooksSessionEndHelpTemplate = `Usage: databricks-claude hooks session-end [flags]
+
+Hook-invoked internal: POST /shutdown to the proxy to decrement the
+per-port refcount. The proxy exits when the last session ends. Called
+by the SessionEnd hook JSON written by 'hooks install'. Not intended to
+be invoked directly by end users.
+
+Replaces the legacy --headless-release root flag.
+
+Flags:
+  --port int   Proxy listen port (default: saved state > 49153)
+  --help, -h   Show this help message
 `

--- a/hooks.go
+++ b/hooks.go
@@ -15,7 +15,7 @@ import (
 
 // headlessEnsure checks whether the proxy is healthy on the given port.
 // If not, it starts a detached headless proxy and polls until ready (max 10s).
-// Called by the SessionStart hook via: databricks-claude --headless-ensure
+// Called by the SessionStart hook via: databricks-claude hooks session-start
 func headlessEnsure(port int) {
 	if err := headless.Ensure(headless.Config{
 		Port:          port,
@@ -28,23 +28,23 @@ func headlessEnsure(port int) {
 }
 
 // headlessRelease calls POST /shutdown on the proxy to decrement the refcount.
-// Called by the Stop hook via: databricks-claude --headless-release
+// Called by the SessionEnd hook via: databricks-claude hooks session-end
 // Errors are logged but not fatal — proxy may already be stopped.
 func headlessRelease(port int) {
 	if os.Getenv("DATABRICKS_CLAUDE_MANAGED") == "1" {
-		log.Printf("databricks-claude: --headless-release: skipped (managed session)")
+		log.Printf("databricks-claude: hooks session-end: skipped (managed session)")
 		return
 	}
 
 	if mode, _ := health.ProxyMode(port, "http"); mode == "daemon" {
-		log.Printf("databricks-claude: --headless-release: managed by daemon, hook is no-op")
+		log.Printf("databricks-claude: hooks session-end: managed by daemon, hook is no-op")
 		return
 	}
 
 	client := &http.Client{Timeout: 3 * time.Second}
 	resp, err := client.Post(fmt.Sprintf("http://127.0.0.1:%d/shutdown", port), "application/json", nil)
 	if err != nil {
-		log.Printf("databricks-claude: --headless-release: %v (proxy may already be stopped)", err)
+		log.Printf("databricks-claude: hooks session-end: %v (proxy may already be stopped)", err)
 		return
 	}
 	resp.Body.Close()
@@ -74,7 +74,7 @@ func installHooks(settingsPath string) error {
 		"hooks": []interface{}{
 			map[string]interface{}{
 				"type":    "command",
-				"command": "databricks-claude --headless-ensure",
+				"command": "databricks-claude hooks session-start",
 				"timeout": 15,
 			},
 		},
@@ -90,7 +90,7 @@ func installHooks(settingsPath string) error {
 		"hooks": []interface{}{
 			map[string]interface{}{
 				"type":    "command",
-				"command": "databricks-claude --headless-release",
+				"command": "databricks-claude hooks session-end",
 				"timeout": 5,
 			},
 		},
@@ -130,7 +130,11 @@ func uninstallHooks(settingsPath string) error {
 	return writeSettingsJSON(settingsPath, doc)
 }
 
-// removeDBXHooks removes any hook entries whose command contains "databricks-claude --headless".
+// removeDBXHooks removes any hook entries whose command starts with
+// "databricks-claude hooks " (the new prefix introduced in #173). Detector
+// MUST stay aligned with the command names installHooks writes — drift here
+// silently orphans hooks (uninstall no-ops) and breaks idempotent re-install
+// (duplicates entries).
 func removeDBXHooks(hooks map[string]interface{}) {
 	for event, val := range hooks {
 		arr, _ := val.([]interface{})
@@ -144,7 +148,12 @@ func removeDBXHooks(hooks map[string]interface{}) {
 	}
 }
 
-// isDBXHookEntry returns true if any nested hook command references databricks-claude --headless.
+// isDBXHookEntry returns true if any nested hook command references
+// "databricks-claude hooks " — i.e. one of the session-start / session-end
+// commands written by installHooks. Prefix swap from the legacy
+// "databricks-claude --headless" landed in #173 alongside the JSON command
+// rewrite; the two MUST move together (see the round-trip test in
+// hooks_test.go for the bidirectional guard).
 func isDBXHookEntry(entry interface{}) bool {
 	m, ok := entry.(map[string]interface{})
 	if !ok {
@@ -154,7 +163,7 @@ func isDBXHookEntry(entry interface{}) bool {
 	for _, h := range inner {
 		hm, _ := h.(map[string]interface{})
 		if cmd, _ := hm["command"].(string); len(cmd) > 0 {
-			if strings.HasPrefix(cmd, "databricks-claude --headless") {
+			if strings.HasPrefix(cmd, "databricks-claude hooks ") {
 				return true
 			}
 		}

--- a/hooks_cmd.go
+++ b/hooks_cmd.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/IceRhymers/databricks-claude/internal/cmd"
+)
+
+// runHooksCommand implements `databricks-claude hooks ...`. args is everything
+// after the literal "hooks" token. Dispatches install / uninstall /
+// session-start / session-end. Bare `hooks` (no args) prints help and exits 2
+// — same convention as `desktop` / `config` with no action.
+//
+// Introduced in #173 to consolidate the 4 hooks-lifecycle root flags
+// (--install-hooks, --uninstall-hooks, --headless-ensure, --headless-release)
+// off the root command. The hook-install logic, first-run bootstrap, and
+// refcount-managed proxy lifecycle in hooks.go are unchanged; this dispatcher
+// is purely a surface reshape so the deployment mode is discoverable and the
+// internal entrypoints stop polluting the user-facing root flag namespace.
+func runHooksCommand(args []string) {
+	if len(args) == 0 {
+		_ = cmd.Render(os.Stderr, hooksCommand, nil)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "install":
+		runHooksInstall(args[1:])
+	case "uninstall":
+		runHooksUninstall(args[1:])
+	case "session-start":
+		runHooksSessionStart(args[1:])
+	case "session-end":
+		runHooksSessionEnd(args[1:])
+	case "--help", "-h", "help":
+		_ = cmd.Render(os.Stdout, hooksCommand, nil)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-claude: unknown hooks subcommand %q\n\n", args[0])
+		_ = cmd.Render(os.Stderr, hooksCommand, nil)
+		os.Exit(1)
+	}
+}
+
+// runHooksInstall implements `databricks-claude hooks install`. Lifts the
+// pre-#173 --install-hooks block from main.go. Persists profile/port to
+// state and writes the SessionStart/SessionEnd hook entries into
+// ~/.claude/settings.json. Idempotent.
+//
+// The placeholder ANTHROPIC_BASE_URL=http://127.0.0.1:<port> is overwritten
+// at session start by 'hooks session-start' with the discovered gateway URL.
+func runHooksInstall(args []string) {
+	node := hooksCommand.Subcommand("install")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("databricks-claude: cannot determine home dir: %v", err)
+	}
+	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
+
+	resolvedProfile := r.Strings["profile"]
+	if resolvedProfile == "" {
+		resolvedProfile = "DEFAULT"
+	}
+	portFlag := parseIntOrZero(r.Strings["port"])
+	port := resolvePort(portFlag, loadState())
+	placeholder := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	if err := bootstrapSettings(portFlag, resolvedProfile, placeholder, nil); err != nil {
+		log.Fatalf("databricks-claude: hooks install bootstrap: %v", err)
+	}
+	if err := installHooks(settingsPath); err != nil {
+		log.Fatalf("databricks-claude: hooks install: %v", err)
+	}
+	fmt.Fprintln(os.Stderr, "databricks-claude: hooks installed — SessionStart and SessionEnd hooks added to ~/.claude/settings.json")
+}
+
+// runHooksUninstall implements `databricks-claude hooks uninstall`. Lifts
+// the pre-#173 --uninstall-hooks block from main.go. Tolerates "not
+// installed" — uninstallHooks returns nil when settings.json does not exist
+// or contains no hooks.
+func runHooksUninstall(args []string) {
+	node := hooksCommand.Subcommand("uninstall")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("databricks-claude: cannot determine home dir: %v", err)
+	}
+	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
+
+	if err := uninstallHooks(settingsPath); err != nil {
+		log.Fatalf("databricks-claude: hooks uninstall: %v", err)
+	}
+	fmt.Fprintln(os.Stderr, "databricks-claude: hooks removed from ~/.claude/settings.json")
+}
+
+// runHooksSessionStart implements `databricks-claude hooks session-start`.
+// Hook-invoked internal — replaces the legacy --headless-ensure flag.
+// Refcount-acquire + spawn detached proxy if not healthy.
+func runHooksSessionStart(args []string) {
+	node := hooksCommand.Subcommand("session-start")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	state := loadState()
+	port := resolvePort(parseIntOrZero(r.Strings["port"]), state)
+	headlessEnsure(port)
+}
+
+// runHooksSessionEnd implements `databricks-claude hooks session-end`.
+// Hook-invoked internal — replaces the legacy --headless-release flag.
+// POST /shutdown (refcount decrement); proxy exits when last session ends.
+func runHooksSessionEnd(args []string) {
+	node := hooksCommand.Subcommand("session-end")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	state := loadState()
+	port := resolvePort(parseIntOrZero(r.Strings["port"]), state)
+	headlessRelease(port)
+}

--- a/hooks_cmd_test.go
+++ b/hooks_cmd_test.go
@@ -1,0 +1,310 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/IceRhymers/databricks-claude/pkg/refcount"
+)
+
+// --- #173 hooks tree parity tests ---
+
+// TestHooksCommandParity asserts the top-level `hooks` node carries no
+// flags of its own (it's a pure dispatcher; subcommands carry the flag
+// surface). Mirrors TestConfigCommandParity (#172).
+func TestHooksCommandParity(t *testing.T) {
+	assertFlagSetEqual(t, "hooksCommand", hooksCommand, []string{})
+}
+
+func TestHooksInstallParity(t *testing.T) {
+	install := hooksCommand.Subcommand("install")
+	if install == nil {
+		t.Fatal("hooksCommand should have an `install` subcommand")
+	}
+	assertFlagSetEqual(t, "hooks install", *install, []string{
+		"profile", "port", "help",
+	})
+}
+
+func TestHooksUninstallParity(t *testing.T) {
+	uninst := hooksCommand.Subcommand("uninstall")
+	if uninst == nil {
+		t.Fatal("hooksCommand should have an `uninstall` subcommand")
+	}
+	assertFlagSetEqual(t, "hooks uninstall", *uninst, []string{"help"})
+}
+
+func TestHooksSessionStartParity(t *testing.T) {
+	ss := hooksCommand.Subcommand("session-start")
+	if ss == nil {
+		t.Fatal("hooksCommand should have a `session-start` subcommand")
+	}
+	assertFlagSetEqual(t, "hooks session-start", *ss, []string{"port", "help"})
+}
+
+func TestHooksSessionEndParity(t *testing.T) {
+	se := hooksCommand.Subcommand("session-end")
+	if se == nil {
+		t.Fatal("hooksCommand should have a `session-end` subcommand")
+	}
+	assertFlagSetEqual(t, "hooks session-end", *se, []string{"port", "help"})
+}
+
+// TestHooksHasNestedSubcommands asserts the install/uninstall/session-start/
+// session-end children are declared so completion can offer them nested.
+// Mirrors TestServeHasNestedSubcommands (#171) and TestConfigHasNestedSubcommands
+// (#172). Drives the AC: "Help + completion derived from the tree".
+func TestHooksHasNestedSubcommands(t *testing.T) {
+	want := []string{"install", "uninstall", "session-start", "session-end"}
+	got := make(map[string]bool, len(hooksCommand.Subcommands))
+	for _, s := range hooksCommand.Subcommands {
+		got[s.Name] = true
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("hooksCommand should have nested `%s` subcommand for nested completion", w)
+		}
+	}
+}
+
+// TestRootCompletionOffersHooksSubcommand asserts `hooks` is surfaced as a
+// position-1 subcommand completion. Mirrors the implicit pattern that every
+// other subcommand on the root tree gets here automatically.
+func TestRootCompletionOffersHooksSubcommand(t *testing.T) {
+	for _, sc := range knownSubcommands {
+		if sc.Name == "hooks" {
+			// Ensure the nested children come through too — install / uninstall
+			// / session-start / session-end must be reachable via the recursive
+			// CompletionSubcommands path. Without this, `hooks <TAB>` would not
+			// offer the leaves.
+			gotChildren := make(map[string]bool, len(sc.Subcommands))
+			for _, child := range sc.Subcommands {
+				gotChildren[child.Name] = true
+			}
+			for _, want := range []string{"install", "uninstall", "session-start", "session-end"} {
+				if !gotChildren[want] {
+					t.Errorf("knownSubcommands `hooks` is missing nested child %q (recursive completion broken)", want)
+				}
+			}
+			return
+		}
+	}
+	t.Error("knownSubcommands should offer `hooks` as a position-1 subcommand")
+}
+
+// --- #173 hook JSON round-trip test ---
+//
+// THE LOAD-BEARING TEST. Validates that installHooks writes JSON pointing at
+// the new command names AND that uninstallHooks (via isDBXHookEntry) detects
+// + removes them. If the JSON-name swap and the detector-prefix swap fall out
+// of sync, this test fails bidirectionally (install→detect, uninstall→empty).
+// See the Risk 1 callout in plan #173.
+
+// TestInstallHooks_WritesNewCommandNames asserts the JSON written by
+// installHooks invokes `databricks-claude hooks session-start` /
+// `databricks-claude hooks session-end` — the new command names introduced
+// in #173. The previous values were `databricks-claude --headless-ensure` /
+// `--headless-release`; a stale install path that kept emitting those would
+// generate hooks that no longer resolve to a known root flag and would
+// silently fail at session start.
+func TestInstallHooks_WritesNewCommandNames(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := installHooks(settingsPath); err != nil {
+		t.Fatalf("installHooks: %v", err)
+	}
+
+	doc, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	hooks, _ := doc["hooks"].(map[string]interface{})
+	if hooks == nil {
+		t.Fatal("hooks block missing")
+	}
+
+	// SessionStart command must be the new `hooks session-start` form.
+	startCmd := nestedHookCommand(t, hooks, "SessionStart")
+	if startCmd != "databricks-claude hooks session-start" {
+		t.Errorf("SessionStart command = %q, want %q", startCmd, "databricks-claude hooks session-start")
+	}
+	endCmd := nestedHookCommand(t, hooks, "SessionEnd")
+	if endCmd != "databricks-claude hooks session-end" {
+		t.Errorf("SessionEnd command = %q, want %q", endCmd, "databricks-claude hooks session-end")
+	}
+}
+
+// TestInstallUninstallHooks_RoundTrip is the bidirectional round-trip:
+// install writes the new command names → uninstall detects them via the
+// updated `isDBXHookEntry` prefix and removes them cleanly. If the detector
+// prefix stayed pinned to the old `databricks-claude --headless` form,
+// uninstallHooks would silently leave the new entries behind — this test is
+// the load-bearing safeguard against that drift.
+func TestInstallUninstallHooks_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := installHooks(settingsPath); err != nil {
+		t.Fatalf("installHooks: %v", err)
+	}
+
+	// Verify hooks present (sanity check before we tear them down).
+	doc, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json after install: %v", err)
+	}
+	if _, ok := doc["hooks"]; !ok {
+		t.Fatal("hooks block missing after installHooks")
+	}
+
+	// Uninstall and re-read.
+	if err := uninstallHooks(settingsPath); err != nil {
+		t.Fatalf("uninstallHooks: %v", err)
+	}
+	doc, err = readSettingsJSON(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json after uninstall: %v", err)
+	}
+	if h, ok := doc["hooks"]; ok {
+		// The hooks block (or its inner SessionStart/SessionEnd arrays)
+		// should be empty/absent. If it persists, the detector prefix is
+		// out of sync with the JSON command names — orphaned entries.
+		if hm, _ := h.(map[string]interface{}); hm != nil {
+			for event, val := range hm {
+				if arr, _ := val.([]interface{}); len(arr) > 0 {
+					t.Errorf("uninstallHooks left %d entries under %q — detector prefix likely out of sync with installHooks command names",
+						len(arr), event)
+				}
+			}
+		}
+	}
+}
+
+// nestedHookCommand pulls the inner command string out of the nested hook
+// JSON shape Claude Code expects:
+//
+//	"<event>": [{ "matcher": "...", "hooks": [{ "type": "command", "command": "..." }] }]
+func nestedHookCommand(t *testing.T, hooks map[string]interface{}, event string) string {
+	t.Helper()
+	arr, _ := hooks[event].([]interface{})
+	if len(arr) == 0 {
+		t.Fatalf("%s hook missing", event)
+	}
+	entry, _ := arr[0].(map[string]interface{})
+	inner, _ := entry["hooks"].([]interface{})
+	if len(inner) == 0 {
+		t.Fatalf("%s inner hooks empty", event)
+	}
+	hm, _ := inner[0].(map[string]interface{})
+	cmd, _ := hm["command"].(string)
+	return cmd
+}
+
+// --- #173 end-to-end hooks lifecycle test ---
+//
+// Drives the AC: "Hooks deployment mode end-to-end verified: install hooks
+// → simulate SessionStart → proxy comes up (refcounted) → simulate
+// SessionEnd → refcount decrements / proxy tears down."
+//
+// We do NOT spawn a real detached proxy — that path is `pkg/headless`'s
+// concern and out of `hooks`' scope. Instead we stand up a stub health
+// server (the proven `TestHeadlessEnsure_AcquiresRefcount` /
+// `TestHeadlessRelease_EphemeralPostsShutdown` pattern) so headlessEnsure
+// sees a healthy proxy and just acquires the refcount, and headlessRelease
+// POSTs /shutdown. This exercises every code path the hook JSON triggers;
+// the only stubbed piece is the proxy process itself.
+
+// TestHooksLifecycleEndToEnd walks the full install → session-start →
+// session-end cycle through the SAME code paths the runner functions call
+// (bootstrapSettings / installHooks / headlessEnsure / headlessRelease).
+func TestHooksLifecycleEndToEnd(t *testing.T) {
+	home := withTempHome(t)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+
+	// --- 1. Install (mirrors runHooksInstall body without os.Exit) ---
+	if err := bootstrapSettings(0, "DEFAULT", "http://127.0.0.1:49153", nil); err != nil {
+		t.Fatalf("bootstrapSettings: %v", err)
+	}
+	if err := installHooks(settingsPath); err != nil {
+		t.Fatalf("installHooks: %v", err)
+	}
+
+	// settings.json must carry the placeholder ANTHROPIC_BASE_URL — Risk 4
+	// in the plan: install writes the placeholder and session-start
+	// overwrites it at runtime. Assert the placeholder, not the gateway URL.
+	doc, err := readSettingsJSON(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	env := envBlock(doc)
+	if got, _ := env["ANTHROPIC_BASE_URL"].(string); got != "http://127.0.0.1:49153" {
+		t.Errorf("ANTHROPIC_BASE_URL after install: got %q, want placeholder %q", got, "http://127.0.0.1:49153")
+	}
+	// Hook entries must be present + carry the new command names.
+	hooks, _ := doc["hooks"].(map[string]interface{})
+	if hooks == nil {
+		t.Fatal("hooks block missing after install")
+	}
+	if cmd := nestedHookCommand(t, hooks, "SessionStart"); cmd != "databricks-claude hooks session-start" {
+		t.Errorf("SessionStart command = %q, want %q", cmd, "databricks-claude hooks session-start")
+	}
+	if cmd := nestedHookCommand(t, hooks, "SessionEnd"); cmd != "databricks-claude hooks session-end" {
+		t.Errorf("SessionEnd command = %q, want %q", cmd, "databricks-claude hooks session-end")
+	}
+
+	// --- 2. Stub proxy (so headlessEnsure sees "healthy" and just
+	//        acquires the refcount instead of spawning a real proxy) ---
+	shutdownCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"daemon":false}`)
+		case "/shutdown":
+			if r.Method == http.MethodPost {
+				shutdownCalled = true
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+
+	rcPath := refcount.PathForPort(".databricks-claude-sessions", port)
+	os.Remove(rcPath)
+	t.Cleanup(func() { os.Remove(rcPath) })
+
+	// --- 3. Simulate SessionStart hook firing (runHooksSessionStart body) ---
+	headlessEnsure(port)
+
+	// Refcount file must exist with count == 1.
+	data, err := os.ReadFile(rcPath)
+	if err != nil {
+		t.Fatalf("refcount file not found after session-start: %v", err)
+	}
+	var rc struct {
+		Count int `json:"count"`
+	}
+	if err := json.Unmarshal(data, &rc); err != nil {
+		t.Fatalf("unmarshal refcount file: %v", err)
+	}
+	if rc.Count != 1 {
+		t.Errorf("refcount after session-start = %d, want 1", rc.Count)
+	}
+
+	// --- 4. Simulate SessionEnd hook firing (runHooksSessionEnd body) ---
+	headlessRelease(port)
+
+	if !shutdownCalled {
+		t.Error("/shutdown was not POSTed by headlessRelease — session-end teardown path broken")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -40,25 +40,25 @@ var Version = "dev"
 // OTELMetricsTable*, OTELLogsTable*, OTELTraces, OTELTracesTable*, NoOTEL*,
 // WriteClaudeConfig, WithWebSearch*, WebSearchBackend*, WebSearchFetchBudget*).
 // Their mutation paths now live under the `config` subcommand tree.
+//
+// #173 removed the 4 hooks-lifecycle fields (InstallHooks, UninstallHooks,
+// HeadlessEnsure, HeadlessRelease). Their entrypoints now live under the
+// `hooks` subcommand tree (install / uninstall / session-start / session-end).
 type Args struct {
-	Profile         string
-	Verbose         bool
-	Version         bool
-	ShowHelp        bool
-	Upstream        string
-	LogFile         string
-	ProxyAPIKey     string
-	TLSCert         string
-	TLSKey          string
-	Port            int
-	Headless        bool
-	IdleTimeout     time.Duration
-	InstallHooks    bool
-	UninstallHooks  bool
-	HeadlessEnsure  bool
-	HeadlessRelease bool
-	NoUpdateCheck   bool
-	ClaudeArgs      []string
+	Profile       string
+	Verbose       bool
+	Version       bool
+	ShowHelp      bool
+	Upstream      string
+	LogFile       string
+	ProxyAPIKey   string
+	TLSCert       string
+	TLSKey        string
+	Port          int
+	Headless      bool
+	IdleTimeout   time.Duration
+	NoUpdateCheck bool
+	ClaudeArgs    []string
 }
 
 func main() {
@@ -149,6 +149,16 @@ func main() {
 		return
 	}
 
+	// `hooks` subcommand — session-hook deployment mode. install/uninstall
+	// manage the SessionStart/SessionEnd entries in ~/.claude/settings.json;
+	// session-start/session-end are the hook-invoked refcount-managed proxy
+	// lifecycle internals (formerly --headless-ensure / --headless-release
+	// before #173 consolidated them off the root flag namespace).
+	if len(os.Args) >= 2 && os.Args[1] == "hooks" {
+		runHooksCommand(os.Args[2:])
+		return
+	}
+
 	// Parse databricks-claude flags, passing everything else through to claude.
 	// Usage: databricks-claude [databricks-claude-flags] [--] [claude-args...]
 	// Unknown flags are forwarded to claude automatically.
@@ -168,53 +178,6 @@ func main() {
 
 	if a.Version {
 		fmt.Printf("databricks-claude %s\n", Version)
-		os.Exit(0)
-	}
-
-	// --- Hook lifecycle commands (handled before auth/config setup) ---
-	if a.InstallHooks || a.UninstallHooks {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			log.Fatalf("databricks-claude: cannot determine home dir: %v", err)
-		}
-		sp := filepath.Join(homeDir, ".claude", "settings.json")
-		if a.InstallHooks {
-			// First-run env setup: persist profile/port and write
-			// ANTHROPIC_BASE_URL placeholder so users no longer need to run
-			// `databricks-claude` once before installing hooks. The placeholder
-			// URL is overwritten by --headless-ensure at session start with
-			// the discovered gateway URL.
-			resolvedProfile := a.Profile
-			if resolvedProfile == "" {
-				resolvedProfile = "DEFAULT"
-			}
-			port := resolvePort(a.Port, loadState())
-			placeholder := fmt.Sprintf("http://127.0.0.1:%d", port)
-			if err := bootstrapSettings(a.Port, resolvedProfile, placeholder, nil); err != nil {
-				log.Fatalf("databricks-claude: --install-hooks bootstrap: %v", err)
-			}
-			if err := installHooks(sp); err != nil {
-				log.Fatalf("databricks-claude: --install-hooks: %v", err)
-			}
-			fmt.Fprintln(os.Stderr, "databricks-claude: hooks installed — SessionStart and SessionEnd hooks added to ~/.claude/settings.json")
-		} else {
-			if err := uninstallHooks(sp); err != nil {
-				log.Fatalf("databricks-claude: --uninstall-hooks: %v", err)
-			}
-			fmt.Fprintln(os.Stderr, "databricks-claude: hooks removed from ~/.claude/settings.json")
-		}
-		os.Exit(0)
-	}
-
-	// --- Headless hook commands (called by installed hooks, not by end users) ---
-	if a.HeadlessEnsure || a.HeadlessRelease {
-		state := loadState()
-		port := resolvePort(a.Port, state)
-		if a.HeadlessEnsure {
-			headlessEnsure(port)
-		} else {
-			headlessRelease(port)
-		}
 		os.Exit(0)
 	}
 
@@ -683,8 +646,7 @@ func envBlock(doc map[string]interface{}) map[string]interface{} {
 // parseArgs separates databricks-claude flags from claude flags.
 // databricks-claude owns: --profile, --port, --verbose/-v, --version, --help,
 // --upstream, --log-file, --proxy-api-key, --tls-cert, --tls-key, --headless,
-// --idle-timeout, --install-hooks, --uninstall-hooks, --headless-ensure,
-// --headless-release, --no-update-check.
+// --idle-timeout, --no-update-check.
 // Everything else (including unknown flags like --debug) passes through to claude.
 // An explicit "--" separator is supported but not required.
 //
@@ -693,6 +655,11 @@ func envBlock(doc map[string]interface{}) map[string]interface{} {
 // websearch enable|disable, config write, config show). Old flags are
 // removed, NOT aliased: `databricks-claude --otel` now passes `--otel`
 // through to claude as an unknown flag.
+//
+// #173 removed the 4 hooks-lifecycle flags (--install-hooks,
+// --uninstall-hooks, --headless-ensure, --headless-release) — they live
+// behind the `hooks` subcommand tree now (hooks install / uninstall /
+// session-start / session-end). Same "removed, not aliased" semantics.
 func parseArgs(args []string) (*Args, error) {
 	a := &Args{
 		IdleTimeout: 30 * time.Minute, // default
@@ -792,14 +759,6 @@ func parseArgs(args []string) (*Args, error) {
 					}
 				case "--headless":
 					a.Headless = true
-				case "--install-hooks":
-					a.InstallHooks = true
-				case "--uninstall-hooks":
-					a.UninstallHooks = true
-				case "--headless-ensure":
-					a.HeadlessEnsure = true
-				case "--headless-release":
-					a.HeadlessRelease = true
 				case "--no-update-check":
 					a.NoUpdateCheck = true
 				case "--idle-timeout":


### PR DESCRIPTION
## What

Consolidates the 4 hooks-lifecycle root flags into a `hooks` subcommand tree. Implements #173 (part of #169's CLI command-tree restructure). Targets the `feat/cli-command-tree` integration branch.

**Breaking change** — old flags are **removed, not aliased** (they now pass through to `claude` as unknowns). Acceptable per #169 — no user base yet.

### New surface

```
hooks install      [--profile P] [--port N]   # was --install-hooks
hooks uninstall                               # was --uninstall-hooks
hooks session-start                           # was --headless-ensure  (hook-invoked internal)
hooks session-end                             # was --headless-release (hook-invoked internal)
```

### Flag mapping

| Removed root flag | Replacement |
|---|---|
| `--install-hooks` | `hooks install` |
| `--uninstall-hooks` | `hooks uninstall` |
| `--headless-ensure` | `hooks session-start` (hook-invoked internal) |
| `--headless-release` | `hooks session-end` (hook-invoked internal) |

`--headless` and `--idle-timeout` stay on the root command — they are #174's scope, untouched here.

## Behaviour — unchanged

Pure surface reshape. The hook-install logic (`installHooks`/`uninstallHooks`), the first-run env bootstrap (`bootstrapSettings`), and the refcount-managed proxy lifecycle (`headlessEnsure`/`headlessRelease`) are behaviorally identical — they move behind tree commands in a new `hooks_cmd.go` runner. The hooks deployment mode itself is unchanged: the proxy still spins up on SessionStart and tears down on SessionEnd.

## The load-bearing change

`installHooks` now writes hook JSON invoking `databricks-claude hooks session-start` / `hooks session-end`, and the `isDBXHookEntry` detector prefix swaps from `"databricks-claude --headless"` to `"databricks-claude hooks "` **in the same commit**. These two must move together — if they drift, `hooks uninstall` silently orphans entries and `hooks install` duplicates them. `TestInstallUninstallHooks_RoundTrip` is the bidirectional guard: install writes the new names → uninstall's detector must find and remove them → settings.json comes back empty.

## Tests

- `hooks_cmd_test.go` (new, 13 tests): per-leaf parity, nested-completion exposure, the JSON round-trip guard, and **`TestHooksLifecycleEndToEnd`** — the AC's load-bearing e2e test. It walks install → session-start → session-end through the same code paths the runner functions call, using the proven stub-health-server + refcount-file technique from the existing `hooks_test.go` (no real detached proxy spawn — that's `pkg/headless`' concern, out of scope). Asserts: placeholder `ANTHROPIC_BASE_URL` after install, new command names in the JSON, refcount==1 after session-start, `/shutdown` POSTed on session-end.
- Parity tests (`TestRootTreeFlagsAreParseRecognised` / `TestParseArgsCasesAreDeclaredInRootTree`) enforce the 4 flags were removed from **both** `commands.go` and the `parseArgs` switch.
- Full suite green; `go build ./... && go vet ./... && go test ./...` all pass.

## Verification

- `databricks-claude --help` — 0 occurrences of the 4 removed flags; `--headless` still present (>=1, #174's scope)
- `hooks --help` / `hooks install --help` render from the tree
- `hooks install` writes JSON containing both `databricks-claude hooks session-start` and `databricks-claude hooks session-end`
- Nested bash completion offers `hooks` with `install` / `uninstall` / `session-start` / `session-end` children

## NIT

Hook entries written by a **pre-#173 binary** (`databricks-claude --headless-ensure` etc.) won't be matched by the new `isDBXHookEntry` prefix — so `hooks uninstall` won't remove them and `hooks install` won't dedupe them. This is explicitly sanctioned by the issue ("No back-compat for already-installed hooks is required — nobody has deployed them"). A clean prefix swap is the correct call; documented in plan #173 Risk 1.

Part of #169. Closes #173.
