### PR TITLE
feat(proxy): add path-prefix multi-upstream routing to pkg/proxy

### DIFF
--- a/pkg/proxy/AGENTS.md
+++ b/pkg/proxy/AGENTS.md
@@ -4,7 +4,7 @@
 # proxy
 
 ## Purpose
-HTTP/WebSocket reverse proxy with two routes: inference (`/`) and OTEL (`/otel/`). Injects fresh Databricks OAuth tokens per-request, supports optional API key authentication, TLS listeners, WebSocket upgrades (for databricks-codex), and includes security checks and log sanitization.
+HTTP/WebSocket reverse proxy with two built-in routes — inference (`/`) and OTEL (`/otel/`) — plus optional `Config.Routes` for path-prefix dispatch to additional AI Gateway upstreams (e.g. Anthropic + Gemini Native on the same port). Injects fresh Databricks OAuth tokens per-request, supports optional API key authentication, TLS listeners, WebSocket upgrades (for databricks-codex), and includes security checks and log sanitization.
 
 ## Key Files
 
@@ -21,7 +21,8 @@ HTTP/WebSocket reverse proxy with two routes: inference (`/`) and OTEL (`/otel/`
 
 ### Working In This Directory
 - The `TokenSource` interface has a single method: `Token(ctx) (string, error)`. The root package's `TokenProvider` satisfies it.
-- **Two proxy routes**: `/` for inference (AI Gateway), `/otel/` for telemetry. Path algebra prepends the upstream's base path.
+- **Built-in routes**: `/` for inference (AI Gateway), `/otel/` for telemetry. Path algebra prepends the upstream's base path.
+- **Optional `Config.Routes`** (`UpstreamRoute` slice): registers additional path-prefix routes via `mux.Handle(PathPrefix+"/", ...)`. Each route shares the same `inferenceHandler` factory (token injection + WS detect + path-prepend) — only the upstream URL differs and a `StripPrefix` (defaults to `PathPrefix`) is removed from the incoming path before the existing prepend logic runs. `Routes: nil` is byte-identical to behavior before this field existed (sibling consumers `databricks-codex`, `databricks-cursor`, `databricks-opencode` rely on this).
 - **WebSocket support** exists for databricks-codex (Codex CLI), not for Claude Code (which uses HTTP+SSE). The `isWebSocketUpgrade` check is passive -- zero overhead for non-upgrade requests.
 - `FlushInterval: -1` on both reverse proxies enables streaming (SSE).
 - All routes are wrapped in `RecoveryHandler` for panic safety (returns HTTP 502).

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -23,6 +23,30 @@ type TokenSource interface {
 	Token(ctx context.Context) (string, error)
 }
 
+// UpstreamRoute is an additive, optional path-prefix route to an upstream
+// other than InferenceUpstream. When an incoming request path starts with
+// PathPrefix, the proxy strips StripPrefix (defaults to PathPrefix when
+// empty) from the path and forwards to Upstream — reusing the same
+// token-injection / WebSocket-detect / upstream-base-path-prepend logic
+// the default inference handler uses.
+//
+// Used to wire one local proxy port to multiple Databricks AI Gateway
+// upstreams (e.g. Anthropic on / and Gemini Native on /v1beta).
+type UpstreamRoute struct {
+	// PathPrefix is matched against the incoming request path. The proxy
+	// registers this route at PathPrefix+"/" on the mux, so http.ServeMux
+	// longest-prefix-match handles dispatch ordering.
+	PathPrefix string
+	// Upstream is the full upstream URL including any base path (e.g.
+	// "https://workspace.cloud.databricks.com/ai-gateway/gemini/v1beta").
+	// The base path is prepended to the (post-strip) request path.
+	Upstream string
+	// StripPrefix is removed from the front of the incoming request path
+	// before the upstream base path is prepended. Defaults to PathPrefix
+	// when empty.
+	StripPrefix string
+}
+
 // Config holds the configuration for the proxy server.
 //
 // WebSocket note: databricks-claude (Claude Code) uses HTTP with SSE for
@@ -34,6 +58,11 @@ type TokenSource interface {
 type Config struct {
 	InferenceUpstream string
 	OTELUpstream      string
+	// Routes are optional path-prefix overrides. When a request matches a
+	// route's PathPrefix it is forwarded to that route's Upstream rather
+	// than InferenceUpstream. Leave nil/empty for byte-identical behavior
+	// to before this field existed (sibling consumers depend on this).
+	Routes []UpstreamRoute
 	// UCMetricsTable is the Unity Catalog table for OTEL metrics.
 	// Leave empty if the caller does not emit metrics (e.g. databricks-codex,
 	// which has no native metrics support). When empty the
@@ -410,6 +439,19 @@ func NewServer(config *Config) (http.Handler, error) {
 		})
 	})
 
