### PR TITLE
fix(completion): declare desktop action keywords as subcommands

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -143,6 +143,17 @@ var desktopCommand = cmd.Command{
 		{Name: "otel", Description: "generate-config --daemon: also emit otlpEndpoint pointing at the daemon (Cowork OTEL routing)"},
 		{Name: "help", Short: "h", Description: "Show help message"},
 	},
+	// Action keywords parsed positionally by runDesktopCommand. They have no
+	// per-action Flags here because runDesktopCommand passes args[1:] (every
+	// arg after the action) into a UNION flag scanner — splitting flags per
+	// action would change which flags trip "unknown" detection (see comment
+	// above). Declaring the names lets shell completion offer them at
+	// `databricks-claude desktop <TAB>`.
+	Subcommands: []cmd.Command{
+		{Name: "generate-config", Short: "Generate Claude Desktop config (.mobileconfig/.reg/.json) with embedded credential-helper"},
+		{Name: "credential-helper", Short: "Internal: emit a Databricks token on stdout (invoked by Claude Desktop, not by users)"},
+		{Name: "generate-trust-profile", Short: "Generate MDM trust profile (.mobileconfig) embedding a PEM cert"},
+	},
 }
 
 // setupCommand declares the `setup` subcommand's flags + help body.


### PR DESCRIPTION
## Bug

After installing v1.0.1, `databricks-claude desktop <TAB>` offers no completions, and `desktop ge<TAB>` does not complete to `generate-config`.

## Root cause

`desktop` parses three action keywords positionally inside `runDesktopCommand`:

```go
switch r.Positional[0] {
case "generate-config":      ...
case "credential-helper":    ...
case "generate-trust-profile": ...
}
```

But those keywords were never declared as `Subcommands` of `desktopCommand` in `commands.go`. The shell-completion script (`pkg/completion`) walks the command tree to discover offerable names — if a name isn't in the tree, it isn't offered. `config` and `hooks` already declare their action subcommands; `desktop` was missed during the #169 milestone.

## Fix

Add the three actions as bare `Subcommands` entries with descriptions. No per-action `Flags` are declared because `runDesktopCommand` uses a *union* flag scanner across all actions (see existing explanatory comment on `desktopCommand`) — splitting flags per action would change which flags trip "unknown" detection. Just declaring the names is enough for completion.

## Verification

```
$ /tmp/dbc-test completion zsh | grep _subcmds2.*generate
_subcmds2+=('generate-config:Generate Claude Desktop config (.mobileconfig/.reg/.json) with embedded credential-helper')
_subcmds2+=('credential-helper:Internal: emit a Databricks token on stdout (invoked by Claude Desktop, not by users)')
_subcmds2+=('generate-trust-profile:Generate MDM trust profile (.mobileconfig) embedding a PEM cert')
```

`go test ./...` green.
