### PR TITLE
fix(completion): escape apostrophes in zsh flag/subcommand descriptions

### DIFF
--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -262,7 +262,7 @@ func emitZshSubcommandDispatch(rootFlags []FlagDef, subcommands []SubcommandDef)
 	var b strings.Builder
 	b.WriteString("    local -a _subcmds\n")
 	for _, s := range subcommands {
-		desc := strings.ReplaceAll(s.Description, "'", "\\'")
+		desc := zshEscape(s.Description)
 		b.WriteString("    _subcmds+=(" + fmt.Sprintf("'%s:%s'", s.Name, desc) + ")\n")
 	}
 	b.WriteString("\n")
@@ -282,7 +282,7 @@ func emitZshSubcommandDispatch(rootFlags []FlagDef, subcommands []SubcommandDef)
 		if len(sub.Subcommands) > 0 {
 			b.WriteString("            local -a _subcmds2\n")
 			for _, sub2 := range sub.Subcommands {
-				desc := strings.ReplaceAll(sub2.Description, "'", "\\'")
+				desc := zshEscape(sub2.Description)
 				b.WriteString("            _subcmds2+=(" + fmt.Sprintf("'%s:%s'", sub2.Name, desc) + ")\n")
 			}
 			b.WriteString("            case \"$sub2\" in\n")
@@ -564,9 +564,17 @@ end`
 	}
 }
 
+// zshEscape escapes a string for safe interpolation inside a zsh
+// single-quoted string. zsh does NOT honor backslash escapes inside '...';
+// the canonical way to embed a literal ' is to close the quote, emit a
+// backslash-escaped quote, and reopen: ' becomes '\''.
+func zshEscape(s string) string {
+	return strings.ReplaceAll(s, "'", "'\\''")
+}
+
 // zshFlagSpec returns the _arguments spec string for one flag.
 func zshFlagSpec(f FlagDef) string {
-	desc := f.Description
+	desc := zshEscape(f.Description)
 
 	if f.Short != "" {
 		// Pair short and long together.

--- a/pkg/completion/completion_test.go
+++ b/pkg/completion/completion_test.go
@@ -58,6 +58,40 @@ func TestGenerateZsh_ContainsFlags(t *testing.T) {
 	}
 }
 
+// TestGenerateZsh_EscapesApostrophesInDescriptions is a regression test for
+// the bug where a flag or subcommand description containing a single quote
+// (e.g. "emit artifacts pointing at a local 'databricks-claude serve' daemon")
+// would collapse the surrounding zsh single-quoted _arguments spec, producing
+// "_arguments:comparguments:NNN: invalid option definition" at completion time.
+// zsh does NOT honor backslash escapes inside single-quoted strings — the
+// canonical escape for a literal ' is '\''.
+func TestGenerateZsh_EscapesApostrophesInDescriptions(t *testing.T) {
+	flags := []FlagDef{
+		{Name: "daemon", Description: "emit artifacts pointing at a local 'databricks-claude serve' daemon"},
+		{Name: "host", Description: "Workspace URL forwarded to 'databricks auth login --host'", TakesArg: true},
+	}
+	subs := []SubcommandDef{
+		{Name: "desktop", Description: "Generate config for Claude's desktop app", Flags: flags},
+	}
+	out := GenerateZshFull("databricks-claude", nil, subs)
+
+	// The literal apostrophe must be escaped via '\'' (close, escaped ', reopen).
+	// The naïve backslash-escape "\\'" is INVALID inside zsh '...' strings.
+	if strings.Contains(out, `local \'databricks-claude serve\' daemon`) {
+		t.Error("zsh output contains backslash-escaped apostrophes — these don't work inside zsh single-quoted strings; use '\\''")
+	}
+	if !strings.Contains(out, `local '\''databricks-claude serve'\'' daemon`) {
+		t.Error("zsh output missing canonical '\\'' escape for apostrophe in flag description")
+	}
+	if !strings.Contains(out, `forwarded to '\''databricks auth login --host'\''`) {
+		t.Error("zsh output missing canonical '\\'' escape for apostrophe in --host description")
+	}
+	// Subcommand description with an apostrophe must also be escaped.
+	if !strings.Contains(out, `Claude'\''s desktop app`) {
+		t.Error("zsh output missing canonical '\\'' escape for apostrophe in subcommand description")
+	}
+}
+
 func TestGenerateZsh_ShortFlags(t *testing.T) {
 	out := GenerateZsh("databricks-claude", testFlags)
 	// verbose has short -v so should appear as paired spec


### PR DESCRIPTION
## Bug

zsh tab completions break for any subcommand whose flag or subcommand descriptions contain an apostrophe. Reproducer:

```
$ databricks-claude desktop gen<TAB>
_arguments:comparguments:327: invalid option definition: --daemon[generate-config: emit daemon-mode artifacts pointing at a local databricks-claude_
```

## Root cause

`pkg/completion/completion.go` emits zsh `_arguments` specs and `_describe` entries as single-quoted strings (`'--daemon[desc]'`, `'name:desc'`) but never escapes `'` inside `f.Description` / `s.Description`. zsh `'...'` strings cannot contain `'`, and **do not honor backslash escapes** — the canonical workaround is `'\''` (close, escaped `'`, reopen).

Two code sites were affected:

1. `zshFlagSpec` used `f.Description` raw → broken spec at the first `'` in the description.
2. `emitZshSubcommandDispatch` used `strings.ReplaceAll(desc, "'", "\\'")` — backslash-escape inside zsh `'...'` is a no-op, so subcommand descriptions with apostrophes also collapsed.

Five descriptions currently carry apostrophes (`commands.go`): `--daemon`, `--databricks-cli-path`, `--host`, `--force`, plus any subcommand description that ever grows one. So tab completion was broken inside both `desktop` and `setup`.

Bash output is unaffected — descriptions are not embedded in shell-string context. Fish is left alone — fish *does* honor `\'` inside `'...'`, so its existing escape continues to work.

## Fix

- Add `zshEscape(s) = strings.ReplaceAll(s, "'", "'\\''")` helper.
- Use it in `zshFlagSpec`, the `_subcmds` builder, and the `_subcmds2` builder.
- Add `TestGenerateZsh_EscapesApostrophesInDescriptions` regression test covering flag descriptions, takes-arg flag descriptions, and subcommand descriptions. Bidirectionally verified: the new test fails when the helper is removed and passes when restored.

## Verification

```
$ go test ./pkg/completion/...
ok  	github.com/IceRhymers/databricks-claude/pkg/completion	0.002s
$ go test ./...
ok  ... (all packages green)
$ /tmp/dbc-test completion zsh | grep daemon | head -1
  '--daemon[generate-config: emit daemon-mode artifacts pointing at a local '\''databricks-claude serve'\'' daemon]' \
```

No more `arguments:327: invalid option definition` error in a real zsh session.
