### PR TITLE
feat(proxy): rewrite mismatched item_ids in Responses API SSE streams

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -91,6 +91,13 @@ type Config struct {
 	// inference requests are forwarded byte-identically and this struct
 	// has no effect — see pkg/proxy/websearch_handler.go.
 	WebSearch WebSearchSettings
+	// ResponsesRewrite (--with-responses-rewrite, or enabled by sibling
+	// consumers like databricks-opencode) gates the OpenAI Responses-API SSE
+	// id-reconciliation rewriter. When Enabled is false, inference responses
+	// are forwarded byte-identically and this struct has no effect — see
+	// pkg/proxy/responses_rewriter.go. Claude Code never targets /responses,
+	// so leaving this false is byte-identical to prior behavior.
+	ResponsesRewrite ResponsesRewriteSettings
 	// Daemon, when true, indicates this proxy is running as a long-lived daemon
 	// (databricks-claude serve). The /health response includes daemon-specific
 	// fields; /shutdown is not registered (serve.go never wraps with lifecycle).

--- a/pkg/proxy/responses_rewriter.go
+++ b/pkg/proxy/responses_rewriter.go
@@ -1,0 +1,239 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// ResponsesRewriteSettings bundles the optional Responses-API SSE rewriter
+// knobs. Embedded in Config; when Enabled is false the rewriter is fully
+// bypassed and the proxy forwards bytes verbatim. OpenAI-shaped consumers
+// (databricks-opencode) set Enabled=true; Claude Code leaves it false.
+type ResponsesRewriteSettings struct {
+	Enabled bool
+}
+
+// responsesIndexCacheLimit bounds the per-stream output_index -> item.id cache.
+// Far above any real Responses-API turn (which has a handful of output items)
+// but cheap insurance against an upstream that emits many distinct indices
+// without ever sending output_item.done. On overflow new ids are not cached and
+// affected downstream events degrade to passthrough.
+const responsesIndexCacheLimit = 1024
+
+// responsesRewriteState holds per-stream mutable state for the Responses-API
+// SSE rewriter. It caches the canonical item id (from response.output_item.added)
+// keyed by output_index, so downstream events that carry a mismatched item_id
+// can be corrected.
+type responsesRewriteState struct {
+	// canonicalByIndex maps output_index -> the item.id reported in the
+	// response.output_item.added event for that index (message items only).
+	// Entries are deleted on response.output_item.done so a reused index
+	// never carries a stale id.
+	canonicalByIndex map[int]string
+	// warned tracks (output_index, originalId) pairs already logged so a
+	// long stream emits at most one warning per distinct mismatch.
+	warned map[string]struct{}
+}
+
+// responsesEnvelope is the lightweight shape we probe on every frame. Only the
+// fields needed for id reconciliation are decoded; everything else in the JSON
+// payload is preserved by re-marshalling the full object on the rare rewrite
+// path (conforming streams are emitted verbatim, byte-for-byte).
+type responsesEnvelope struct {
+	Type        string `json:"type"`
+	OutputIndex *int   `json:"output_index"`
+	ItemID      string `json:"item_id"`
+	Item        *struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	} `json:"item"`
+}
+
+// pumpResponsesSSE reads OpenAI Responses-API SSE frames from src and writes
+// them to w, rewriting a downstream event's item_id to the canonical item.id
+// announced by the matching response.output_item.added event when the two
+// disagree. This works around OpenAI-compatible proxies (notably Databricks AI
+// Gateway) that re-encode the stream and emit divergent ids, which otherwise
+// breaks @ai-sdk/openai's parser with "text part <id> not found".
+//
+// Behaviour:
+//   - Caches output_index -> item.id from output_item.added (message items only;
+//     reasoning / function_call items are intentionally ignored).
+//   - Deletes the cache entry on output_item.done so reused indices don't carry
+//     a stale id.
+//   - Rewrites item_id on downstream events only when it disagrees with the
+//     cached canonical id; logs once per (output_index, originalId) pair.
+//   - Passes through verbatim (byte-identical) for: comment/empty frames,
+//     [DONE], parse failures, unknown event types, reordered events
+//     (delta before added -> cache miss), and any event that already agrees.
+//
+// Returns nil on clean EOF, otherwise the underlying scanner error. Caller owns
+// src.Close.
+func pumpResponsesSSE(ctx context.Context, w http.ResponseWriter, src io.Reader, verbose bool) error {
+	flusher, _ := w.(http.Flusher)
+	state := &responsesRewriteState{
+		canonicalByIndex: map[int]string{},
+		warned:           map[string]struct{}{},
+	}
+
+	scanner := bufio.NewScanner(src)
+	// SSE frames are delimited by "\n\n". Allow up to 1 MiB per frame.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	scanner.Split(splitSSEFrames)
+
+	emit := func(b []byte) error {
+		if _, err := w.Write(b); err != nil {
+			return err
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return nil
+	}
+
+	for scanner.Scan() {
+		// Honour context cancellation between frames.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		raw := scanner.Bytes()
+		// Copy — bufio.Scanner reuses its buffer on the next Scan.
+		frame := append([]byte(nil), raw...)
+
+		ev := parseSSEFrame(frame)
+		if len(ev.Data) == 0 {
+			// Comment-only or data-less frame; pass through verbatim.
+			if err := emit(frame); err != nil {
+				return err
+			}
+			continue
+		}
+
+		out := maybeRewriteResponsesFrame(frame, ev, state, verbose)
+		if err := emit(out); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		if verbose {
+			log.Printf("databricks-claude: responses: SSE scanner error: %v", err)
+		}
+		return err
+	}
+	return nil
+}
+
+// maybeRewriteResponsesFrame inspects a single SSE frame and returns either the
+// original bytes (the overwhelmingly common case) or a re-serialized frame with
+// a corrected item_id. State (the index->canonical-id cache) is updated as a
+// side effect on output_item.added / output_item.done events.
+func maybeRewriteResponsesFrame(frame []byte, ev sseFrame, state *responsesRewriteState, verbose bool) []byte {
+	// [DONE] sentinel and anything that isn't a JSON object: pass through.
+	trimmed := bytes.TrimSpace(ev.Data)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return frame
+	}
+
+	var env responsesEnvelope
+	if err := json.Unmarshal(ev.Data, &env); err != nil {
+		// Unparseable payload: pass through verbatim.
+		return frame
+	}
+
+	switch env.Type {
+	case "response.output_item.added":
+		// Cache the canonical id for message items only.
+		if env.OutputIndex != nil && env.Item != nil && env.Item.Type == "message" && env.Item.ID != "" {
+			// Bound the cache against a hostile/buggy upstream that emits many
+			// distinct output_index values without ever sending
+			// output_item.done. Mirrors the websearch rewriter's
+			// fulfilledMemoryLimit discipline. On overflow we stop caching new
+			// ids (downstream mismatches for uncached indices degrade to
+			// passthrough — never a panic or unbounded growth).
+			if len(state.canonicalByIndex) < responsesIndexCacheLimit {
+				state.canonicalByIndex[*env.OutputIndex] = env.Item.ID
+			} else if verbose {
+				log.Printf("databricks-claude: responses: index cache at cap (%d); not caching output_index=%d", responsesIndexCacheLimit, *env.OutputIndex)
+			}
+		}
+		return frame
+
+	case "response.output_item.done":
+		// Index is being retired; drop the cached entry so a reused index
+		// cannot carry a stale id.
+		if env.OutputIndex != nil {
+			delete(state.canonicalByIndex, *env.OutputIndex)
+		}
+		return frame
+	}
+
+	// Downstream events: only those carrying both an output_index and an
+	// item_id are candidates for rewrite.
+	if env.OutputIndex == nil || env.ItemID == "" {
+		return frame
+	}
+	canonical, ok := state.canonicalByIndex[*env.OutputIndex]
+	if !ok || canonical == env.ItemID {
+		// Cache miss (e.g. reordered delta-before-added, or non-message
+		// item) or already-correct id: pass through verbatim.
+		return frame
+	}
+
+	// Mismatch — rewrite item_id to the canonical id. Decode into a generic
+	// map to preserve all other fields, then re-emit. This path is only taken
+	// for non-conforming streams, so byte-identity of conforming streams is
+	// unaffected.
+	var obj map[string]any
+	if err := json.Unmarshal(ev.Data, &obj); err != nil {
+		return frame
+	}
+	obj["item_id"] = canonical
+	rewritten, err := json.Marshal(obj)
+	if err != nil {
+		return frame
+	}
+
+	if verbose {
+		key := env.ItemID + "@" + strconv.Itoa(*env.OutputIndex)
+		if _, seen := state.warned[key]; !seen {
+			state.warned[key] = struct{}{}
+			log.Printf("databricks-claude: responses: rewrote item_id %q -> %q (output_index=%d, type=%s)",
+				env.ItemID, canonical, *env.OutputIndex, env.Type)
+		}
+	}
+
+	return buildSSEFrame(ev.EventType, rewritten)
+}
+
+// buildSSEFrame reconstructs an SSE frame from an optional event type and a
+// single-line JSON data payload, terminated by the "\n\n" boundary. Used only
+// on the rewrite path; conforming frames are forwarded verbatim.
+func buildSSEFrame(eventType string, data []byte) []byte {
+	var b bytes.Buffer
+	if eventType != "" {
+		b.WriteString("event: ")
+		b.WriteString(eventType)
+		b.WriteByte('\n')
+	}
+	b.WriteString("data: ")
+	b.Write(data)
+	b.WriteString("\n\n")
+	return b.Bytes()
+}
+
+// isResponsesPath reports whether the request path targets the OpenAI
+// Responses API (".../responses"). The Databricks serving-endpoint shape is
+// "/serving-endpoints/{...}/openai/v1/responses".
+func isResponsesPath(p string) bool {
+	return strings.Contains(p, "/responses")
+}