+	// Optional path-prefix routes — registered before the catch-all so the
+	// mux's longest-prefix-match dispatches correctly. Routes share the same
+	// inferenceHandler factory (token injection + WebSocket detect + path
+	// prepend) and only differ in the upstream URL and the per-route prefix
+	// stripped from the incoming path before the prepend step.
+	for i, route := range config.Routes {
+		routeUpstream, err := url.Parse(route.Upstream)
+		if err != nil {
+			return nil, fmt.Errorf("databricks-claude: invalid Routes[%d].Upstream %q: %v", i, route.Upstream, err)
+		}
+		mux.Handle(route.PathPrefix+"/", RecoveryHandler(newRouteHandler(route, routeUpstream, config)))
+	}
+
 	mux.Handle("/otel/", RecoveryHandler(otelProxy))
 
 	// Daemon mode: explicitly reject /shutdown with 404 so it does not fall
@@ -426,6 +468,29 @@ func NewServer(config *Config) (http.Handler, error) {
 
 	// APIKey check applies to all connections including WebSocket upgrades (used by databricks-codex)
 	return requireAPIKey(mux, config.APIKey), nil
+}
+
+// newRouteHandler returns an http.Handler for a single UpstreamRoute. It is
+// a thin shim over inferenceHandler: strip the local PathPrefix from the
+// incoming request path, then delegate to the same handler the default
+// inference route uses. WebSocket detection, token injection, and the
+// upstream-base-path prepend all come along for free — no logic duplicated.
+func newRouteHandler(route UpstreamRoute, upstream *url.URL, config *Config) http.Handler {
+	inner := inferenceHandler(upstream, config, config.WebSearch)
+	stripPrefix := route.StripPrefix
+	if stripPrefix == "" {
+		stripPrefix = route.PathPrefix
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if stripPrefix != "" {
+			r.URL.Path = strings.TrimPrefix(r.URL.Path, stripPrefix)
+			if r.URL.Path == "" {
+				r.URL.Path = "/"
+			}
+			r.URL.RawPath = ""
+		}
+		inner.ServeHTTP(w, r)
+	})
 }
 
 // ValidateTLSConfig returns an error if the TLS configuration is incomplete

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -1018,6 +1018,263 @@ func TestProxy_Daemon_EmptyOTELTables(t *testing.T) {
 	}
 }
 
+// --- Config.Routes (path-prefix multi-upstream) tests ---
+//
+// These cover #188: a single proxy port dispatching to multiple AI Gateway
+// upstreams via path-prefix routes (e.g. Anthropic on / + Gemini Native on
+// /v1beta). The route handler is a thin shim over inferenceHandler — strip
+// the local prefix, then let the existing prepend logic add the upstream
+// base path.
+
+// TestProxy_Routes_PathPrefixDispatch verifies that requests matching a
+// route's PathPrefix are forwarded to that route's upstream, and other
+// requests fall through to InferenceUpstream.
+func TestProxy_Routes_PathPrefixDispatch(t *testing.T) {
+	var routeHits, defaultHits int
+	routeUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		routeHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer routeUpstream.Close()
+
+	defaultUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defaultHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer defaultUpstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: defaultUpstream.URL,
+		OTELUpstream:      defaultUpstream.URL,
+		TokenSource:       warmToken("tok"),
+		Routes: []UpstreamRoute{
+			{PathPrefix: "/v1beta", Upstream: routeUpstream.URL + "/ai-gateway/gemini/v1beta"},
+		},
+	}
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	// Request matching route prefix → routed upstream.
+	req1 := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-pro:generateContent", nil)
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+	if routeHits != 1 || defaultHits != 0 {
+		t.Errorf("after /v1beta request: routeHits=%d defaultHits=%d, want 1/0", routeHits, defaultHits)
+	}
+
+	// Request not matching route prefix → default upstream.
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+	if routeHits != 1 || defaultHits != 1 {
+		t.Errorf("after /v1/messages request: routeHits=%d defaultHits=%d, want 1/1", routeHits, defaultHits)
+	}
+}
+
+// TestProxy_Routes_TokenInjectionOnBothPaths verifies that the Bearer token
+// is injected on both the routed upstream and the default upstream — the
+// route handler shares inferenceHandler's token-injection codepath.
+func TestProxy_Routes_TokenInjectionOnBothPaths(t *testing.T) {
+	var routeAuth, defaultAuth string
+	routeUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		routeAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer routeUpstream.Close()
+
+	defaultUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defaultAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer defaultUpstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: defaultUpstream.URL,
+		OTELUpstream:      defaultUpstream.URL,
+		TokenSource:       warmToken("shared-token"),
+		Routes: []UpstreamRoute{
+			{PathPrefix: "/v1beta", Upstream: routeUpstream.URL},
+		},
+	}
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, httptest.NewRequest(http.MethodPost, "/v1beta/models/x", nil))
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, httptest.NewRequest(http.MethodPost, "/v1/messages", nil))
+
+	want := "Bearer shared-token"
+	if routeAuth != want {
+		t.Errorf("routed upstream Authorization = %q, want %q", routeAuth, want)
+	}
+	if defaultAuth != want {
+		t.Errorf("default upstream Authorization = %q, want %q", defaultAuth, want)
+	}
+}
+
+// TestProxy_Routes_StripsLocalPrefix is the prefix-collision regression pin.
+// It verifies the upstream sees the EXACT expected path string after
+// strip-then-prepend — not /v1beta/v1beta/... (double-prefix) and not just
+// /models/x (over-strip). The plan calls this out as the most likely place
+// to land a bug.
+func TestProxy_Routes_StripsLocalPrefix(t *testing.T) {
+	var gotPath string
+	routeUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer routeUpstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: routeUpstream.URL,
+		OTELUpstream:      routeUpstream.URL,
+		TokenSource:       warmToken("tok"),
+		Routes: []UpstreamRoute{
+			{
+				PathPrefix: "/v1beta",
+				Upstream:   routeUpstream.URL + "/ai-gateway/gemini/v1beta",
+			},
+		},
+	}
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.0-flash:generateContent", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// Exact match — not strings.Contains, not HasPrefix. The whole point of
+	// this test is to pin the path algebra: incoming /v1beta/models/x with
+	// upstream /ai-gateway/gemini/v1beta and StripPrefix defaulted to
+	// PathPrefix should produce exactly this on the wire. A failure here
+	// likely means double-prefix (/ai-gateway/gemini/v1beta/v1beta/...) or
+	// over-strip (/ai-gateway/gemini/models/...).
+	want := "/ai-gateway/gemini/v1beta/models/gemini-2.0-flash:generateContent"
+	if gotPath != want {
+		t.Errorf("upstream saw path %q, want exactly %q", gotPath, want)
+	}
+}
+
+// TestProxy_Routes_EmptyRoutesIsBackwardCompatible regression-pins the
+// sibling-consumer guarantee: with Routes nil, NewServer's behavior is
+// byte-identical to its behavior before this field existed. databricks-codex
+// / databricks-cursor / databricks-opencode all leave Routes unset.
+func TestProxy_Routes_EmptyRoutesIsBackwardCompatible(t *testing.T) {
+	var gotPath, gotAuth, gotCodingHeader string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotCodingHeader = r.Header.Get("x-databricks-use-coding-agent-mode")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL + "/anthropic",
+		OTELUpstream:      upstream.URL,
+		UCMetricsTable:    "main.t.m",
+		UCLogsTable:       "main.t.l",
+		TokenSource:       warmToken("tok"),
+		// Routes intentionally unset (nil) — backward-compat path.
+	}
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// These three assertions mirror the load-bearing observable behavior
+	// of the existing TestProxy_PathAlgebra_Inference + TestProxy_InjectsAuthHeader
+	// + TestProxy_InjectsCustomHeaders tests. If any of them changes when
+	// Routes is nil, sibling consumers break.
+	if gotPath != "/anthropic/v1/messages" {
+		t.Errorf("path: got %q, want %q", gotPath, "/anthropic/v1/messages")
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("auth: got %q, want %q", gotAuth, "Bearer tok")
+	}
+	if gotCodingHeader != "true" {
+		t.Errorf("x-databricks-use-coding-agent-mode: got %q, want %q", gotCodingHeader, "true")
+	}
+}
+
+// TestProxy_Routes_OrderIndependent verifies that registering two routes in
+// either order produces the same dispatch — http.ServeMux matches the
+// longest-prefix regardless of registration order. The plan calls this out
+// as a guard against any future implementation that smuggles in registration
+// order as an implicit precedence signal (e.g. switching to a slice scan).
+func TestProxy_Routes_OrderIndependent(t *testing.T) {
+	for _, order := range []struct {
+		name   string
+		routes []string // PathPrefixes in registration order
+	}{
+		{"a-then-b", []string{"/alpha", "/beta"}},
+		{"b-then-a", []string{"/beta", "/alpha"}},
+	} {
+		t.Run(order.name, func(t *testing.T) {
+			var alphaHits, betaHits, defaultHits int
+			alphaUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				alphaHits++
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer alphaUpstream.Close()
+			betaUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				betaHits++
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer betaUpstream.Close()
+			defaultUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defaultHits++
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer defaultUpstream.Close()
+
+			urlByPrefix := map[string]string{
+				"/alpha": alphaUpstream.URL,
+				"/beta":  betaUpstream.URL,
+			}
+			var routes []UpstreamRoute
+			for _, p := range order.routes {
+				routes = append(routes, UpstreamRoute{PathPrefix: p, Upstream: urlByPrefix[p]})
+			}
+
+			cfg := &Config{
+				InferenceUpstream: defaultUpstream.URL,
+				OTELUpstream:      defaultUpstream.URL,
+				TokenSource:       warmToken("tok"),
+				Routes:            routes,
+			}
+			handler, err := NewServer(cfg)
+			if err != nil {
+				t.Fatalf("NewServer: %v", err)
+			}
+
+			// Three requests: one for each route + one default.
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/alpha/x", nil))
+			rec = httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/beta/y", nil))
+			rec = httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/default/z", nil))
+
+			if alphaHits != 1 || betaHits != 1 || defaultHits != 1 {
+				t.Errorf("registration order %v: alpha=%d beta=%d default=%d, want 1/1/1",
+					order.routes, alphaHits, betaHits, defaultHits)
+			}
+		})
+	}
+}
+
 // expiringTokenSource implements TokenSource and tokenExpirer for testing
 // the token_valid_until field in /health.
 type expiringTokenSource struct {


### PR DESCRIPTION
## Summary

Adds path-prefix multi-upstream routing to `pkg/proxy`. A single proxy instance can now dispatch requests to different Databricks AI Gateway upstreams based on path prefix — e.g. `/v1beta` → Gemini Native, default `/` → Anthropic — through one local port.

Closes #188. Unblocks IceRhymers/databricks-opencode#92 (wiring `databricks-opencode` up to Databricks Gemini Native alongside the existing Anthropic upstream).

## API

```go
type UpstreamRoute struct {
    PathPrefix  string // e.g. "/v1beta"
    Upstream    string // e.g. "https://workspace/ai-gateway/gemini"
    StripPrefix string // defaults to PathPrefix
}

type Config struct {
    InferenceUpstream string
    Routes            []UpstreamRoute // optional, additive
    // ...existing fields unchanged...
}
```

## Routing semantics

Strip-then-prepend: incoming `/v1beta/models/x` with `PathPrefix=/v1beta`, `Upstream=…/ai-gateway/gemini/v1beta` becomes exactly `/ai-gateway/gemini/v1beta/models/x` on the wire. The route handler is a thin shim over the same `inferenceHandler` factory the default route uses, so token injection (`Authorization: Bearer` + `x-api-key`) and WebSocket detection come along for free — no logic duplicated.

`http.ServeMux` longest-prefix-match handles ordering; the default `inferenceHandler` for `InferenceUpstream` stays the catch-all.

## Backward compatibility

With `Routes` unset (nil), `NewServer` is byte-identical to its prior behavior — the route loop is zero-iteration, no mux registrations added, no mutated shared state. Sibling consumers (databricks-codex, databricks-cursor, databricks-opencode) that import this package continue to compile and behave identically without any changes.

## Tests

5 new tests in `pkg/proxy/proxy_test.go`:
- `TestProxy_Routes_PathPrefixDispatch` — `/v1beta` vs default routing
- `TestProxy_Routes_TokenInjectionOnBothPaths` — `Authorization: Bearer` on route + default
- `TestProxy_Routes_StripsLocalPrefix` — exact-string path-algebra regression pin (catches double-prefix `/v1beta/v1beta/...` and over-strip `/models/x` bugs)
- `TestProxy_Routes_EmptyRoutesIsBackwardCompatible` — nil-Routes byte-identity guard
- `TestProxy_Routes_OrderIndependent` — mux longest-prefix-match independent of registration order (subtests run both orderings)

All existing tests (especially `TestProxy_PathAlgebra_Inference`) pass unmodified.

## Pipeline

Implemented via OMC: issue plan → autopilot (27 turns, $2.63) → cross-lane review (APPROVE, 0 BLOCKER / 0 MAJOR, 1 MINOR + 3 NITs follow-ups noted) → PR.

Acceptance:
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] Single conventional commit (`feat(proxy):` → release-please minor bump)
- [x] Zero new external deps (stdlib only)
- [x] Additive only (no existing handler bodies modified)