--- a/pkg/proxy/responses_rewriter_test.go
+++ b/pkg/proxy/responses_rewriter_test.go
@@ -1,0 +1,298 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// runResponsesPump runs pumpResponsesSSE on the given input and returns the
+// written output as a string. Reuses flushRecorder from sse_rewriter_test.go.
+func runResponsesPump(t *testing.T, input string) string {
+	t.Helper()
+	rec := newFlushRecorder()
+	if err := pumpResponsesSSE(context.Background(), rec, strings.NewReader(input), false); err != nil {
+		t.Fatalf("pumpResponsesSSE: %v", err)
+	}
+	return rec.body.String()
+}
+
+// TestResponsesRewriter_MismatchRewritten: a downstream output_text.delta
+// carrying an item_id that disagrees with the output_item.added item.id is
+// rewritten to the canonical id.
+func TestResponsesRewriter_MismatchRewritten(t *testing.T) {
+	input := strings.Join([]string{
+		frame("response.output_item.added", `{"type":"response.output_item.added","output_index":0,"item":{"id":"item_canonical","type":"message"}}`),
+		frame("response.content_part.added", `{"type":"response.content_part.added","output_index":0,"item_id":"item_WRONG","part":{"type":"output_text","text":""}}`),
+		frame("response.output_text.delta", `{"type":"response.output_text.delta","output_index":0,"item_id":"item_WRONG","delta":"hello"}`),
+		frame("response.output_text.done", `{"type":"response.output_text.done","output_index":0,"item_id":"item_WRONG","text":"hello"}`),
+	}, "")
+
+	out := runResponsesPump(t, input)
+
+	if strings.Contains(out, "item_WRONG") {
+		t.Errorf("mismatched id should have been rewritten away; output still contains item_WRONG:\n%s", out)
+	}
+	// The added event's own canonical id stays; downstream events now carry it.
+	if c := strings.Count(out, "item_canonical"); c != 4 {
+		t.Errorf("expected canonical id on the added event + 3 rewritten downstream events (4 total), got %d:\n%s", c, out)
+	}
+}
+
+// TestResponsesRewriter_MatchingIdPassthrough: when downstream item_id already
+// equals the canonical id, frames are byte-identical to the input.
+func TestResponsesRewriter_MatchingIdPassthrough(t *testing.T) {
+	input := strings.Join([]string{
+		frame("response.output_item.added", `{"type":"response.output_item.added","output_index":0,"item":{"id":"item_ok","type":"message"}}`),
+		frame("response.output_text.delta", `{"type":"response.output_text.delta","output_index":0,"item_id":"item_ok","delta":"hi"}`),
+	}, "")
+
+	out := runResponsesPump(t, input)
+	if out != input {
+		t.Errorf("conforming stream must be byte-identical.\n--- want ---\n%q\n--- got ---\n%q", input, out)
+	}
+}
+
+// TestResponsesRewriter_ConformingByteIdentical: a full, well-formed Responses
+// stream (added/delta/done/output_item.done/response.completed) is emitted
+// byte-for-byte unchanged. Mirrors the websearch byte-identity guarantee.
+func TestResponsesRewriter_ConformingByteIdentical(t *testing.T) {
+	input := strings.Join([]string{
+		frame("response.created", `{"type":"response.created","response":{"id":"resp_1"}}`),
+		frame("response.output_item.added", `{"type":"response.output_item.added","output_index":0,"item":{"id":"item_0","type":"message"}}`),
+		frame("response.content_part.added", `{"type":"response.content_part.added","output_index":0,"item_id":"item_0","part":{"type":"output_text"}}`),
+		frame("response.output_text.delta", `{"type":"response.output_text.delta","output_index":0,"item_id":"item_0","delta":"abc"}`),
+		frame("response.output_text.done", `{"type":"response.output_text.done","output_index":0,"item_id":"item_0","text":"abc"}`),
+		frame("response.output_item.done", `{"type":"response.output_item.done","output_index":0,"item":{"id":"item_0","type":"message"}}`),
+		frame("response.completed", `{"type":"response.completed","response":{"id":"resp_1"}}`),
+		"data: [DONE]\n\n",
+	}, "")
+
+	out := runResponsesPump(t, input)
+	if out != input {
+		t.Errorf("conforming full stream must be byte-identical.\n--- want ---\n%q\n--- got ---\n%q", input, out)
+	}
+}
+
+// TestResponsesRewriter_ReorderedDeltaBeforeAdded: a delta arriving before its
+// output_item.added (cache miss) is passed through unchanged — we never invent
+// a canonical id we haven't seen.
+func TestResponsesRewriter_ReorderedDeltaBeforeAdded(t *testing.T) {
+	input := strings.Join([]string{
+		frame("response.output_text.delta", `{"type":"response.output_text.delta","output_index":0,"item_id":"item_early","delta":"x"}`),
+		frame("response.output_item.added", `{"type":"response.output_item.added","output_index":0,"item":{"id":"item_late","type":"message"}}`),
+	}, "")
+
+	out := runResponsesPump(t, input)
+	if out != input {
+		t.Errorf("reordered delta-before-added must pass through unchanged.\n--- want ---\n%q\n--- got ---\n%q", input, out)
+	}
+}
+
+// TestResponsesRewriter_ReusedIndexNoStaleId: after output_item.done retires an
+// index, a new output_item.added reusing the same index installs a fresh
+// canonical id; a stale id from the first item is NOT applied to the second.
+func TestResponsesRewriter_ReusedIndexNoStaleId(t *testing.T) {
+	input := strings.Join([]string{
+		frame("response.output_item.added", `{"type":"response.output_item.added","output_index":0,"item":{"id":"item_first","type":"message"}}`),
+		frame("response.output_text.delta", `{"type":"response.output_text.delta","output_index":0,"item_id":"item_first","delta":"a"}`),
+		frame("response.output_item.done", `{"type":"response.output_item.done","output_index":0,"item":{"id":"item_first","type":"message"}}`),
+		// Index 0 reused for a new item.
+		frame("response.output_item.added", `{"type":"response.output_item.added","output_index":0,"item":{"id":"item_second","type":"message"}}`),
+		frame("response.output_text.delta", `{"type":"response.output_text.delta","output_index":0,"item_id":"item_WRONG","delta":"b"}`),
+	}, "")
+
+	out := runResponsesPump(t, input)
+	// The second delta's wrong id must be rewritten to item_second, not the
+	// retired item_first.
+	if strings.Contains(out, "item_WRONG") {
+		t.Errorf("reused-index delta should have been rewritten:\n%s", out)
+	}
+	// item_first legitimately appears on the first item's added/delta/done
+	// frames; the failure mode we guard against is item_first leaking onto the
+	// SECOND item's delta. Assert the second delta (the last frame) carries
+	// item_second, proving the retired id was not reapplied.
+	frames := strings.Split(strings.TrimRight(out, "\n"), "\n\n")
+	lastFrame := frames[len(frames)-1]
+	if !strings.Contains(lastFrame, `"item_id":"item_second"`) {
+		t.Errorf("reused-index delta should carry item_second, not the retired id:\nlast frame: %s\nfull:\n%s", lastFrame, out)
+	}
+	if strings.Contains(lastFrame, "item_first") {
+		t.Errorf("stale id from retired index leaked onto the reused index:\n%s", lastFrame)
+	}
+}
+
+// TestResponsesRewriter_NonMessageItemIgnored: reasoning / function_call items
+// are not cached, so a downstream event for that index is passed through (no
+// canonical id to apply).
+func TestResponsesRewriter_NonMessageItemIgnored(t *testing.T) {
+	input := strings.Join([]string{
+		frame("response.output_item.added", `{"type":"response.output_item.added","output_index":0,"item":{"id":"item_reason","type":"reasoning"}}`),
+		frame("response.reasoning_summary_text.delta", `{"type":"response.reasoning_summary_text.delta","output_index":0,"item_id":"item_other","delta":"think"}`),
+	}, "")
+
+	out := runResponsesPump(t, input)
+	if out != input {
+		t.Errorf("non-message item should be ignored (passthrough).\n--- want ---\n%q\n--- got ---\n%q", input, out)
+	}
+}
+
+// TestResponsesRewriter_DonePassthrough: the [DONE] sentinel and unparseable
+// payloads pass through verbatim.
+func TestResponsesRewriter_DonePassthrough(t *testing.T) {
+	input := strings.Join([]string{
+		"data: [DONE]\n\n",
+		"data: not-json\n\n",
+		": comment-only\n\n",
+	}, "")
+
+	out := runResponsesPump(t, input)
+	if out != input {
+		t.Errorf("DONE/non-JSON/comment frames must pass through.\n--- want ---\n%q\n--- got ---\n%q", input, out)
+	}
+}
+
+// TestResponsesRewriter_IndexCacheCapped: an upstream that emits more than
+// responsesIndexCacheLimit distinct output_index added-events (without
+// output_item.done) does not grow the cache unbounded; indices past the cap
+// are not cached and their downstream events degrade to passthrough.
+func TestResponsesRewriter_IndexCacheCapped(t *testing.T) {
+	var b strings.Builder
+	// Emit cap+10 added events at distinct indices, each with a canonical id.
+	for i := 0; i < responsesIndexCacheLimit+10; i++ {
+		b.WriteString(frame("response.output_item.added",
+			fmt.Sprintf(`{"type":"response.output_item.added","output_index":%d,"item":{"id":"item_%d","type":"message"}}`, i, i)))
+	}
+	// A downstream delta for an index BEYOND the cap with a wrong id: since it
+	// was never cached, it must pass through unchanged (no panic, no rewrite).
+	overCapIdx := responsesIndexCacheLimit + 5
+	deltaFrame := frame("response.output_text.delta",
+		fmt.Sprintf(`{"type":"response.output_text.delta","output_index":%d,"item_id":"item_WRONG","delta":"x"}`, overCapIdx))
+	b.WriteString(deltaFrame)
+
+	out := runResponsesPump(t, b.String())
+
+	// The over-cap delta should still contain item_WRONG (was never cached).
+	if !strings.Contains(out, "item_WRONG") {
+		t.Errorf("over-cap delta should pass through unchanged (uncached index), but item_WRONG was removed")
+	}
+}
+
+// TestResponsesRewriter_OversizedFrameNoPanic: a frame larger than the 1 MiB
+// scanner cap surfaces a scanner error rather than panicking.
+func TestResponsesRewriter_OversizedFrameNoPanic(t *testing.T) {
+	huge := strings.Repeat("a", 2*1024*1024)
+	input := frame("response.output_text.delta",
+		fmt.Sprintf(`{"type":"response.output_text.delta","output_index":0,"item_id":"x","delta":"%s"}`, huge))
+
+	rec := newFlushRecorder()
+	// Must not panic; an error is acceptable (oversized frame).
+	_ = pumpResponsesSSE(context.Background(), rec, strings.NewReader(input), false)
+}
+
+func TestIsResponsesPath(t *testing.T) {
+	cases := map[string]bool{
+		"/serving-endpoints/ws.aws.proxy.codex/openai/v1/responses": true,
+		"/responses":           true,
+		"/v1/responses":        true,
+		"/v1/messages":         false,
+		"/v1/chat/completions": false,
+		"/responses/123":       true,
+	}
+	for path, want := range cases {
+		if got := isResponsesPath(path); got != want {
+			t.Errorf("isResponsesPath(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+// TestResponsesRewriter_Integration_EndToEnd: full request -> fake upstream
+// emitting mismatched-id Responses SSE -> proxy output carries canonical ids,
+// Content-Length stripped, Content-Type preserved.
+func TestResponsesRewriter_Integration_EndToEnd(t *testing.T) {
+	upstreamSSE := strings.Join([]string{
+		frame("response.output_item.added", `{"type":"response.output_item.added","output_index":0,"item":{"id":"item_real","type":"message"}}`),
+		frame("response.output_text.delta", `{"type":"response.output_text.delta","output_index":0,"item_id":"item_bad","delta":"chunk"}`),
+		frame("response.output_text.done", `{"type":"response.output_text.done","output_index":0,"item_id":"item_bad","text":"chunk"}`),
+	}, "")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(upstreamSSE)))
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, upstreamSSE)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		TokenSource:       warmToken("tok"),
+		ResponsesRewrite:  ResponsesRewriteSettings{Enabled: true},
+	}
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	body := `{"model":"databricks-gpt-5-4","input":"hi","stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/serving-endpoints/ws.aws.proxy.codex/openai/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	out := rec.Body.String()
+	if strings.Contains(out, "item_bad") {
+		t.Errorf("integration: mismatched id should be rewritten:\n%s", out)
+	}
+	if !strings.Contains(out, "item_real") {
+		t.Errorf("integration: canonical id missing:\n%s", out)
+	}
+	if rec.Header().Get("Content-Length") != "" {
+		t.Errorf("integration: Content-Length should be stripped, got %q", rec.Header().Get("Content-Length"))
+	}
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Errorf("integration: Content-Type should be preserved, got %q", rec.Header().Get("Content-Type"))
+	}
+}
+
+// TestResponsesRewriter_Integration_DisabledByteIdentical: with
+// ResponsesRewrite disabled, the mismatched stream is forwarded byte-identically
+// (the byte-identity guarantee for Claude Code and any opt-out).
+func TestResponsesRewriter_Integration_DisabledByteIdentical(t *testing.T) {
+	upstreamSSE := strings.Join([]string{
+		frame("response.output_item.added", `{"type":"response.output_item.added","output_index":0,"item":{"id":"item_real","type":"message"}}`),
+		frame("response.output_text.delta", `{"type":"response.output_text.delta","output_index":0,"item_id":"item_bad","delta":"chunk"}`),
+	}, "")
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		_, _ = io.WriteString(w, upstreamSSE)
+	}))
+	defer upstream.Close()
+
+	cfg := &Config{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		TokenSource:       warmToken("tok"),
+		// ResponsesRewrite zero value: disabled.
+	}
+	handler, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/serving-endpoints/ws.aws.proxy.codex/openai/v1/responses", strings.NewReader(`{"stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !strings.Contains(rec.Body.String(), "item_bad") {
+		t.Errorf("disabled: stream must be forwarded verbatim (mismatched id preserved):\n%s", rec.Body.String())
+	}
+}

--- a/pkg/proxy/websearch_handler.go
+++ b/pkg/proxy/websearch_handler.go
@@ -126,6 +126,32 @@ func inferenceHandler(upstream *url.URL, config *Config, ws WebSearchSettings) h
 		// is the FIRST check on the response side — no JSON/SSE inspection,
 		// no buffering. Required by TestProxy_WebSearchDisabled_ByteIdenticalForward.
 		if !rewroteTools.Any() {
+			// RESPONSES-API REWRITE: opencode (and other OpenAI-compatible
+			// clients) run with WebSearch disabled, so they always land here.
+			// When ResponsesRewrite is enabled and this is a Responses-API SSE
+			// stream, reconcile mismatched item_ids (Databricks AI Gateway
+			// re-encodes the stream with divergent ids, breaking @ai-sdk/openai).
+			// Independent of ws.Enabled by design. Claude Code never hits
+			// /responses, so this is byte-identical for it.
+			if config.ResponsesRewrite.Enabled && isResponsesPath(r.URL.Path) && isSSEResponse(resp) {
+				for k, vv := range resp.Header {
+					if isHopByHop(k) {
+						continue
+					}
+					for _, v := range vv {
+						w.Header().Add(k, v)
+					}
+				}
+				// Strip Content-Length: a rewritten frame changes the body
+				// length on the wire.
+				w.Header().Del("Content-Length")
+				w.WriteHeader(resp.StatusCode)
+				if err := pumpResponsesSSE(r.Context(), w, resp.Body, config.Verbose); err != nil && config.Verbose {
+					log.Printf("databricks-claude: responses: SSE pump err: %v", err)
+				}
+				return
+			}
+
 			for k, vv := range resp.Header {
 				if isHopByHop(k) {
 					continue


### PR DESCRIPTION
## Summary

Fixes the OpenAI Responses-API SSE `item_id` mismatch (#191). Databricks AI Gateway re-encodes the Responses-API SSE stream and emits a different id in `response.output_item.added` (`item.id`) than in downstream `response.output_text.*` / `response.content_part.*` events (`item_id`), tripping `@ai-sdk/openai`'s stream parser with `text part <id> not found`. This is the Go-side fix for [IceRhymers/opencode#1](https://github.com/IceRhymers/opencode/issues/1) — the proxy already sits in the byte path, so we reconcile ids here in shared `pkg/proxy` instead of carrying a fork delta in opencode's TypeScript.

## What changed

- **New `pkg/proxy/responses_rewriter.go`** — `pumpResponsesSSE` reuses `splitSSEFrames` / `parseSSEFrame`. Per-stream `output_index -> item.id` cache populated from `output_item.added` (message items only — reasoning/function_call ignored), deleted on `output_item.done` so a reused index never carries a stale id. Downstream events get their `item_id` rewritten only when it disagrees with the cached canonical id. Cache is bounded (`responsesIndexCacheLimit = 1024`, mirroring the websearch rewriter's `fulfilledMemoryLimit`) to guard against an upstream that omits `output_item.done`.
- **New `Config.ResponsesRewrite ResponsesRewriteSettings{ Enabled bool }`** — sibling to `WebSearch`, default false.
- **Gate in `inferenceHandler`** — added inside the `!rewroteTools.Any()` byte-identity fast path, **independent of `ws.Enabled`** (opencode runs websearch off). Fires only when `ResponsesRewrite.Enabled && isResponsesPath(path) && isSSEResponse(resp)`; strips Content-Length and pumps. Otherwise falls through to the existing `flushingCopy`.

## Why this seam

`NewServer` always registers `inferenceHandler` on the catch-all `/`. opencode's `/responses` requests aren't `/v1beta` or `/otel`, so they hit it unconditionally, and with websearch off they take the byte-identity fast path — the only place the rewriter can branch in for opencode. Claude Code never emits `/responses`, so it stays byte-identical.

## Verbatim-passthrough guarantees

Frames are forwarded byte-for-byte (re-serialization only on a genuine mismatch) for: conforming streams, comment/empty frames, `[DONE]`, non-`{` payloads, parse failures, unknown event types, reordered events (delta-before-added cache miss), non-message items, and already-correct ids.

## Test Plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] `go test ./...` — full suite passes, no regressions
- [x] Independent code review (fresh-context reviewer): PASS, no security/logic findings

New tests in `responses_rewriter_test.go` cover:
- Mismatched `item_id` rewritten to canonical
- Matching id + full conforming stream byte-identity
- Reordered delta-before-added passthrough
- Reused-index-no-stale-id (post `output_item.done`)
- Non-message item ignored
- `[DONE]` / non-JSON / comment passthrough
- Index cache cap (no unbounded growth)
- Oversized-frame no-panic
- Path gate (`isResponsesPath`)
- End-to-end integration (mismatch rewritten, Content-Length stripped, Content-Type preserved)
- End-to-end integration with rewriter disabled (byte-identical forward)

## Downstream

databricks-opencode#95 bumps to the resulting release and enables `ResponsesRewrite`. databricks-codex also shares `pkg/proxy`, so the rewriter is available there if its SSE path ever needs it.

Closes #191
