### PR TITLE
Unify #5: fold in cmd/databricks-codex (+ tomlconfig), drop external module dep (#201)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /databricks-claude
 /databricks-claude-credential-helper
+/databricks-codex
 dist/
 *.exe
 .omc/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
-<!-- Generated: 2026-04-06 | Updated: 2026-04-06 -->
+<!-- Generated: 2026-04-06 | Updated: 2026-07-15 -->
 
-# databricks-claude
+# databricks-agents
 
 ## Purpose
-Transparent proxy wrapper for Claude Code that auto-refreshes Databricks OAuth tokens via the Databricks CLI. Intercepts Claude Code's API calls, injects fresh workspace tokens per-request, and optionally routes OpenTelemetry metrics/logs through the Databricks OTEL endpoint. Zero external Go dependencies -- pure stdlib only.
+Monorepo of transparent proxy wrappers that auto-refresh Databricks OAuth tokens via the Databricks CLI, intercepting each wrapped tool's API calls, injecting fresh workspace tokens per-request, and optionally routing OpenTelemetry metrics/logs through the Databricks OTEL endpoint. Two launchers today: `databricks-claude` (wraps Claude Code) and `databricks-codex` (wraps the OpenAI Codex CLI, folded in via #201). Zero external Go dependencies -- pure stdlib only.
 
-## Key Files
+## Key Files (`cmd/databricks-claude/`)
 
-> All `*.go` source files listed below now live under `cmd/databricks-claude/` (the `main` package, relocated from the repo root in #197). `Makefile`, `go.mod`, `CLAUDE.md`, and `README.md` remain at the repo root. The Go module is `github.com/IceRhymers/databricks-agents`.
+> All `*.go` source files listed below now live under `cmd/databricks-claude/` (the `main` package, relocated from the repo root in #197). `cmd/databricks-codex/` (see its own table below) is a sibling launcher. `Makefile`, `go.mod`, `CLAUDE.md`, and `README.md` remain at the repo root. The Go module is `github.com/IceRhymers/databricks-agents`.
 
 | File | Description |
 |------|-------------|
@@ -52,16 +52,38 @@ Transparent proxy wrapper for Claude Code that auto-refreshes Databricks OAuth t
 | `CLAUDE.md` | Project-level AI agent instructions |
 | `README.md` | User-facing documentation |
 
+## Key Files (`cmd/databricks-codex/`)
+
+The `databricks-codex` launcher (`main` package, folded in via #201). Same monorepo, same `internal/core` engine, but wraps the OpenAI Codex CLI instead of Claude Code: no settings.json-style env block (patches `~/.codex/config.toml` every session via `internal/codex/tomlconfig`), no daemon, no Desktop/MDM surface.
+
+| File | Description |
+|------|--------------|
+| `main.go` | Thin CLI entry point: subcommand dispatch (completion/hooks/config/serve/update), `parseArgs`, help/version, then `buildCodexLaunchPlan(a)` → `core.Run(CodexProfile(patcher), plan, a.CodexArgs)`. Hosts shared helpers: `resolveModel`/`defaultModel`, `resolveProfile`, `resolveOtel`, `deriveLogsTable`, `handlePrintEnv`, `buildUpdaterConfig`. |
+| `launch_codex.go` | `buildCodexLaunchPlan(a *Args) (core.LaunchPlan, codexSettingsPatcher, error)`: codex pre-flight — logging, profile/model resolution + state saves, auth, port/TLS resolution, token seed, host discovery, gateway URL (`{host}/ai-gateway/openai/v1`), OTEL table resolution (metrics+logs only), `exec.LookPath("codex")` guard. Returns `BuildEnv: nil` (codex writes no env block) plus the field-bearing `codexSettingsPatcher` it constructed. |
+| `profile_codex.go` | `CodexProfile(patcher)` factory, `codexSettingsPatcher` (`SettingsPatcher` impl — computes `base_url` + OTEL endpoints from `req.ProxyURL`, delegates to `tomlconfig.Manager.Patch`), `codexDaemon` (inert `DaemonStrategy` — codex has no daemon, `Install`/`Uninstall` return `profile.ErrDaemonUnsupported`), `codexHooks` (`HookInstaller` — delegates to `hooks.go` against `~/.codex/hooks.json`). |
+| `serve_codex.go` | `serve` subcommand: session/headless sibling entrypoint (lifecycle wrap + idle timeout, no child process, no daemon sub-subcommands). Calls the same `codexSettingsPatcher.Patch` writer as wrapper mode via `profile2Request`, so both paths emit byte-identical config.toml. |
+| `hooks.go` | `installHooks`/`uninstallHooks` manage the SessionStart entry in `~/.codex/hooks.json` and flip `[features] hooks = true` in config.toml (documented TOCTOU vs. `tomlconfig.Manager`, carried forward as `TODO(#72 follow-up)`). `headlessEnsure`/`headlessEnsureConfig` spawn `databricks-codex serve --port=N`. |
+| `hooks_cmd.go` | `hooks <install\|uninstall\|session-start>` subcommand dispatcher |
+| `cli_config.go` | `config <otel\|show>` subcommand runner. Smaller surface than claude's `config`: no `write` (no settings.json bootstrap), no `websearch` (no local fulfillment). `resolveConfigOTEL` is the pure orchestration resolver. |
+| `state.go` | `persistentState` for `~/.codex/.databricks-codex.json` (profile, model, port, TLS paths, OTEL tables, `OtelMetricsDisabled`/`OtelLogsDisabled` sticky bits) |
+| `token.go` | `NewTokenProvider`/`DiscoverHost`/`ConstructGatewayURL` (gateway `/ai-gateway/openai/v1`) |
+| `proxy.go` | Facade over `internal/core/proxy`; used directly by `serve_codex.go` (which doesn't route through `core.Run`) |
+| `commands.go` | Source-of-truth `rootCommand` tree (`config`, `hooks`, `serve` subcommands) |
+| `completion_flags.go` | `flagDefs`/`knownFlags`/`knownSubcommands`, derived from `rootCommand` |
+
 ## Subdirectories
 
 | Directory | Purpose |
 |-----------|---------|
 | `cmd/databricks-claude/` | CLI entry point (`main` package), relocated from the repo root in #197. Builds the `databricks-claude` binary. |
-| `internal/cmd/` | Pre-existing command-tree parsing/help/completion library (distinct from `cmd/databricks-claude/`) |
-| `internal/core/` | The shared tool-agnostic engine (proxy, tokencache, authcheck, childproc, state, headless, lifecycle, portbind, health, refcount, updater, completion, cli). Promoted from `pkg/` in #198; module-private (see `internal/core/doc.go`). `run.go` (#200) adds `LaunchPlan` + `Run(profile.Profile, LaunchPlan, []string) int` — the wrapper-mode launch engine (bind → serve/watch → BuildEnv → Patch → child → refcount teardown) shared by all launchers. |
-| `internal/profile/` | Placeholder for profile resolution (epic #196); empty `doc.go` skeleton added in #197, filled by #D/#E |
-| `pkg/` | Only the Claude/Anthropic-coupled libraries remain after #198 (see `pkg/AGENTS.md`): `modeldiscovery`, `mdmprofile`, `websearch` |
-| `pkg/mdmprofile/` | Platform-specific readers for MDM-managed preferences (darwin: plist, windows: registry, other: stub). Used by the credential helper to resolve the Databricks profile on endpoint machines. |
+| `cmd/databricks-codex/` | CLI entry point (`main` package) for the codex launcher, folded in via #201. Builds the `databricks-codex` binary. See the Key Files table above. |
+| `internal/cmd/` | Pre-existing command-tree parsing/help/completion library (shared by both launchers' `commands.go`) |
+| `internal/core/` | The shared tool-agnostic engine (proxy, tokencache, authcheck, childproc, state, headless, lifecycle, portbind, health, refcount, updater, completion, cli). Promoted from `pkg/` in #198; module-private (see `internal/core/doc.go`). `run.go` (#200) adds `LaunchPlan` + `Run(profile.Profile, LaunchPlan, []string) int` — the wrapper-mode launch engine (bind → serve/watch → BuildEnv → Patch → child → refcount teardown) shared by both launchers. |
+| `internal/codex/` | codex-specific libraries -- the `internal/`-tree analog of `pkg/` for codex, since it must be importable from `cmd/databricks-codex` (see `internal/codex/AGENTS.md`) |
+| `internal/codex/tomlconfig/` | codex-specific string-based surgical patcher for `~/.codex/config.toml` (see `internal/codex/tomlconfig/AGENTS.md`). Not tool-agnostic, so it lives outside `internal/core`; not promoted to `pkg/` since only `cmd/databricks-codex` imports it. |
+| `internal/profile/` | The per-tool `Profile` abstraction (#199): `Profile` struct + `SettingsPatcher`/`DaemonStrategy`/`HookInstaller` interfaces. Interfaces live here; concrete impls live in each launcher's `package main` (`profile_claude.go`, `profile_codex.go`). |
+| `pkg/` | Only the Claude/Anthropic-coupled libraries remain after #198 (see `pkg/AGENTS.md`): `modeldiscovery`, `mdmprofile`, `websearch`. codex has no `pkg/*` packages — its one tool-specific library (`tomlconfig`) lives under `internal/codex/` instead. |
+| `pkg/mdmprofile/` | Platform-specific readers for MDM-managed preferences (darwin: plist, windows: registry, other: stub). Used by the credential helper to resolve the Databricks profile on endpoint machines. Claude Desktop-only; codex has no Desktop/MDM surface. |
 | `.github/` | GitHub Actions CI configuration (see `.github/AGENTS.md`) |
 | `.claude/` | Claude Code project configuration (settings only, no AGENTS.md needed) |
 
@@ -69,25 +91,26 @@ Transparent proxy wrapper for Claude Code that auto-refreshes Databricks OAuth t
 
 ### Working In This Directory
 - **Zero external dependencies** -- do not add any third-party imports. All code must use the Go stdlib only.
-- The CLI entry-point package is `main`, located at `cmd/databricks-claude/`. The `.go` files there are thin facades that delegate to the shared engine in `internal/core/` (plus the remaining Claude-coupled `pkg/*` packages). Keep them thin.
-- `main.go` is a thin launcher: it dispatches subcommands, parses flags, then delegates wrapper-mode to `buildClaudeLaunchPlan` (`launch_claude.go`, claude pre-flight) + `core.Run` (`internal/core/run.go`, the generic bind/serve/patch/child lifecycle). `token.go` owns Databricks auth; `proxy.go` is a test-facing facade over `internal/core/proxy`. Keep claude-specific launch assembly in `launch_claude.go` and tool-agnostic lifecycle in `internal/core`.
-- `lock.go` and `registry.go` are pure type-alias forwarding files -- they exist only for backward compatibility with root-level tests.
+- Both launchers' entry-point packages are `main`: `cmd/databricks-claude/` and `cmd/databricks-codex/`. The `.go` files in each are thin facades that delegate to the shared engine in `internal/core/` (plus each launcher's own tool-coupled libraries -- claude: `pkg/*`; codex: `internal/codex/tomlconfig`). Keep them thin.
+- `main.go` (either launcher) is a thin dispatcher: it dispatches subcommands, parses flags, then delegates wrapper-mode to a launcher-specific `buildXLaunchPlan` (claude: `launch_claude.go`; codex: `launch_codex.go`) + `core.Run` (`internal/core/run.go`, the generic bind/serve/patch/child lifecycle). Each launcher's `token.go` owns Databricks auth; `proxy.go` is a facade over `internal/core/proxy`. Keep launcher-specific launch assembly in `launch_*.go` and tool-agnostic lifecycle in `internal/core`.
+- codex has no daemon, no settings.json-style env block, and no Desktop/MDM surface -- do not add those without an explicit design decision; its `serve` is a session/headless leaf only, and its "settings file" is `~/.codex/config.toml`, patched every session (not a one-shot bootstrap).
 
 ### Testing Requirements
 - Run `make test` or `go test ./... -v`
-- Tests use **helper binaries compiled at test time** to mock the `databricks` CLI (see `buildHelperBinary`, `buildSlowBinary`, `buildAuthEnvBinary` in `token_test.go`)
-- `warmToken()` in `proxy_test.go` pre-loads the token cache to avoid subprocess calls during proxy tests
-- `process_test.go` creates temp directories for settings.json isolation
+- Tests use **helper binaries compiled at test time** to mock the `databricks` CLI (see `buildHelperBinary`, `buildSlowBinary`, `buildAuthEnvBinary` in `cmd/databricks-claude/token_test.go`); codex reuses the same pattern for its own token/auth tests
+- `warmToken()` pre-loads the token cache to avoid subprocess calls during proxy tests
+- Settings/config isolation: tests create temp directories for `settings.json` (claude) or `config.toml` (codex) so no test touches the real user config
 
 ### Common Patterns
-- **Atomic file writes**: all JSON writes use temp-file-then-`os.Rename` in the same directory
-- **Settings.json lifecycle**: `SaveAndOverwrite` / `FullSetup` saves originals, patches env block, `Restore` puts them back (smart handoff to surviving sessions)
+- **Atomic file writes**: all JSON/TOML writes use temp-file-then-`os.Rename` in the same directory
+- **Settings.json lifecycle** (claude): `SaveAndOverwrite` / `FullSetup` saves originals, patches env block, `Restore` puts them back (smart handoff to surviving sessions)
+- **config.toml lifecycle** (codex): `tomlconfig.Manager.Patch` surgically rewrites only the managed keys/sections (`profile`, `profiles.databricks-proxy`, `model_providers.databricks-proxy`, `otel`), preserving all other user content byte-for-byte
 - **Token caching**: mutex-guarded, 5-minute refresh buffer, fallback to last good token on error
 
 ### Critical Safety Rules
-- **Never break settings.json restore** -- a botched restore leaves the user's Claude config pointing at a dead proxy
-- **OTEL key persistence** -- when `otelKeysPersistent` is true, Restore must skip OTEL keys
-- **Session handoff** -- when multiple instances run concurrently, the exiting session hands `ANTHROPIC_BASE_URL` to the most recent survivor
+- **Never break settings.json / config.toml restore** -- a botched restore leaves the user's config pointing at a dead proxy
+- **OTEL key persistence** -- claude: when `otelKeysPersistent` is true, Restore must skip OTEL keys. codex: `OtelMetricsDisabled`/`OtelLogsDisabled` sticky bits in state let `config otel disable` suppress export while preserving table-name preferences for a future re-enable
+- **Session handoff** -- when multiple instances of the same launcher run concurrently, the exiting session hands the base URL to the most recent survivor
 
 ## Dependencies
 
@@ -97,7 +120,9 @@ Transparent proxy wrapper for Claude Code that auto-refreshes Databricks OAuth t
 - `internal/core/tokencache` -- generic token caching
 - `internal/core/{state,headless,lifecycle,portbind,health,refcount,updater,completion,cli}` -- the rest of the shared engine
 - `internal/cmd` -- command-tree parsing/help/completion library
-- `pkg/modeldiscovery`, `pkg/mdmprofile`, `pkg/websearch` -- the remaining Claude-coupled libraries (not promoted into core)
+- `internal/profile` -- the per-tool `Profile` abstraction (interfaces only; impls live in each launcher)
+- `internal/codex/tomlconfig` -- codex-only: surgical `~/.codex/config.toml` patcher
+- `pkg/modeldiscovery`, `pkg/mdmprofile`, `pkg/websearch` -- claude-only libraries (not promoted into core; codex has no equivalents)
 
 ### External
 - None (pure Go stdlib)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,22 +4,29 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Transparent proxy wrapper for Claude Code that auto-refreshes Databricks OAuth tokens via the Databricks CLI. Zero external Go dependencies — pure stdlib only.
+A monorepo of transparent proxy wrappers that auto-refresh Databricks OAuth tokens via the Databricks CLI, so Databricks-hosted models can be used with unmodified AI coding CLIs. It hosts two launchers today:
+
+- **`databricks-claude`** — wraps Claude Code. Patches `~/.claude/settings.json`'s env block; gateway `{host}/ai-gateway/anthropic`.
+- **`databricks-codex`** — wraps the OpenAI Codex CLI. Surgically patches `~/.codex/config.toml` every session (no settings.json-style env block); gateway `{host}/ai-gateway/openai/v1`.
+
+Both share the tool-agnostic engine in `internal/core/` (proxy, auth, token cache, child process, state, lifecycle) via the `internal/profile.Profile` abstraction; each launcher is its own `package main` under `cmd/`. Zero external Go dependencies — pure stdlib only.
 
 ## Build & Test
 
 ```bash
-make build                       # produces ./databricks-claude (builds ./cmd/databricks-claude)
+make build                       # produces ./databricks-claude and ./databricks-codex
 make test                        # go test ./... -v
 make lint                        # go vet ./...
-make install                     # installs to $GOPATH/bin
-make dist                        # cross-compile darwin/linux/windows amd64+arm64
-go build ./cmd/databricks-claude # build the CLI binary directly (module: github.com/IceRhymers/databricks-agents)
+make install                     # installs both to $GOPATH/bin
+make dist                        # cross-compile darwin/linux/windows amd64+arm64, both binaries
+go build ./cmd/databricks-claude # build the claude CLI binary directly (module: github.com/IceRhymers/databricks-agents)
+go build ./cmd/databricks-codex  # build the codex CLI binary directly
 go test -run TestParseArgs -v    # run a single test
-go test ./internal/core/proxy/... -v  # test a single package
+go test ./internal/core/proxy/... -v       # test a single package
+go test ./internal/codex/tomlconfig/... -v # test the codex config.toml patcher
 ```
 
-The Go module is `github.com/IceRhymers/databricks-agents`. The CLI entry point (`main` package) lives at `cmd/databricks-claude/`; the built binary is still named `databricks-claude`.
+The Go module is `github.com/IceRhymers/databricks-agents`. Each launcher's `main` package lives at `cmd/<binary-name>/`; the built binaries are named `databricks-claude` and `databricks-codex`. `databricks-codex` has no credential-helper alias, no `.pkg`/MDM/trust-profile surface, and no daemon — see the codex architecture section below for what's intentionally smaller than claude's.
 
 ## Architecture
 
@@ -51,6 +58,23 @@ The `main` package lives at `cmd/databricks-claude/` — a set of `.go` files th
 - **serve_install_other.go** — `//go:build !darwin && !windows && !linux` — stubs returning "unsupported platform" error for `installDaemon`/`uninstallDaemon`/`daemonStatus`, plus a `("", nil)` `diagnosticsTail` so cross-platform CI builds (freebsd/openbsd) compile.
 - **profile_claude.go** — The claude implementation of the `internal/profile` abstraction (#199). Lives in `package main` because a launcher can't be imported. Defines `const ProfileName = "databricks-claude"` and three tiny delegating adapters: `claudeSettingsPatcher` (`.Patch` → one-line `bootstrapSettings`; `.Restore` → unwired no-op scoped to #E), `claudeDaemon` (`.Install`/`.Uninstall`/`.Status`/`.Diagnostics` → `installDaemon`/`uninstallDaemon`/`daemonStatus`/`diagnosticsTail`, mapping all 8 `installOptions` fields in and all 11 `statusResult` fields out via `toDaemonStatus`/`fromDaemonStatus`), and `claudeHooks` (`.Install`/`.Uninstall` → `installHooks`/`uninstallHooks(claudeSettingsPath())`). `ClaudeProfile()` is the typed constructor the 3 live call sites (`main.go` settings patch, `hooks_cmd.go` hook install/uninstall, `serve_install.go` daemon leaf calls) route through. `claudeSettingsPath()` centralizes the `~/.claude/settings.json` path.
 
+### CLI entry-point package (`cmd/databricks-codex/`, package `main`)
+
+`databricks-codex` wraps the OpenAI Codex CLI, mirroring claude's thin-`main`-over-`core.Run` shape (#201) but with a smaller surface: no settings.json-style env block, no daemon, no Desktop/MDM artifacts. Its "settings file" is `~/.codex/config.toml`, surgically patched every session (not a one-shot bootstrap):
+
+- **main.go** — Thin CLI entry point: early-exit subcommand dispatch (completion/hooks/config/serve/update), `parseArgs`, help/version, then `plan, patcher, err := buildCodexLaunchPlan(a); os.Exit(core.Run(CodexProfile(patcher), plan, a.CodexArgs))`. Hosts shared package-`main` helpers: `parseArgs`, `handleHelp`, `handlePrintEnv`, `buildUpdaterConfig`, `defaultModel`/`resolveModel`, `resolveProfile`, `resolveOtel` (state-only — no session-time OTEL flags), `deriveLogsTable`.
+- **launch_codex.go** — `buildCodexLaunchPlan(a *Args) (core.LaunchPlan, codexSettingsPatcher, error)`: codex-specific wrapper pre-flight — logging setup, profile/model resolution with state persistence, `authcheck.EnsureAuthenticated`, port resolution, TLS validation, startup security warnings, token seeding, host discovery, gateway URL construction (`{host}/ai-gateway/openai/v1`), OTEL table resolution (metrics + logs only — codex has no traces signal), and the `exec.LookPath("codex")` guard (positioned after host discovery so auth/discovery errors surface first; excluded from `serve` and from `core.Run`, which launches `ChildBinary` blindly). Returns the neutral `core.LaunchPlan` (`BuildEnv: nil` — codex writes no env block) plus the field-bearing `codexSettingsPatcher` it constructed, so the launch-time model/OTEL values it resolved are single-sourced into both the proxy headers and the config.toml patch (avoiding parity drift between them).
+- **profile_codex.go** — The codex implementation of the `internal/profile` abstraction. `codexSettingsPatcher{mgr, model, modelExplicit, otelMetricsTable, otelLogsTable, otelEnabled}` implements `SettingsPatcher`: `.Patch` computes `base_url` + the OTEL exporter endpoints (`{proxyURL}/otel/v1/{logs,metrics}`, emitted only when OTEL is enabled and the corresponding table is non-empty) from `req.ProxyURL` and delegates to `tomlconfig.Manager.Patch` — the *same* writer `serve_codex.go` calls, so wrapper-mode and `serve` emit byte-identical config.toml for identical inputs. The zero-value patcher is a valid `SettingsPatcher` (satisfies the compile-time conformance assert and Registry/test usage); the launch path always supplies a field-bearing value. `codexDaemon` is an **inert** API-shape conformance struct — codex has no daemon, so `Install`/`Uninstall` return `profile.ErrDaemonUnsupported` and `Status`/`Diagnostics` return zero values; never invoked at runtime. `codexHooks` delegates to `installHooks`/`uninstallHooks(codexHooksPath())` against `~/.codex/hooks.json`. `CodexProfile(patcher profile.SettingsPatcher) profile.Profile` is a one-arg factory (Option A — the launch-time-static model/OTEL fields live on the patcher, not threaded through `PatchRequest`, since `PatchRequest.Env` is contractually "the settings.json env block" and codex writes none).
+- **serve_codex.go** — `serve` subcommand: codex's session/headless sibling entrypoint. Unlike claude, codex has **no daemon** (no LaunchAgent/systemd/schtasks equivalent) — `serve` is a leaf with no `install`/`uninstall`/`status` sub-subcommands. It does NOT route through `core.Run` (distinct lifecycle: `internal/core/lifecycle` wrap + idle timeout, no child process, no `LookPath("codex")` guard since it never launches codex) but **does** call the exact same `codexSettingsPatcher.Patch` config.toml writer as wrapper mode via `profile2Request(proxyURL)`, guaranteeing byte-identical config.toml from either entrypoint.
+- **hooks.go** — `installHooks`/`uninstallHooks` manage the SessionStart entry in `~/.codex/hooks.json` (Codex has no SessionEnd event, so there's no release hook — the proxy self-exits via idle timeout) and flip `[features] hooks = true` in `config.toml` so Codex actually reads `hooks.json`. `ensureHooksFeatureFlag`/`removeHooksFeatureFlag` write `config.toml` directly, bypassing `tomlconfig.Manager`'s backup/restore bookkeeping — a documented TOCTOU carried forward unchanged from the standalone repo (`TODO(#72 follow-up)`), not fixed here to preserve byte-parity. `headlessEnsure`/`headlessEnsureConfig` (called by `hooks session-start`) spawn `databricks-codex serve --port=N` via `headless.Config.EnsureCommand=["serve"]`.
+- **hooks_cmd.go** — `hooks <install|uninstall|session-start>` subcommand dispatcher; thin wrappers around `hooks.go`.
+- **cli_config.go** — `config <otel|show>` subcommand runner. Smaller surface than claude's: no `config write` (codex has no settings.json bootstrap — config.toml is patched every session by the proxy lifecycle, not a one-shot writer) and no `config websearch` (codex has no local web-search fulfillment). `resolveConfigOTEL` is the pure orchestration resolver (mirrors claude's `resolveConfigOTEL` pattern); `config otel disable` preserves state-file table preferences so a later `enable` restores them without re-typing.
+- **state.go** — `persistentState` for `~/.codex/.databricks-codex.json` (profile, model, port, TLS paths, OTEL tables, and `OtelMetricsDisabled`/`OtelLogsDisabled` sticky bits — codex's two-store equivalent of claude's settings-json-absence-means-off model, adapted because codex has no env block to absent).
+- **token.go** — `NewTokenProvider`/`DiscoverHost`/`ConstructGatewayURL` (gateway path `/ai-gateway/openai/v1`, distinct from claude's `/ai-gateway/anthropic`). Same `databricks auth token`/`auth env` shelling pattern as claude's `token.go`.
+- **proxy.go** — Thin facade over `internal/core/proxy` (`ProxyConfig`, `NewProxyServer`, `ServeProxy`, `StartProxy`), used by both `launch_codex.go` (indirectly via `core.Run`) and `serve_codex.go` (directly, since `serve` doesn't route through `core.Run`).
+- **commands.go** — Source-of-truth `rootCommand` tree (`config`, `hooks`, `serve` subcommands) driving parsing, help, and completion — same `internal/cmd` machinery claude uses.
+- **completion_flags.go** — `flagDefs`/`knownFlags`/`knownSubcommands`, derived from `rootCommand` the same way claude's are.
+
 ### Core packages (`internal/core/`)
 
 The tool-agnostic proxy/auth/gateway/token/state engine every launcher runs. Promoted from `pkg/` into module-private `internal/core` in #198 (no behavior change) — the `internal/` boundary is compiler-enforced, so only this module can import them:
@@ -61,7 +85,7 @@ The tool-agnostic proxy/auth/gateway/token/state engine every launcher runs. Pro
 | `internal/core/childproc` | Child process start, SIGINT/SIGTERM forwarding, exit code propagation |
 | `internal/core/cli` | Shared CLI helpers |
 | `internal/core/completion` | Shell completion script generation (bash, zsh, fish) from `FlagDef` slices |
-| `internal/core/headless` | Detached-proxy spawn helpers: `Ensure` (start-if-absent) and `Release` (refcount decrement). `Config.EnsureCommand` (added in #174) lets databricks-claude target `serve --session-mode` instead of the deleted `--headless` root flag; siblings (databricks-codex, databricks-opencode) leave it empty for the legacy `--headless` shape. |
+| `internal/core/headless` | Detached-proxy spawn helpers: `Ensure` (start-if-absent) and `Release` (refcount decrement). `Config.EnsureCommand` (added in #174) lets a launcher target its own subcommand instead of the legacy bare `--headless` flag shape: databricks-claude sets it to `["serve", "--session-mode"]`, databricks-codex to `["serve"]` (#201). |
 | `internal/core/health` | `/health` endpoint handler returning JSON with tool name, version, and PID |
 | `internal/core/lifecycle` | HTTP handler wrapper adding `/shutdown` refcount endpoint and idle timeout |
 | `internal/core/portbind` | Port binding helpers: bind to a configured port with fallback |
@@ -85,11 +109,14 @@ Only the Claude/Anthropic-coupled packages remain here after #198 — deliberate
 
 | Package | Purpose |
 |---------|---------|
-| `internal/cmd` | Pre-existing command-tree parsing/help/completion library (distinct from `cmd/databricks-claude/`; drives `rootCommand` in `commands.go`). |
+| `internal/cmd` | Pre-existing command-tree parsing/help/completion library (distinct from `cmd/databricks-claude/`; drives `rootCommand` in both launchers' `commands.go`). |
 | `internal/core` | The shared tool-agnostic engine (proxy/auth/gateway/token/state). Populated in #198 — see the Core packages table above. |
-| `internal/profile` | The per-tool `Profile` abstraction (#199): `Profile` struct (Name, ChildBinary, ConfigPath, GatewayPath + the three seams) plus the `SettingsPatcher` / `DaemonStrategy` / `HookInstaller` interfaces and their neutral, lossless request/response structs (`PatchRequest`, `RestoreRequest`, `DaemonInstallRequest` mirroring all 8 install fields, `DaemonStatus` mirroring all 11 status fields). `Registry` (Register/Lookup/Names) is an API-shape deliverable for the future multiplexer (#H) — no `var Default`, no `init()` registration, does NOT compose #H via init. Stdlib-only (imports `errors`/`sort`); interfaces live here, concrete impls live in each launcher's `package main` (claude: `profile_claude.go`). `ErrDaemonUnsupported` is a forward-looking sentinel unused by claude. |
+| `internal/profile` | The per-tool `Profile` abstraction (#199): `Profile` struct (Name, ChildBinary, ConfigPath, GatewayPath + the three seams) plus the `SettingsPatcher` / `DaemonStrategy` / `HookInstaller` interfaces and their neutral, lossless request/response structs (`PatchRequest`, `RestoreRequest`, `DaemonInstallRequest` mirroring all 8 install fields, `DaemonStatus` mirroring all 11 status fields). `Registry` (Register/Lookup/Names) is an API-shape deliverable for the future multiplexer (#H) — no `var Default`, no `init()` registration, does NOT compose #H via init. Stdlib-only (imports `errors`/`sort`); interfaces live here, concrete impls live in each launcher's `package main` (claude: `profile_claude.go`; codex: `profile_codex.go`). `ErrDaemonUnsupported` is used for real by `codexDaemon` (codex has no daemon) and is a forward-looking sentinel unused by claude. |
+| `internal/codex/tomlconfig` | codex-specific (not tool-agnostic like `internal/core`) string-based surgical patcher for `~/.codex/config.toml` — `Manager.Patch`/`Backup`/`Restore`/`RestoreFromBackup`/`UpdateProxyURL`. Lives under module-root `internal/` (not `pkg/`) so it's importable from `cmd/databricks-codex` (`package main`) while staying out of `internal/core` (claude has no equivalent — its settings file is a JSON env block, not TOML). Zero deps. See `internal/codex/tomlconfig/AGENTS.md`. |
 
 ### Key data flow
+
+**databricks-claude:**
 
 1. Wrapper mode: `main.go` → `buildClaudeLaunchPlan` (`launch_claude.go`) seeds the token cache and resolves upstreams into a neutral `core.LaunchPlan` → `core.Run` (`internal/core/run.go`) binds the proxy on the configured port (default `49153`) → assembles the env block via `plan.BuildEnv(proxyURL)` → patches `settings.json` (through `ClaudeProfile().PatchSettings.Patch`) to point `ANTHROPIC_BASE_URL` at the proxy → launches `claude` as child → releases the cross-session refcount on exit.
 2. Session-scoped standalone proxy: `serve --session-mode` (in `serve_session.go`) does the same setup but blocks on SIGINT/SIGTERM or `/shutdown` instead of launching claude. Handler is wrapped with `internal/core/lifecycle` (`POST /shutdown` refcount decrement + conditional exit; idle timeout defaults to 30m, resets on each proxied request).
@@ -97,14 +124,21 @@ Only the Claude/Anthropic-coupled packages remain here after #198 — deliberate
 4. Proxy intercepts every request, injects fresh OAuth token via `internal/core/tokencache` → forwards to AI Gateway (`{host}/ai-gateway/anthropic`) or Databricks OTEL endpoint.
 5. On exit, settings are restored **explicitly before `os.Exit`** (not via defer — `os.Exit` skips defers). `ANTHROPIC_BASE_URL` is handed off to a surviving session if one exists.
 
+**databricks-codex:**
+
+1. Wrapper mode: `main.go` → `buildCodexLaunchPlan` (`launch_codex.go`) seeds the token cache, resolves upstreams (gateway `{host}/ai-gateway/openai/v1`), and guards on `exec.LookPath("codex")` → returns a neutral `core.LaunchPlan` (`BuildEnv: nil`) plus a field-bearing `codexSettingsPatcher` → `core.Run` binds the proxy on the configured port (default `49154`) → patches `~/.codex/config.toml` (through `CodexProfile(patcher).PatchSettings.Patch`, computing `base_url` + OTEL exporter endpoints from the bound proxy URL) → launches `codex` as child → releases the cross-session refcount on exit.
+2. Session/headless proxy: `serve` (in `serve_codex.go`) does the same resolution but blocks on SIGINT/SIGTERM or `/shutdown` instead of launching codex, and calls the *same* `codexSettingsPatcher.Patch` writer directly (byte-identical config.toml from either entrypoint). No daemon mode exists — `serve` is codex's only headless lifecycle, with no `install`/`uninstall`/`status` sub-subcommands.
+3. Proxy intercepts every request, injects a fresh OAuth token → forwards to AI Gateway or the Databricks OTEL endpoint (metrics + logs only, no traces signal).
+4. SessionStart hooks (`~/.codex/hooks.json`, gated by `[features] hooks = true` in config.toml) spawn `databricks-codex serve --port=N` on demand; there is no SessionEnd hook (Codex CLI has no session-end event), so the proxy relies entirely on its idle timeout to exit.
+
 ## Key Design Constraints
 
 - **Zero external dependencies** — do not add third-party imports. Pure Go stdlib only.
-- **No breaking changes to settings.json** — a botched restore leaves the user's Claude config pointing at a dead proxy. Any change to key names, restore logic, or the save/restore lifecycle requires extreme care.
-- **Atomic file writes everywhere** — all JSON writes (settings, registry, persistent config) use temp-file + `os.Rename` in the same directory.
-- **Session handoff** — when multiple `databricks-claude` instances run concurrently, the exiting one hands `ANTHROPIC_BASE_URL` to the most recent survivor.
-- **OTEL key persistence** — when OTEL is active (state file has any `otel_*_table` set, or settings.json carries OTEL keys), OTEL keys survive settings restore (controlled by `otelKeysPersistent` flag).
-- **No model discovery on the launch hot path** — `pkg/modeldiscovery` network calls run only at `config write` / `desktop generate-config` / `doctor` time. The wrapper launch path (`buildClaudeLaunchPlan` in `launch_claude.go`, via `launchModelRouting`) and the unconditional `serve --session-mode` startup read the persisted `ModelRouting` from state (or fall back to `defaultModelRouting()`); they never call the gateway.
+- **No breaking changes to settings.json / config.toml** — a botched restore leaves the user's config pointing at a dead proxy. Any change to key names, restore logic, or the save/restore lifecycle requires extreme care, for both claude's `settings.json` env block and codex's `config.toml` surgical patch.
+- **Atomic file writes everywhere** — all JSON/TOML writes (settings, config.toml, registry, persistent config) use temp-file + `os.Rename` in the same directory.
+- **Session handoff** — when multiple instances of the same launcher run concurrently, the exiting one hands the base URL to the most recent survivor.
+- **OTEL key persistence** — when OTEL is active (state file has any `otel_*_table` set, or settings.json/config.toml carries OTEL keys), OTEL keys survive restore (controlled by `otelKeysPersistent` for claude; codex's `OtelMetricsDisabled`/`OtelLogsDisabled` sticky bits for codex).
+- **No model discovery on the launch hot path** — `pkg/modeldiscovery` (claude-only) network calls run only at `config write` / `desktop generate-config` / `doctor` time. The wrapper launch path (`buildClaudeLaunchPlan` in `launch_claude.go`, via `launchModelRouting`) and the unconditional `serve --session-mode` startup read the persisted `ModelRouting` from state (or fall back to `defaultModelRouting()`); they never call the gateway. codex has no equivalent discovery — its model is a flag/state value with a hardcoded `defaultModel()` fallback, no Unity Catalog lookup.
 
 ## Testing Patterns
 

--- a/Makefile
+++ b/Makefile
@@ -38,16 +38,20 @@ CERT_COUNTRY ?= US
 
 ## Build the databricks-claude binary (and the credential-helper alias that
 ## the Claude Desktop MDM artifacts expect — symlink on Unix, hard link on
-## Windows).
+## Windows) plus the databricks-codex binary. codex has no credential-helper
+## surface, so it gets a plain `go build` with no alias step.
 build:
 	go build -ldflags="$(LDFLAGS)" -o databricks-claude$(EXE) ./cmd/databricks-claude
 	$(LINK_ALIAS)
+	go build -ldflags="$(LDFLAGS)" -o databricks-codex$(EXE) ./cmd/databricks-codex
 
 ## Install to GOPATH/bin (also drops the credential-helper alias so Claude
-## Desktop's inferenceCredentialHelper can target a stable path).
+## Desktop's inferenceCredentialHelper can target a stable path). codex
+## installs plainly — no alias, no Desktop/MDM surface.
 install:
 	go install -ldflags="$(LDFLAGS)" ./cmd/databricks-claude
 	$(INSTALL_LINK_ALIAS)
+	go install -ldflags="$(LDFLAGS)" ./cmd/databricks-codex
 
 ## Run tests with verbose output
 test:
@@ -56,7 +60,9 @@ test:
 ## Cross-compile for linux/darwin/windows amd64 + arm64. Symlinks for the
 ## credential-helper alias are NOT generated here — packagers (brew, .pkg,
 ## .deb) are responsible for creating them at install time pointing at a
-## predictable system path.
+## predictable system path. databricks-codex ships the same 6 targets
+## alongside databricks-claude — no credential-helper alias, no .pkg/MDM
+## surface (codex is CLI-only).
 dist:
 	mkdir -p dist
 	GOOS=darwin  GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-claude-darwin-arm64  ./cmd/databricks-claude
@@ -65,6 +71,12 @@ dist:
 	GOOS=linux   GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-claude-linux-arm64   ./cmd/databricks-claude
 	GOOS=windows GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-claude-windows-amd64.exe ./cmd/databricks-claude
 	GOOS=windows GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-claude-windows-arm64.exe ./cmd/databricks-claude
+	GOOS=darwin  GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-codex-darwin-arm64  ./cmd/databricks-codex
+	GOOS=darwin  GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-codex-darwin-amd64  ./cmd/databricks-codex
+	GOOS=linux   GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-codex-linux-amd64   ./cmd/databricks-codex
+	GOOS=linux   GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-codex-linux-arm64   ./cmd/databricks-codex
+	GOOS=windows GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-codex-windows-amd64.exe ./cmd/databricks-codex
+	GOOS=windows GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o dist/databricks-codex-windows-arm64.exe ./cmd/databricks-codex
 
 ## Build a universal2 macOS .pkg installer. Set APPLE_INTERNAL_SIGNING_IDENTITY
 ## to codesign the binary inside the pkg with hardened-runtime flags; otherwise
@@ -152,7 +164,7 @@ generate-signing-cert:
 
 ## Remove build artifacts
 clean:
-	rm -f databricks-claude databricks-claude-credential-helper
+	rm -f databricks-claude databricks-claude-credential-helper databricks-codex
 	rm -rf dist/ build/ root/ scripts/postinstall
 
 ## Run go vet

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Transparent proxy wrapper for Claude Code that auto-refreshes Databricks OAuth tokens — so you never manually paste a token again.
 
+> This repo also ships **`databricks-codex`**, the same idea for the OpenAI Codex CLI. It's a smaller tool — no Desktop/MDM surface, no daemon — documented in its own [`databricks-codex`](#databricks-codex) section below. Everything else on this page is about `databricks-claude`.
+
 ## The Problem
 
 Databricks AI Gateway supports short-lived OAuth tokens. Claude Code only supports a static `ANTHROPIC_AUTH_TOKEN` in `~/.claude/settings.json`. Without this tool, you'd need to configure long-living credentials with PAT tokens.
@@ -40,6 +42,8 @@ Download the latest release from the [releases page](https://github.com/IceRhyme
 ```bash
 go install github.com/IceRhymers/databricks-agents/cmd/databricks-claude@latest
 ```
+
+This module also builds `databricks-codex` (`go install github.com/IceRhymers/databricks-agents/cmd/databricks-codex@latest`) — see [`databricks-codex`](#databricks-codex) below for its own install/usage.
 
 ## Pick Your Setup
 
@@ -1048,6 +1052,137 @@ export DATABRICKS_NO_UPDATE_CHECK=1
 ```
 
 Both suppress the startup check and disable the `update` subcommand.
+
+## databricks-codex
+
+> **Disclaimer:** Same as above — unofficial, community-built, not supported or endorsed by Databricks or OpenAI. Use at your own risk.
+
+Transparent proxy wrapper for the [OpenAI Codex CLI](https://github.com/openai/codex) that auto-refreshes Databricks OAuth tokens and surgically patches `~/.codex/config.toml` so Codex authenticates through your Databricks AI Gateway. Everything above this section is about `databricks-claude`; `databricks-codex` is a smaller, sibling tool built from the same module (`github.com/IceRhymers/databricks-agents`) and sharing the same underlying proxy engine — but it has **no daemon, no Claude Desktop/MDM surface, no model auto-discovery, and no local web-search fulfilment**. Its config file is TOML (not a settings.json env block), so it's re-patched at the start of every session rather than bootstrapped once.
+
+### Prerequisites
+
+- [Databricks CLI](https://docs.databricks.com/dev-tools/cli/databricks-cli.html) installed and authenticated (`databricks auth login`)
+- [Codex CLI](https://github.com/openai/codex) installed (`codex` on your `PATH`)
+- A Databricks Model Serving endpoint with [AI Gateway](https://docs.databricks.com/aws/en/ai-gateway/) enabled, exposing an OpenAI-compatible model
+- Go 1.22+ (only required if building from source)
+
+### Install
+
+```bash
+go install github.com/IceRhymers/databricks-agents/cmd/databricks-codex@latest
+```
+
+Or clone this repo and `make build` (produces `./databricks-codex` alongside `./databricks-claude`; see [Development](#development)).
+
+### Quick Start
+
+Use it exactly like `codex` — every flag and argument not recognized by the wrapper is forwarded:
+
+```bash
+# Use exactly like codex:
+databricks-codex "explain this codebase"
+
+# With a specific Databricks CLI profile and model:
+databricks-codex --profile my-workspace --model databricks-gpt-5-5 "write tests for auth.py"
+
+# Verbose logging:
+databricks-codex --verbose "fix the bug in main.go"
+```
+
+On each run, `databricks-codex` binds a local proxy, patches `~/.codex/config.toml` to point a `databricks-proxy` model provider at it, and launches `codex` as a child. The first run authenticates you (browser SSO) if needed.
+
+### Session Hooks (recommended)
+
+Like `databricks-claude`, install hooks so every Codex session auto-starts the proxy — no manual `serve` needed:
+
+```bash
+databricks-codex hooks install
+databricks-codex hooks uninstall   # remove later
+```
+
+`hooks install` adds a `SessionStart` entry to `~/.codex/hooks.json` (calls `databricks-codex hooks session-start`, which starts a refcounted background proxy if one isn't already healthy) and flips `[features] hooks = true` in `config.toml` so Codex actually reads `hooks.json`. Idempotent — safe to re-run after upgrades.
+
+**Unlike `databricks-claude`, there is no SessionEnd hook** — the Codex CLI has no session-end event to hook into. The background proxy instead relies entirely on its idle timeout (default 30 minutes, configurable via `serve --idle-timeout`) to exit when nothing is using it.
+
+### `config` Subcommand
+
+Smaller than `databricks-claude`'s: no `config write` (there's no settings.json-style bootstrap to run once — `config.toml` is re-patched automatically at the start of every session) and no `config websearch` (codex has no local web-search/web-fetch fulfilment).
+
+```
+config otel enable  [--metrics-table T] [--logs-table T] [--profile P]
+config otel disable [--metrics] [--logs]      # no flags = disable both
+config show [--profile P]
+```
+
+OTEL table preferences persist to `~/.codex/.databricks-codex.json`; the `[otel]` section in `config.toml` is written or removed by the proxy lifecycle the next time a session starts (codex routes metrics + logs only — no traces signal). `config otel disable` preserves table-name preferences so a later `config otel enable` restores them without re-typing:
+
+```bash
+databricks-codex config otel enable \
+  --metrics-table main.codex_telemetry.codex_otel_metrics \
+  --logs-table   main.codex_telemetry.codex_otel_logs
+
+databricks-codex config otel disable          # both signals off, tables preserved
+databricks-codex config show                  # diagnostic dump (token redacted)
+```
+
+### `serve` Subcommand
+
+`databricks-codex serve` runs the proxy standalone without launching `codex` — used by IDE extensions, external tooling, and the SessionStart hook. Unlike `databricks-claude serve`, codex has **no daemon lifecycle** — `serve` is a single leaf command with no `--session-mode`/`--daemon` split and no `install`/`uninstall`/`status` sub-subcommands, since codex has no LaunchAgent/systemd/schtasks equivalent.
+
+```bash
+databricks-codex serve
+# prints: PROXY_URL=http://127.0.0.1:<port>
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--idle-timeout` | `30m` | Idle timeout (`0` disables); e.g. `30s`, `5m`, `1h` |
+| `--profile` | state → `DEFAULT` | Databricks CLI profile |
+| `--port` | state → `49154` | Proxy listen port |
+| `--model` | saved for future sessions | Model name |
+| `--upstream` | auto-discovered | Override the AI Gateway URL |
+| `--log-file` | | Write debug logs to a file |
+| `--verbose`, `-v` | `false` | Enable debug logging to stderr |
+| `--proxy-api-key` | | Require Bearer token auth on all proxy requests |
+| `--tls-cert`, `--tls-key` | | Enable TLS on the proxy listener |
+| `--no-update-check` | | Skip the automatic update check on startup |
+| `--help`, `-h` | | Show this help message |
+
+The proxy exits on SIGINT/SIGTERM, `POST /shutdown`, or when `--idle-timeout` elapses with zero in-flight requests.
+
+### Flags Reference (root wrapper)
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--profile` | `DEFAULT` | Databricks CLI profile (saved for future sessions) |
+| `--model` | `databricks-gpt-5-5` | Model name (saved for future sessions) |
+| `--upstream` | auto-discovered | Override the AI Gateway URL |
+| `--verbose`, `-v` | `false` | Enable debug logging to stderr |
+| `--log-file` | | Write debug logs to a file (combinable with `--verbose`) |
+| `--proxy-api-key` | | Require Bearer token auth on all proxy requests |
+| `--port` | `49154` | Fixed proxy port (saved to state) |
+| `--tls-cert`, `--tls-key` | | Enable TLS on the proxy listener |
+| `--no-update-check` | | Skip the automatic update check on startup |
+| `--version` | | Print version and exit |
+| `--help`, `-h` | | Print the wrapper's flags and exit. Use `databricks-codex -- --help` to forward to codex's own `--help`. |
+
+All other flags and args are forwarded to `codex`. As with `databricks-claude`, `DATABRICKS_CONFIG_PROFILE` is intentionally not consulted during profile resolution (flag → saved state → `DEFAULT`), so an injected env var can't silently override your saved choice.
+
+### How It Works
+
+`databricks-codex` wraps the `codex` binary. On every invocation (wrapper mode or `serve`) it:
+
+1. Resolves profile/model (flag → saved state → default) and persists explicit choices to `~/.codex/.databricks-codex.json`.
+2. Authenticates (`authcheck.EnsureAuthenticated`, browser SSO fallback) and discovers your workspace host + AI Gateway URL (`{host}/ai-gateway/openai/v1`).
+3. Binds a local HTTP proxy on the configured port (default `49154`).
+4. Surgically patches `~/.codex/config.toml`: sets the root `profile = "databricks-proxy"`, writes a `[profiles.databricks-proxy]` section pinning `model`, and a `[model_providers.databricks-proxy]` section with `base_url` pointed at the local proxy and `wire_api = "responses"`. Only these managed keys/sections are touched — all other content in `config.toml` is preserved byte-for-byte. If OTEL is enabled, an `[otel]` section is added/updated (removed entirely when both signals are off).
+5. Launches `codex` as a child (wrapper mode only — `serve` doesn't launch anything).
+6. Injects fresh Databricks OAuth tokens on every proxied request (auto-refreshed from `databricks auth token`).
+7. Tracks concurrent sessions with a ref-count; the last session out closes the listener.
+
+### Automatic Update Check
+
+Same mechanism as `databricks-claude` (see [Automatic Update Check](#automatic-update-check) above): a 24-hour cached check on startup, force-checkable via `databricks-codex update`, opt out with `--no-update-check` or `DATABRICKS_NO_UPDATE_CHECK=1`.
 
 ## Development
 

--- a/cmd/databricks-codex/cli_config.go
+++ b/cmd/databricks-codex/cli_config.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/IceRhymers/databricks-agents/internal/cmd"
+)
+
+// runConfigCommand implements the `databricks-codex config ...` dispatcher.
+// args is everything after the literal "config" token. Routes to the otel
+// or show runner. Bare `config` (no args) prints help and exits 2 — same
+// convention as the rest of the binary's subcommand-with-no-action paths.
+//
+// The persistent-config editor was previously a sprawl of 7 root flags
+// (--otel, --no-otel*, --otel-*-table, --print-env); #87 consolidates them
+// under this tree and removes them from the root. Storage semantics — state
+// file table preservation across `config otel disable`, [otel] section
+// removal (not just skip-the-write) when both signals are off — are
+// unchanged; this is a pure surface reshape. The pure-function resolver
+// (resolveConfigOTEL) makes the orchestration matrix testable in isolation;
+// helper-level tests passing while composition is broken is the known
+// failure mode for this kind of refactor, and the matrix test in
+// cli_config_test.go is the safety net.
+func runConfigCommand(args []string) {
+	if len(args) == 0 {
+		_ = cmd.Render(os.Stderr, configCommand, nil)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "otel":
+		runConfigOTEL(args[1:])
+	case "show":
+		runConfigShow(args[1:])
+	case "--help", "-h", "help":
+		_ = cmd.Render(os.Stdout, configCommand, nil)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-codex: unknown config subcommand %q\n\n", args[0])
+		_ = cmd.Render(os.Stderr, configCommand, nil)
+		os.Exit(1)
+	}
+}
+
+// configOTELResolution is the pure-function projection of the OTEL enable
+// resolution chain. Extracted so the orchestration matrix test (state
+// empty/populated × explicit table flags × derive-logs-from-metrics) can
+// drive it in isolation. Caller is responsible for the post-resolve state
+// persistence write.
+type configOTELResolution struct {
+	MetricsTable string
+	LogsTable    string
+	NewState     persistentState // state to persist (callers gate the write on StateMutated)
+	StateMutated bool            // true when NewState differs from the input saved state
+}
+
+// resolveConfigOTEL performs the OTEL enable-side resolution that the legacy
+// resolveOtel did inline for the regular session path. Pure function: no
+// I/O, no global state, no defaults applied at this layer. Drives the
+// orchestration matrix test (#87 acceptance criterion).
+//
+// Resolution chain per signal: explicit flag > saved state > (logs only:
+// derive from metrics) > unset. The bare-toggle metrics default (the legacy
+// `else if metricsTable == "" && a.Otel` branch in main.go) is applied by
+// the caller (runConfigOTELEnable), NOT here — this mirrors the pattern
+// caught in databricks-claude PR #172 round-1 review where a shared
+// resolver applying a default that only one caller should get is the bug
+// class. Codex's surface only has one caller right now (`config otel
+// enable`), but keeping the resolver pure makes it easier to reuse if the
+// future #88/#89 work needs it.
+//
+// The Disabled flags on the input saved state are CLEARED in NewState
+// (config otel enable un-sticks a previous disable). Sentinel-guard the
+// persist: NewState is only meaningfully different when an explicit flag
+// was passed OR a Disabled flag was previously set.
+func resolveConfigOTEL(
+	saved persistentState,
+	metricsTableFlag string, metricsTableSet bool,
+	logsTableFlag string, logsTableSet bool,
+) configOTELResolution {
+	r := configOTELResolution{
+		MetricsTable: saved.OtelMetricsTable,
+		LogsTable:    saved.OtelLogsTable,
+		NewState:     saved,
+	}
+
+	if metricsTableSet {
+		r.MetricsTable = metricsTableFlag
+	}
+
+	if logsTableSet {
+		r.LogsTable = logsTableFlag
+	} else if r.LogsTable == "" && r.MetricsTable != "" {
+		r.LogsTable = deriveLogsTable(r.MetricsTable)
+	}
+
+	mutated := false
+	if metricsTableSet && r.MetricsTable != "" && r.NewState.OtelMetricsTable != r.MetricsTable {
+		r.NewState.OtelMetricsTable = r.MetricsTable
+		mutated = true
+	}
+	if logsTableSet && r.LogsTable != "" && r.NewState.OtelLogsTable != r.LogsTable {
+		r.NewState.OtelLogsTable = r.LogsTable
+		mutated = true
+	}
+	// Enable always clears any sticky disable bit so the next session emits
+	// the [otel] section. If neither was set, no mutation.
+	if r.NewState.OtelMetricsDisabled {
+		r.NewState.OtelMetricsDisabled = false
+		mutated = true
+	}
+	if r.NewState.OtelLogsDisabled {
+		r.NewState.OtelLogsDisabled = false
+		mutated = true
+	}
+	r.StateMutated = mutated
+	return r
+}
+
+// runConfigOTEL implements `databricks-codex config otel <enable|disable>`.
+func runConfigOTEL(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "databricks-codex: 'config otel' requires a subcommand: enable or disable")
+		_ = cmd.Render(os.Stderr, *configCommand.Subcommand("otel"), nil)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "enable":
+		runConfigOTELEnable(args[1:])
+	case "disable":
+		runConfigOTELDisable(args[1:])
+	case "--help", "-h", "help":
+		_ = cmd.Render(os.Stdout, *configCommand.Subcommand("otel"), nil)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-codex: unknown config otel subcommand %q\n\n", args[0])
+		_ = cmd.Render(os.Stderr, *configCommand.Subcommand("otel"), nil)
+		os.Exit(1)
+	}
+}
+
+// runConfigOTELEnable implements `databricks-codex config otel enable`.
+// Persists the resolved table preferences to the state file. config.toml is
+// NOT touched — the proxy lifecycle re-emits the [otel] section based on
+// state at the next session start.
+func runConfigOTELEnable(args []string) {
+	node := configCommand.Subcommand("otel").Subcommand("enable")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	saved := loadState()
+	profile := r.Strings["profile"]
+	if profile == "" {
+		profile = saved.Profile
+	}
+	if profile == "" {
+		profile = "DEFAULT"
+	}
+
+	// Validate profile reachability before persisting anything — fail fast
+	// with an actionable error rather than writing state for a profile that
+	// is broken at next session start.
+	if _, err := DiscoverHost("", profile); err != nil {
+		log.Fatalf("databricks-codex: config otel enable: failed to discover host for profile %q: %v\n"+
+			"Run 'databricks auth login --profile %s' first", profile, err, profile)
+	}
+
+	res := resolveConfigOTEL(
+		saved,
+		r.Strings["metrics-table"], r.Set["metrics-table"],
+		r.Strings["logs-table"], r.Set["logs-table"],
+	)
+
+	// Caller-level metrics default: a bare `config otel enable` (no flags,
+	// empty state) inherits the legacy --otel default table. The resolver
+	// itself is kept pure so it never invents a table name; the default
+	// fallback is the caller's policy decision. Mirrors the
+	// applyMetricsDefault gate in databricks-claude's resolveConfigOTEL,
+	// implemented here as a caller-side branch since codex only has one
+	// caller (no shared resolver to risk).
+	if res.MetricsTable == "" && !r.Set["metrics-table"] && !r.Set["logs-table"] {
+		res.MetricsTable = "main.codex_telemetry.codex_otel_metrics"
+		if res.LogsTable == "" {
+			res.LogsTable = deriveLogsTable(res.MetricsTable)
+		}
+		// Bare-toggle default is intentionally NOT persisted to state — the
+		// next session resolves the same default fresh if state is still
+		// empty. Persisting it would silently lock a fleet to a default the
+		// user never asked for.
+	}
+
+	if res.StateMutated {
+		if err := saveState(res.NewState); err != nil {
+			log.Fatalf("databricks-codex: config otel enable: could not persist OTEL tables: %v", err)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "databricks-codex: OTEL enabled (profile=%s, metrics=%s, logs=%s). Take effect on next 'databricks-codex' invocation.\n",
+		profile, displayTableOrNone(res.MetricsTable), displayTableOrNone(res.LogsTable))
+}
+
+// runConfigOTELDisable implements `databricks-codex config otel disable`.
+// Sets the per-signal "disabled" sticky bits in the state file. The proxy
+// lifecycle reads these on the next session start and removes the [otel]
+// section from config.toml when all signals are off. Table-name
+// preferences are PRESERVED so a future `config otel enable` restores them.
+func runConfigOTELDisable(args []string) {
+	node := configCommand.Subcommand("otel").Subcommand("disable")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	saved := loadState()
+	clearMetrics := r.Bools["metrics"]
+	clearLogs := r.Bools["logs"]
+
+	// No flags = both signals (the legacy --no-otel nuclear option).
+	if !clearMetrics && !clearLogs {
+		clearMetrics = true
+		clearLogs = true
+	}
+
+	mutated := false
+	if clearMetrics && !saved.OtelMetricsDisabled {
+		saved.OtelMetricsDisabled = true
+		mutated = true
+	}
+	if clearLogs && !saved.OtelLogsDisabled {
+		saved.OtelLogsDisabled = true
+		mutated = true
+	}
+
+	if mutated {
+		if err := saveState(saved); err != nil {
+			log.Fatalf("databricks-codex: config otel disable: could not persist OTEL disable: %v", err)
+		}
+	}
+
+	switch {
+	case clearMetrics && clearLogs:
+		fmt.Fprintln(os.Stderr, "databricks-codex: OTEL disabled — [otel] section will be removed from config.toml on the next session start (state file table preferences preserved)")
+	case clearMetrics:
+		fmt.Fprintln(os.Stderr, "databricks-codex: OTEL metrics disabled (logs preserved if previously enabled; state file table preferences preserved)")
+	case clearLogs:
+		fmt.Fprintln(os.Stderr, "databricks-codex: OTEL logs disabled (metrics preserved if previously enabled; state file table preferences preserved)")
+	}
+}
+
+// runConfigShow implements `databricks-codex config show` — the legacy
+// --print-env flow lifted into a subcommand. Read-only diagnostic.
+func runConfigShow(args []string) {
+	node := configCommand.Subcommand("show")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	saved := loadState()
+	profile := r.Strings["profile"]
+	if profile == "" {
+		profile = saved.Profile
+	}
+	if profile == "" {
+		profile = "DEFAULT"
+	}
+
+	host, err := DiscoverHost("", profile)
+	if err != nil {
+		log.Fatalf("databricks-codex: config show: failed to discover host for profile %q: %v\n"+
+			"Run 'databricks auth login --profile %s' first", profile, err, profile)
+	}
+	gatewayURL := ConstructGatewayURL(host)
+
+	tp := NewTokenProvider("", profile)
+	token, err := tp.Token(context.Background())
+	if err != nil {
+		log.Fatalf("databricks-codex: config show: failed to fetch token for profile %q: %v", profile, err)
+	}
+
+	model := resolveModel("", saved.Model)
+
+	// resolveOtel reads from saved state (no flag input — the session
+	// flags are gone with #87). Mirrors what the regular session path
+	// will read at next start.
+	_, metricsTable, logsTable := resolveOtel(saved)
+
+	handlePrintEnv(host, gatewayURL, token, profile, model, metricsTable, logsTable)
+}
+
+// displayTableOrNone returns the literal table name or "(none)" when empty,
+// for the confirmation log line emitted by `config otel enable`.
+func displayTableOrNone(t string) string {
+	if t == "" {
+		return "(none)"
+	}
+	return t
+}

--- a/cmd/databricks-codex/cli_config_test.go
+++ b/cmd/databricks-codex/cli_config_test.go
@@ -1,0 +1,401 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/IceRhymers/databricks-agents/internal/cmd"
+)
+
+// --- #87 config tree parity tests ---
+//
+// Bidirectional contract: every flag declared on a config leaf must be
+// consumed by its runner, and every flag the runner consumes must be
+// declared on the leaf. The hand-rolled flag scanners in cli_config.go
+// drive parseResult lookups; the only way to fail loudly when one side
+// drifts is an explicit per-leaf parity test.
+//
+// Bidirectional-verification note: temporarily removing configCommand
+// from rootCommand.Subcommands fails TestRootHasConfigSubcommand; adding
+// an extra flag to a leaf without wiring it into the runner fails the
+// `assertConfigFlagSetEqual` "declares but does not consume" arm. Both
+// directions exercised manually during #87 development to confirm the
+// parity tests fire.
+
+func TestConfigCommandParity(t *testing.T) {
+	assertConfigFlagSetEqual(t, "configCommand", configCommand, []string{})
+}
+
+func TestConfigOTELEnableParity(t *testing.T) {
+	otel := configCommand.Subcommand("otel")
+	if otel == nil {
+		t.Fatal("configCommand should have an `otel` subcommand")
+	}
+	enable := otel.Subcommand("enable")
+	if enable == nil {
+		t.Fatal("config otel should have an `enable` subcommand")
+	}
+	assertConfigFlagSetEqual(t, "config otel enable", *enable, []string{
+		"metrics-table", "logs-table", "profile", "help",
+	})
+}
+
+func TestConfigOTELDisableParity(t *testing.T) {
+	otel := configCommand.Subcommand("otel")
+	if otel == nil {
+		t.Fatal("configCommand should have an `otel` subcommand")
+	}
+	disable := otel.Subcommand("disable")
+	if disable == nil {
+		t.Fatal("config otel should have a `disable` subcommand")
+	}
+	assertConfigFlagSetEqual(t, "config otel disable", *disable, []string{
+		"metrics", "logs", "help",
+	})
+}
+
+func TestConfigShowParity(t *testing.T) {
+	show := configCommand.Subcommand("show")
+	if show == nil {
+		t.Fatal("configCommand should have a `show` subcommand")
+	}
+	assertConfigFlagSetEqual(t, "config show", *show, []string{"profile", "help"})
+}
+
+// TestConfigHasNestedSubcommands asserts the otel/show children are declared
+// so completion can offer them nested. Locks in the surface of the new tree.
+func TestConfigHasNestedSubcommands(t *testing.T) {
+	want := []string{"otel", "show"}
+	got := make(map[string]bool, len(configCommand.Subcommands))
+	for _, s := range configCommand.Subcommands {
+		got[s.Name] = true
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("configCommand should have nested `%s` subcommand", w)
+		}
+	}
+}
+
+// TestRootHasConfigSubcommand is the structural counterpart to the breaking
+// change in #87: the root tree must declare config so dispatch from
+// main.go (and shell completion) finds it.
+func TestRootHasConfigSubcommand(t *testing.T) {
+	for _, s := range rootCommand.Subcommands {
+		if s.Name == "config" {
+			return
+		}
+	}
+	t.Error("rootCommand must declare a `config` subcommand (the surface introduced in #87)")
+}
+
+// TestRootCommandLegacyOTELFlagsRemoved locks the breaking surface change
+// from #87: the legacy --otel*/--print-env flags must NOT appear on
+// rootCommand any more. If a future refactor accidentally re-adds one, this
+// test fires and points at the migration sub-issue.
+func TestRootCommandLegacyOTELFlagsRemoved(t *testing.T) {
+	declared := flagNameSetForConfig(rootCommand)
+	for _, flag := range []string{
+		"otel", "no-otel", "no-otel-metrics", "no-otel-logs",
+		"otel-metrics-table", "otel-logs-table",
+		"print-env",
+	} {
+		if declared[flag] {
+			t.Errorf("rootCommand still declares --%s after #87 migration; the user-facing flag must move to `config otel ...` / `config show`", flag)
+		}
+	}
+}
+
+// --- #87 OTEL orchestration matrix test ---
+//
+// AC requirement: "Orchestration matrix test ported: state empty/populated
+// × explicit table flags — assert the final resolved (metricsTable,
+// logsTable) tuple plus the persisted state shape."
+//
+// Drives the pure resolveConfigOTEL function. Helper-level tests passing
+// while composition is broken is the known failure mode for refactors of
+// this shape; this matrix covers the cross-product so a regression in any
+// branch of the resolver fails the suite loudly.
+
+func TestResolveConfigOTEL_OrchestrationMatrix(t *testing.T) {
+	emptyState := persistentState{}
+	populatedState := persistentState{
+		OtelMetricsTable: "main.team.metrics_prior",
+		OtelLogsTable:    "main.team.logs_prior",
+	}
+	disabledState := persistentState{
+		OtelMetricsTable:    "main.team.metrics_prior",
+		OtelLogsTable:       "main.team.logs_prior",
+		OtelMetricsDisabled: true,
+		OtelLogsDisabled:    true,
+	}
+
+	type wantTuple struct {
+		metrics, logs       string
+		stateMetrics        string
+		stateLogs           string
+		stateMetricsDisable bool
+		stateLogsDisable    bool
+		stateMutated        bool
+	}
+
+	cases := []struct {
+		name        string
+		saved       persistentState
+		metricsFlag string
+		metricsSet  bool
+		logsFlag    string
+		logsSet     bool
+		want        wantTuple
+	}{
+		{
+			// Bare invocation, empty state: resolver itself emits empty
+			// tables — the bare-toggle metrics default is the caller's
+			// policy decision (runConfigOTELEnable applies it). Pure-
+			// resolver test asserts the resolver does NOT invent a table
+			// name on its own.
+			name:  "empty state, no flags: resolver emits empty tables (caller applies default)",
+			saved: emptyState,
+			want: wantTuple{
+				metrics:      "",
+				logs:         "",
+				stateMutated: false,
+			},
+		},
+		{
+			name:        "empty state, --metrics-table only → derives logs, persists metrics",
+			saved:       emptyState,
+			metricsFlag: "cat.s.m",
+			metricsSet:  true,
+			want: wantTuple{
+				metrics:      "cat.s.m",
+				logs:         "cat.s.m_otel_logs",
+				stateMetrics: "cat.s.m",
+				stateMutated: true,
+			},
+		},
+		{
+			name:        "empty state, both metrics and logs explicit → no derivation, both persisted",
+			saved:       emptyState,
+			metricsFlag: "cat.s.m",
+			metricsSet:  true,
+			logsFlag:    "cat.s.l",
+			logsSet:     true,
+			want: wantTuple{
+				metrics:      "cat.s.m",
+				logs:         "cat.s.l",
+				stateMetrics: "cat.s.m",
+				stateLogs:    "cat.s.l",
+				stateMutated: true,
+			},
+		},
+		{
+			name:  "populated state, no flags → state values preserved, no mutation",
+			saved: populatedState,
+			want: wantTuple{
+				metrics:      "main.team.metrics_prior",
+				logs:         "main.team.logs_prior",
+				stateMetrics: "main.team.metrics_prior",
+				stateLogs:    "main.team.logs_prior",
+				stateMutated: false,
+			},
+		},
+		{
+			name:        "populated state, --metrics-table same as state → no mutation",
+			saved:       populatedState,
+			metricsFlag: "main.team.metrics_prior",
+			metricsSet:  true,
+			want: wantTuple{
+				metrics:      "main.team.metrics_prior",
+				logs:         "main.team.logs_prior",
+				stateMetrics: "main.team.metrics_prior",
+				stateLogs:    "main.team.logs_prior",
+				stateMutated: false,
+			},
+		},
+		{
+			name:        "populated state, --metrics-table changes value → mutation",
+			saved:       populatedState,
+			metricsFlag: "main.team.metrics_new",
+			metricsSet:  true,
+			want: wantTuple{
+				metrics:      "main.team.metrics_new",
+				logs:         "main.team.logs_prior",
+				stateMetrics: "main.team.metrics_new",
+				stateLogs:    "main.team.logs_prior",
+				stateMutated: true,
+			},
+		},
+		{
+			// `config otel disable` previously stuck the disable bits;
+			// `config otel enable` (even with no flags) must clear them
+			// so the next session emits the [otel] section. This is the
+			// round-trip that the two-store model requires.
+			name:  "disabled state, no flags → tables preserved, Disabled bits cleared",
+			saved: disabledState,
+			want: wantTuple{
+				metrics:             "main.team.metrics_prior",
+				logs:                "main.team.logs_prior",
+				stateMetrics:        "main.team.metrics_prior",
+				stateLogs:           "main.team.logs_prior",
+				stateMetricsDisable: false,
+				stateLogsDisable:    false,
+				stateMutated:        true,
+			},
+		},
+		{
+			// Empty-state with --logs-table only: logs flag wins, metrics
+			// stays empty (the resolver does NOT apply the bare-toggle
+			// metrics default — that's the caller's job).
+			name:    "empty state, --logs-table only → logs persisted, metrics still empty",
+			saved:   emptyState,
+			logsFlag: "cat.s.l",
+			logsSet: true,
+			want: wantTuple{
+				metrics:      "",
+				logs:         "cat.s.l",
+				stateMetrics: "",
+				stateLogs:    "cat.s.l",
+				stateMutated: true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := resolveConfigOTEL(tc.saved,
+				tc.metricsFlag, tc.metricsSet,
+				tc.logsFlag, tc.logsSet,
+			)
+
+			if res.MetricsTable != tc.want.metrics {
+				t.Errorf("MetricsTable: got %q, want %q", res.MetricsTable, tc.want.metrics)
+			}
+			if res.LogsTable != tc.want.logs {
+				t.Errorf("LogsTable: got %q, want %q", res.LogsTable, tc.want.logs)
+			}
+			if got, want := res.NewState.OtelMetricsTable, tc.want.stateMetrics; got != want {
+				t.Errorf("NewState.OtelMetricsTable: got %q, want %q", got, want)
+			}
+			if got, want := res.NewState.OtelLogsTable, tc.want.stateLogs; got != want {
+				t.Errorf("NewState.OtelLogsTable: got %q, want %q", got, want)
+			}
+			if got, want := res.NewState.OtelMetricsDisabled, tc.want.stateMetricsDisable; got != want {
+				t.Errorf("NewState.OtelMetricsDisabled: got %v, want %v", got, want)
+			}
+			if got, want := res.NewState.OtelLogsDisabled, tc.want.stateLogsDisable; got != want {
+				t.Errorf("NewState.OtelLogsDisabled: got %v, want %v", got, want)
+			}
+			if res.StateMutated != tc.want.stateMutated {
+				t.Errorf("StateMutated: got %v, want %v", res.StateMutated, tc.want.stateMutated)
+			}
+		})
+	}
+}
+
+// TestResolveConfigOTEL_OnlyExplicitFlagsPersist asserts the sentinel-guard
+// invariant: a value derived purely from saved state (no explicit flag)
+// must NOT be re-persisted with a "mutated" flag. This is the issue-#149
+// footgun that bit databricks-claude — assert it here so the codex
+// resolver doesn't grow the same bug class.
+func TestResolveConfigOTEL_OnlyExplicitFlagsPersist(t *testing.T) {
+	saved := persistentState{
+		OtelMetricsTable: "main.team.metrics_prior",
+	}
+	res := resolveConfigOTEL(saved,
+		"", false, // no metrics-table flag — derived from state
+		"", false,
+	)
+	if res.StateMutated {
+		t.Errorf("StateMutated must be false when no explicit flag was passed; resolver should not echo state-derived values back to state. NewState=%+v", res.NewState)
+	}
+}
+
+// TestConfigOTELEnableDisableRoundTrip exercises the full enable→disable→
+// re-enable round trip end-to-end via the resolver, asserting the
+// state-preservation invariant the two-store model promises:
+//
+//  1. enable persists tables.
+//  2. disable sets Disabled bits but leaves table names intact.
+//  3. re-enable (no flags) clears the Disabled bits and resurfaces the
+//     same tables — no re-typing required.
+func TestConfigOTELEnableDisableRoundTrip(t *testing.T) {
+	// Step 1: empty state + explicit tables → enabled with both persisted.
+	step1 := resolveConfigOTEL(persistentState{},
+		"main.team.m", true,
+		"main.team.l", true,
+	)
+	if step1.NewState.OtelMetricsTable != "main.team.m" || step1.NewState.OtelLogsTable != "main.team.l" {
+		t.Fatalf("step 1 state not persisted as expected: %+v", step1.NewState)
+	}
+
+	// Step 2: simulate `config otel disable` — both Disabled bits true,
+	// tables preserved.
+	disabled := step1.NewState
+	disabled.OtelMetricsDisabled = true
+	disabled.OtelLogsDisabled = true
+
+	// resolveOtel (the SESSION reader) sees both signals off.
+	if otel, m, l := resolveOtel(disabled); otel || m != "" || l != "" {
+		t.Errorf("after disable, session resolveOtel must see signals off; got otel=%v metrics=%q logs=%q", otel, m, l)
+	}
+
+	// Step 3: re-enable with no flags. Resolver clears Disabled bits and
+	// re-emits the same tables.
+	step3 := resolveConfigOTEL(disabled, "", false, "", false)
+	if step3.MetricsTable != "main.team.m" {
+		t.Errorf("re-enable MetricsTable: got %q, want %q (round-trip preserved)", step3.MetricsTable, "main.team.m")
+	}
+	if step3.LogsTable != "main.team.l" {
+		t.Errorf("re-enable LogsTable: got %q, want %q (round-trip preserved)", step3.LogsTable, "main.team.l")
+	}
+	if step3.NewState.OtelMetricsDisabled || step3.NewState.OtelLogsDisabled {
+		t.Errorf("re-enable must clear Disabled bits; got %+v", step3.NewState)
+	}
+	if !step3.StateMutated {
+		t.Error("re-enable must mark state mutated (Disabled bits flipping false counts as a mutation)")
+	}
+}
+
+// TestConfigCommandHelpRendersSubcommandNames is a light smoke check on
+// the help layer: the configCommand Long body must mention each surface
+// the README documents (otel enable/disable, show).
+func TestConfigCommandHelpRendersSubcommandNames(t *testing.T) {
+	out := configCommand.Long
+	for _, want := range []string{"otel enable", "otel disable", "show"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("configCommand.Long missing %q; help text drifted from runner surface", want)
+		}
+	}
+}
+
+// flagNameSetForConfig returns the set of long-flag names declared on a
+// tree node (Persistent ++ Flags). Local helper so cli_config_test.go has
+// no dependency on test helpers in main_test.go beyond what's needed.
+func flagNameSetForConfig(c cmd.Command) map[string]bool {
+	out := make(map[string]bool)
+	for _, f := range c.AllFlags() {
+		out[f.Name] = true
+	}
+	return out
+}
+
+// assertConfigFlagSetEqual fails if the actual flag set declared on c
+// differs from the expected slice. Bidirectional: extra flags on either
+// side surface as failures.
+func assertConfigFlagSetEqual(t *testing.T, label string, c cmd.Command, want []string) {
+	t.Helper()
+	got := flagNameSetForConfig(c)
+	wantSet := make(map[string]bool, len(want))
+	for _, w := range want {
+		wantSet[w] = true
+		if !got[w] {
+			t.Errorf("%s should declare --%s but does not (runner consumes it; tree must too)", label, w)
+		}
+	}
+	for n := range got {
+		if !wantSet[n] {
+			t.Errorf("%s declares --%s but its runner does not consume it (dead declaration; remove from tree or wire to runner)", label, n)
+		}
+	}
+}

--- a/cmd/databricks-codex/commands.go
+++ b/cmd/databricks-codex/commands.go
@@ -1,0 +1,527 @@
+package main
+
+import (
+	"github.com/IceRhymers/databricks-agents/internal/cmd"
+)
+
+// rootCommand is the source-of-truth declaration for the databricks-codex
+// CLI. It drives:
+//   - parseArgs → knownFlags (the set of "--flag" names the binary owns;
+//     anything else is forwarded transparently to the wrapped codex binary).
+//   - flagDefs (in completion_flags.go) → the bash/zsh/fish completion
+//     scripts (fed via pkg/completion).
+//
+// Adding a new root flag requires three edits:
+//  1. Append a FlagDef to Flags (or Persistent for inherited flags) here.
+//  2. Add a case to the switch in parseArgs (main.go) that wires the flag
+//     into the Args struct.
+//  3. Add the matching field to the Args struct.
+//
+// The parity tests in main_test.go (TestRootTreeFlagsAreParseRecognised,
+// TestParseArgsCasesAreDeclaredInRootTree) fail loudly if step 1 and 2
+// drift apart — the tree is the single source of truth.
+//
+// #86 migrated the root command onto the tree. #87 lifts the persistent-config
+// editor (the legacy --otel*/--print-env root flags) onto a discoverable
+// `config` subcommand; #88 lifts the hooks lifecycle flags
+// (--install-hooks / --uninstall-hooks / --headless-ensure) onto a `hooks`
+// subcommand. #89 lifts the remaining session-mode root flags (--headless,
+// --idle-timeout) onto a `serve` subcommand. All three sets of legacy
+// root-flag spellings are GONE in this revision. --profile and --port live
+// on Persistent so subcommand inheritance works for the migrated children.
+var rootCommand = cmd.Command{
+	Name:  "databricks-codex",
+	Short: "Databricks AI Gateway wrapper for OpenAI Codex CLI",
+
+	// Persistent flags are inherited by every subcommand once those
+	// commands migrate onto the tree (#89). Each migrated leaf
+	// (today: config + hooks children) re-declares --profile / --port
+	// locally where it consumes them — internal/cmd's parser does not
+	// yet walk ancestors, so this is the same shape as databricks-claude's
+	// configCommand leaves.
+	Persistent: []cmd.FlagDef{
+		{
+			Name:        "profile",
+			Description: "Databricks CLI profile (default: DEFAULT)",
+			TakesArg:    true,
+			Completer:   "__databricks_profiles",
+			StateKey:    "profile",
+			EnvVar:      "DATABRICKS_CONFIG_PROFILE",
+			MDMKey:      "databricksProfile",
+			Default:     "DEFAULT",
+		},
+		{
+			Name:        "port",
+			Description: "Proxy listen port (default: 49154)",
+			TakesArg:    true,
+			StateKey:    "port",
+			Default:     "49154",
+		},
+	},
+
+	// Order matches the legacy flagDefs slice so the bash/zsh/fish
+	// completion output stays byte-identical with the pre-tree binary
+	// for the flags that survived #87/#88/#89. The migrated OTEL/--print-env,
+	// hooks-lifecycle, and session-mode flags are gone from BOTH this slice
+	// and completion_flags.go's `order` — that is the breaking surface
+	// change.
+	Flags: []cmd.FlagDef{
+		{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
+		{Name: "version", Description: "Print version and exit"},
+		{Name: "help", Short: "h", Description: "Show help message"},
+		{Name: "model", Description: "Model to use (default: databricks-gpt-5-5)", TakesArg: true, StateKey: "model"},
+		{Name: "upstream", Description: "Override upstream codex binary path", TakesArg: true, Completer: "__files"},
+		{Name: "log-file", Description: "Write debug logs to file (combinable with --verbose)", TakesArg: true, Completer: "__files"},
+		{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
+		{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
+		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
+		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
+	},
+
+	// Subcommands declared on the root. completion and update dispatch
+	// from main.go directly. config (added in #87) carries its own
+	// dispatcher in cli_config.go. hooks (added in #88) carries its own
+	// dispatcher in hooks_cmd.go. serve (added in #89) carries its own
+	// dispatcher in serve_cmd.go.
+	Subcommands: []cmd.Command{
+		completionCommand,
+		updateCommand,
+		configCommand,
+		hooksCommand,
+		serveCommand,
+	},
+}
+
+// completionCommand declares the `completion` subcommand and its three
+// shell-target children. Dispatch lives in main.go (calls completion.Run);
+// the tree exists so shell completion can offer "completion <TAB>" → bash
+// / zsh / fish, and so the help renderer has a node to describe.
+var completionCommand = cmd.Command{
+	Name:  "completion",
+	Short: "Generate shell completion scripts (bash, zsh, fish)",
+	Subcommands: []cmd.Command{
+		{Name: "bash", Short: "Generate bash completion script"},
+		{Name: "zsh", Short: "Generate zsh completion script"},
+		{Name: "fish", Short: "Generate fish completion script"},
+	},
+}
+
+// updateCommand declares the `update` subcommand. Dispatch lives in main.go
+// (calls updater.Check + prints upgrade instructions).
+var updateCommand = cmd.Command{
+	Name:  "update",
+	Short: "Check for a newer release and print upgrade instructions",
+}
+
+// configCommand declares the `config` subcommand tree introduced in #87.
+// Consolidates the persistent-config root flags (--otel, --no-otel,
+// --no-otel-metrics, --no-otel-logs, --otel-metrics-table,
+// --otel-logs-table, --print-env) into a discoverable tree. Storage
+// semantics — state-file table preferences preserved across `config otel
+// disable`, ~/.codex/config.toml [otel] section *removal* (not just
+// skip-the-write) when both signals are off — are unchanged; this is a
+// pure surface reshape.
+//
+// Tree shape:
+//
+//	config
+//	├── otel
+//	│   ├── enable     [--metrics-table T] [--logs-table T]
+//	│   └── disable    [--metrics] [--logs]      (no flags = both signals)
+//	└── show           (was --print-env)
+//
+// Codex's surface is smaller than databricks-claude's: no `config write`
+// (codex has no settings.json env block — config.toml is patched at
+// session start by the proxy lifecycle, not by a one-shot bootstrap), no
+// `config websearch` (codex has no local websearch fulfilment), no
+// traces signal (codex's tomlconfig manages logs + metrics exporters
+// only).
+var configCommand = cmd.Command{
+	Name:  "config",
+	Short: "Persistent config editor (otel, show)",
+	Long:  configHelpTemplate,
+	Subcommands: []cmd.Command{
+		{
+			Name:  "otel",
+			Short: "Toggle OpenTelemetry signals (enable|disable)",
+			Long:  configOtelHelpTemplate,
+			Subcommands: []cmd.Command{
+				{
+					Name:  "enable",
+					Short: "Enable OTEL — persists table preferences to state for the next codex session",
+					Long:  configOtelEnableHelpTemplate,
+					Flags: []cmd.FlagDef{
+						{Name: "metrics-table", Description: "Unity Catalog table for OTEL metrics (cat.schema.table)", TakesArg: true, StateKey: "otel_metrics_table"},
+						{Name: "logs-table", Description: "Unity Catalog table for OTEL logs (cat.schema.table)", TakesArg: true, StateKey: "otel_logs_table"},
+						{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+						{Name: "help", Short: "h", Description: "Show help message"},
+					},
+				},
+				{
+					Name:  "disable",
+					Short: "Disable OTEL — clears the [otel] section from ~/.codex/config.toml on the next session start (state file preserved)",
+					Long:  configOtelDisableHelpTemplate,
+					Flags: []cmd.FlagDef{
+						{Name: "metrics", Description: "Disable only OTEL metrics (other signals untouched)"},
+						{Name: "logs", Description: "Disable only OTEL logs"},
+						{Name: "help", Short: "h", Description: "Show help message"},
+					},
+				},
+			},
+		},
+		{
+			Name:  "show",
+			Short: "Print resolved configuration (was --print-env)",
+			Long:  configShowHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+	},
+}
+
+// hooksCommand declares the `hooks` subcommand tree introduced in #88.
+// Consolidates the 3 hooks-lifecycle root flags (--install-hooks,
+// --uninstall-hooks, --headless-ensure) under a discoverable subcommand.
+// install/uninstall manage the SessionStart entries in ~/.codex/hooks.json;
+// session-start is hook-invoked refcount-managed proxy lifecycle internal
+// (formerly --headless-ensure).
+//
+// Tree shape:
+//
+//	hooks
+//	├── install        [--profile P] [--port N]
+//	├── uninstall
+//	└── session-start  [--port N]   (hook-invoked internal)
+//
+// The hook-install logic (installHooks/uninstallHooks in hooks.go) and the
+// proxy-ensure logic (headlessEnsure) are unchanged behaviorally — they
+// move behind tree commands. The detector that matches "databricks-codex
+// --headless"-prefixed entries continues to recognise hooks installed by
+// the legacy flag spellings, so a re-install replaces them cleanly with
+// the new "databricks-codex hooks session-start" command line.
+var hooksCommand = cmd.Command{
+	Name:  "hooks",
+	Short: "Session-hook deployment mode: install/uninstall + lifecycle internals",
+	Long:  hooksHelpTemplate,
+	Subcommands: []cmd.Command{
+		{
+			Name:  "install",
+			Short: "Install SessionStart hook into ~/.codex/hooks.json",
+			Long:  hooksInstallHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "uninstall",
+			Short: "Remove databricks-codex hooks from ~/.codex/hooks.json",
+			Long:  hooksUninstallHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "session-start",
+			Short: "Start proxy if not running (invoked by the SessionStart hook — internal)",
+			Long:  hooksSessionStartHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "port", Description: "Proxy listen port (default: saved state > 49154)", TakesArg: true, StateKey: "port", Default: "49154"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+	},
+}
+
+// serveCommand declares the `serve` subcommand introduced in #89.
+// Consolidates the legacy `--headless` and `--idle-timeout` root flags into
+// a discoverable subcommand. Mirrors databricks-claude #174's `serve
+// --session-mode` entrypoint with a deliberately smaller scope: codex has
+// no daemon mode (no LaunchAgent/Service equivalent), so install/uninstall/
+// status sub-subcommands are deferred.
+//
+// Tree shape:
+//
+//	serve   [--idle-timeout D] [--profile P] [--port N] [--model M]
+//	        [--upstream U] [--log-file F] [--verbose|-v]
+//	        [--proxy-api-key K] [--tls-cert C] [--tls-key K]
+//	        [--no-update-check]
+//
+// Behavior is byte-identical with the deleted `databricks-codex --headless`
+// path: the runner constructs the same Args struct that parseArgs used to,
+// sets Headless=true, and dispatches into the shared runProxyMode launcher.
+// The hook-spawn path (headlessEnsure → headless.Ensure) is updated to
+// invoke `databricks-codex serve --port=N` instead of the removed
+// `--headless --port=N` so the SessionStart hook keeps working.
+var serveCommand = cmd.Command{
+	Name:  "serve",
+	Short: "Run the proxy in headless mode (consolidates --headless / --idle-timeout)",
+	Long:  serveHelpTemplate,
+	Flags: []cmd.FlagDef{
+		{Name: "idle-timeout", Description: "Idle timeout (default: 30m; 0 disables; e.g. 30s, 5m, 1h)", TakesArg: true, Default: "30m"},
+		{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+		{Name: "port", Description: "Proxy listen port (default: saved state > 49154)", TakesArg: true, StateKey: "port", Default: "49154"},
+		{Name: "model", Description: "Model to use (saved for future sessions)", TakesArg: true, StateKey: "model"},
+		{Name: "upstream", Description: "Override the AI Gateway URL (default: auto-discovered)", TakesArg: true},
+		{Name: "log-file", Description: "Write debug logs to file (combinable with --verbose)", TakesArg: true, Completer: "__files"},
+		{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
+		{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
+		{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
+		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
+		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
+		{Name: "help", Short: "h", Description: "Show help message"},
+	},
+}
+
+const configHelpTemplate = `Usage: databricks-codex config <subcommand> [flags]
+
+Persistent config editor. Mutates ~/.codex/.databricks-codex.json (state file)
+to record table preferences that the proxy lifecycle reads at the next codex
+session start. ~/.codex/config.toml is NOT touched by config.* commands —
+config.toml is owned by the proxy lifecycle and is rewritten when codex
+launches.
+
+Subcommands:
+  otel enable [flags]   Persist OTEL table preferences and (next session)
+                        emit the [otel] section in config.toml.
+  otel disable [flags]  Mark OTEL signals as off for the next session. The
+                        proxy lifecycle removes the [otel] section from
+                        config.toml on its next start. State-file table
+                        preferences are PRESERVED so a future
+                        'config otel enable' restores them.
+  show [flags]          Print the resolved configuration (token redacted).
+                        Read-only — no writes.
+
+Run 'databricks-codex config <subcommand> --help' for per-subcommand flags.
+
+Examples:
+  # Enable OTEL with explicit metrics + logs tables:
+  databricks-codex config otel enable \
+    --metrics-table main.codex_telemetry.codex_otel_metrics \
+    --logs-table   main.codex_telemetry.codex_otel_logs
+
+  # Disable just metrics (logs still routed if previously enabled):
+  databricks-codex config otel disable --metrics
+
+  # Disable all signals:
+  databricks-codex config otel disable
+
+  # Diagnostic dump:
+  databricks-codex config show
+
+Exit codes:
+  0   success
+  1   write/discovery failure
+  2   missing or unknown subcommand
+`
+
+const configOtelHelpTemplate = `Usage: databricks-codex config otel <enable|disable> [flags]
+
+Toggle OpenTelemetry signal export for the wrapped codex session. Storage:
+  - Tables (metrics/logs) are persisted to ~/.codex/.databricks-codex.json
+  - The [otel] section in ~/.codex/config.toml is written or removed by the
+    proxy lifecycle the next time codex starts (this command does not edit
+    config.toml directly).
+
+'config otel disable' marks signals off in the state file but PRESERVES the
+table-name preferences so a subsequent 'config otel enable' can restore them
+without re-typing.
+
+Subcommands:
+  enable    Persist OTEL table preferences (see 'config otel enable --help').
+  disable   Mark OTEL signals off for the next session (see 'config otel disable --help').
+`
+
+const configOtelEnableHelpTemplate = `Usage: databricks-codex config otel enable [flags]
+
+Enable OTEL — persists the resolved table names to ~/.codex/.databricks-codex.json
+so the proxy lifecycle emits the [otel] section in ~/.codex/config.toml the
+next time codex launches.
+
+Resolution chain per signal: explicit flag > state file > derive (logs from
+metrics) > unset. With no table flags and an empty state file, --metrics-table
+defaults to 'main.codex_telemetry.codex_otel_metrics' (matching the legacy
+'--otel' bare-toggle behavior).
+
+Flags:
+  --metrics-table string   Unity Catalog table for OTEL metrics (cat.schema.table)
+  --logs-table string      Unity Catalog table for OTEL logs   (cat.schema.table)
+  --profile string         Databricks CLI profile (default: state > DEFAULT)
+  --help, -h               Show this help message
+
+Examples:
+  # Enable with custom metrics + logs tables:
+  databricks-codex config otel enable \
+    --metrics-table main.telemetry.codex_otel_metrics \
+    --logs-table   main.telemetry.codex_otel_logs
+
+  # Enable with default tables (logs derived from metrics):
+  databricks-codex config otel enable
+`
+
+const configOtelDisableHelpTemplate = `Usage: databricks-codex config otel disable [flags]
+
+Mark OTEL signals off in the state file. The proxy lifecycle clears the
+[otel] section from ~/.codex/config.toml on its next start. State-file table
+preferences are PRESERVED — a subsequent 'config otel enable' restores them.
+With no flags, BOTH signals are disabled (equivalent to the legacy --no-otel).
+
+Flags:
+  --metrics    Disable only OTEL metrics (logs untouched)
+  --logs       Disable only OTEL logs
+  --help, -h   Show this help message
+
+Examples:
+  # Disable both signals:
+  databricks-codex config otel disable
+
+  # Disable just metrics:
+  databricks-codex config otel disable --metrics
+
+  # Disable just logs:
+  databricks-codex config otel disable --logs
+`
+
+const configShowHelpTemplate = `Usage: databricks-codex config show [flags]
+
+Print the resolved configuration (token redacted) and exit. Read-only —
+zero writes to the state file or config.toml. Replaces the legacy
+--print-env flag.
+
+Resolves: profile, model, Databricks workspace host, AI Gateway URL,
+auth token (redacted), the persisted OTEL UC tables, and the discovered
+codex binary path.
+
+Flags:
+  --profile string   Databricks CLI profile (default: state > DEFAULT)
+  --help, -h         Show this help message
+`
+
+const hooksHelpTemplate = `Usage: databricks-codex hooks <subcommand> [flags]
+
+Session-hook deployment mode for the OpenAI Codex CLI. Installs hook
+entries into ~/.codex/hooks.json that spin a refcount-managed proxy up on
+SessionStart — making 'databricks-codex' auto-launch with every codex
+session without a long-lived daemon.
+
+Subcommands:
+  install        Install the SessionStart hook into ~/.codex/hooks.json
+                 (idempotent). Also flips [features] hooks = true in
+                 ~/.codex/config.toml so codex actually reads the file.
+  uninstall      Remove databricks-codex hooks from
+                 ~/.codex/hooks.json. Tolerates "not installed".
+  session-start  Hook-invoked internal: starts the proxy if it isn't
+                 already running. Called by the SessionStart hook JSON
+                 written by 'hooks install'. Not intended to be invoked
+                 directly.
+
+Run 'databricks-codex hooks <subcommand> --help' for per-subcommand flags.
+
+Examples:
+  # First-time install on a developer machine:
+  databricks-codex hooks install
+
+  # Remove hooks (e.g. when switching back to the manual proxy mode):
+  databricks-codex hooks uninstall
+
+Exit codes:
+  0   success
+  1   write/discovery failure
+  2   missing or unknown subcommand
+`
+
+const hooksInstallHelpTemplate = `Usage: databricks-codex hooks install [flags]
+
+Install the SessionStart hook into ~/.codex/hooks.json so that every
+codex session auto-launches a refcount-managed databricks-codex proxy
+in the background. Idempotent — safe to re-run after upgrades.
+
+Also ensures [features] hooks = true in ~/.codex/config.toml; without
+that flag codex does not read hooks.json at all.
+
+Generated hook JSON:
+  SessionStart → "databricks-codex hooks session-start"
+
+Flags:
+  --help, -h    Show this help message
+`
+
+const hooksUninstallHelpTemplate = `Usage: databricks-codex hooks uninstall [flags]
+
+Remove databricks-codex hook entries from ~/.codex/hooks.json. Other
+user-authored hooks survive byte-identical. Also removes the
+[features] hooks = true line databricks-codex installed; legacy
+codex_hooks = true (if present) is left untouched.
+
+If hooks.json doesn't exist, this is a no-op.
+
+Flags:
+  --help, -h    Show this help message
+`
+
+const hooksSessionStartHelpTemplate = `Usage: databricks-codex hooks session-start [flags]
+
+Hook-invoked internal: probes the local proxy on the configured port
+and, if absent, starts a detached headless databricks-codex process
+that exits via idle timeout. Replaces the legacy --headless-ensure
+flag. Not intended for direct invocation — the SessionStart hook
+JSON written by 'hooks install' calls this command.
+
+MUST remain fast and fail-fast: no interactive auth flow. If the user
+hasn't run 'databricks auth login' yet, this command exits 0 silently
+so the codex session is not blocked on a hook timeout.
+
+Internally spawns 'databricks-codex serve --port=N' (the #89 replacement
+for the deleted '--headless' root flag).
+
+Flags:
+  --port int    Override saved port (default: saved state > 49154)
+  --help, -h    Show this help message
+`
+
+const serveHelpTemplate = `Usage: databricks-codex serve [flags]
+
+Run the proxy in headless mode without launching codex. Replaces the
+legacy '--headless' and '--idle-timeout' root flags (#89) with a
+discoverable subcommand. Behavior is byte-identical with the removed
+flags — the hooks SessionStart entry and IDE extensions can call this
+directly to bring the proxy up and read PROXY_URL=... from stdout.
+
+Use this when:
+  - An IDE extension needs the proxy running but doesn't want a child
+    codex process. Read PROXY_URL=... from stdout, point your client
+    at it, then SIGTERM (or POST /shutdown) when done.
+  - Bringing up the proxy from a SessionStart hook. 'hooks install'
+    wires this for you under the hood.
+
+The proxy exits when:
+  - SIGINT or SIGTERM is received.
+  - POST /shutdown is hit on the proxy URL.
+  - --idle-timeout elapses with zero in-flight requests (default 30m;
+    0 disables idle shutdown).
+
+Flags:
+  --idle-timeout duration  Idle timeout (default 30m, 0 disables; e.g. 30s, 5m, 1h)
+  --profile string         Databricks CLI profile (default: state > DEFAULT)
+  --port int               Proxy listen port (default: state > 49154)
+  --model string           Model name (saved for future sessions)
+  --upstream string        Override the AI Gateway URL (default: auto-discovered)
+  --log-file string        Write debug logs to file (combinable with --verbose)
+  --verbose, -v            Enable debug logging to stderr
+  --proxy-api-key string   Require this API key on all proxy requests
+  --tls-cert string        TLS certificate file (requires --tls-key)
+  --tls-key string         TLS private key file (requires --tls-cert)
+  --no-update-check        Skip the automatic update check on startup
+  --help, -h               Show this help message
+
+Examples:
+  # Start the proxy with the default 30-minute idle timeout:
+  databricks-codex serve
+
+  # Start with a 5-minute idle timeout (test/CI scenarios):
+  databricks-codex serve --idle-timeout 5m
+
+  # Start with idle shutdown disabled (long-running IDE sessions):
+  databricks-codex serve --idle-timeout 0
+`

--- a/cmd/databricks-codex/completion_flags.go
+++ b/cmd/databricks-codex/completion_flags.go
@@ -1,0 +1,74 @@
+package main
+
+import "github.com/IceRhymers/databricks-agents/internal/core/completion"
+
+// flagDefs is the ordered list of root flags fed to pkg/completion for
+// shell-script generation. Order is curated here (not implied by the tree)
+// because bash/zsh/fish completion output is order-sensitive — preserving
+// byte-equivalence with the pre-tree binary requires the original ordering
+// (--profile first, --port toward the end). Each entry is derived from
+// rootCommand so the tree remains the single source of truth for which
+// flags exist and what their descriptions / completers / arg semantics are.
+// #89 removed --headless and --idle-timeout from this slice (alongside the
+// rootCommand.Flags removal); they live on serveCommand now and are
+// reachable via the recursive subcommand-tree wiring in
+// rootCommand.CompletionSubcommands().
+//
+// Adding a new root flag requires:
+//  1. Append a FlagDef to rootCommand.Flags (or .Persistent) in commands.go.
+//  2. Insert the new flag's name into the order slice below at the desired
+//     position in the completion output.
+//
+// The init-time panic and the parity tests in main_test.go fail loudly if
+// step 2 is forgotten or if a name in `order` doesn't appear on rootCommand.
+var flagDefs = func() []completion.FlagDef {
+	// Original flagDefs ordering, preserved verbatim for byte-equivalent
+	// completion script generation. Two flags now live on rootCommand.Persistent
+	// (--profile, --port); the rest are on rootCommand.Flags. Their ordering
+	// here is independent of that partitioning.
+	order := []string{
+		"profile",
+		"verbose",
+		"version",
+		"help",
+		"model",
+		"upstream",
+		"log-file",
+		"proxy-api-key",
+		"tls-cert",
+		"tls-key",
+		"port",
+		"no-update-check",
+	}
+	byName := map[string]completion.FlagDef{}
+	for _, f := range rootCommand.AllFlags() {
+		byName[f.Name] = f.ToCompletion()
+	}
+	out := make([]completion.FlagDef, 0, len(order))
+	for _, name := range order {
+		f, ok := byName[name]
+		if !ok {
+			panic("completion_flags: order entry " + name + " not declared on rootCommand")
+		}
+		out = append(out, f)
+	}
+	return out
+}()
+
+// knownFlags is the set of flag names (with "--" prefix) that databricks-codex
+// owns. Anything not in this set is forwarded to the codex binary. Derived
+// directly from rootCommand so it can never drift from the tree — the tree
+// is the source of truth for which flags the binary recognises.
+var knownFlags = rootCommand.KnownFlags()
+
+// knownSubcommands is the recursive shell-completion subcommand tree fed
+// to pkg/completion so `databricks-codex <TAB>` offers completion / update
+// / config / hooks / serve, and `databricks-codex hooks <TAB>` offers
+// install / uninstall / session-start, `databricks-codex config <TAB>`
+// offers otel / show, etc. #87 introduced this wire-up alongside the dep
+// bump to databricks-claude v1.0.2 (which exports SubcommandDef); #88
+// adds the hooks branch; #89 adds the serve leaf — picked up
+// automatically by the recursive walk now that serveCommand sits on
+// rootCommand.Subcommands. See the doc-comment in internal/cmd/cmd.go
+// for the prior #86 omission.
+var knownSubcommands = rootCommand.CompletionSubcommands()

--- a/cmd/databricks-codex/hooks.go
+++ b/cmd/databricks-codex/hooks.go
@@ -1,0 +1,358 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/IceRhymers/databricks-agents/internal/core/headless"
+	"github.com/IceRhymers/databricks-agents/internal/core/refcount"
+)
+
+// hooksKeyRegexp matches a `hooks` feature-flag assignment line. It is
+// anchored at start-of-line (after optional whitespace) and requires the key
+// be followed by whitespace or `=`, so it does NOT match the legacy
+// `codex_hooks` key.
+var hooksKeyRegexp = regexp.MustCompile(`(?m)^\s*hooks\s*=`)
+
+// headlessEnsure checks whether the proxy is healthy on the given port.
+// If not, it starts a detached headless proxy and polls until ready (max 10s).
+// Called by the SessionStart hook via: databricks-codex hooks session-start
+// (#88 lifted this off the legacy --headless-ensure root flag; the entry
+// written by installHooks now invokes the subcommand spelling).
+//
+// The proxy shuts itself down via idle timeout — there is no corresponding
+// release hook because Codex CLI has no session-end event.
+//
+// #89: the spawned subprocess invokes the new `serve` subcommand instead of
+// the deleted `--headless` root flag. headless.Config.EnsureCommand replaces
+// the default `[]string{"--headless"}` prefix with `[]string{"serve"}`, so
+// pkg/headless.buildArgs now emits `databricks-codex serve --port=N
+// [--tls-cert=... --tls-key=...]`. Without this wiring, every SessionStart
+// hook firing would spawn a process that immediately fails arg parsing.
+func headlessEnsure(port int) error {
+	s := loadState()
+	return headless.Ensure(headlessEnsureConfig(port, s))
+}
+
+// headlessEnsureConfig assembles the headless.Config that headlessEnsure
+// passes to headless.Ensure. Extracted so a unit test can verify the
+// load-bearing fields (EnsureCommand routing through `serve`, the
+// $DATABRICKS_CODEX_MANAGED guard, the codex refcount path) without
+// spawning a real subprocess. Pure projection over (port, state).
+func headlessEnsureConfig(port int, s persistentState) headless.Config {
+	scheme := "http"
+	if s.TLSCert != "" {
+		scheme = "https"
+	}
+	return headless.Config{
+		Port:          port,
+		Scheme:        scheme,
+		TLSCert:       s.TLSCert,
+		TLSKey:        s.TLSKey,
+		ManagedEnvVar: "DATABRICKS_CODEX_MANAGED",
+		LogPrefix:     "databricks-codex",
+		RefcountPath:  refcount.PathForPort(".databricks-codex-sessions", port),
+		// #89: spawn `databricks-codex serve --port=N` instead of the
+		// removed `databricks-codex --headless --port=N`.
+		EnsureCommand: []string{"serve"},
+	}
+}
+
+// installHooks merges the databricks-codex SessionStart and Stop hooks into
+// ~/.codex/hooks.json. Idempotent — safe to run after upgrades.
+func installHooks(hooksPath string) error {
+	doc, err := readHooksDoc(hooksPath)
+	if err != nil {
+		// File may not exist yet — start with an empty document.
+		doc = map[string]interface{}{}
+	}
+
+	hooks, _ := doc["hooks"].(map[string]interface{})
+	if hooks == nil {
+		hooks = map[string]interface{}{}
+	}
+
+	// Remove any existing databricks-codex hooks before re-adding (idempotent).
+	removeDBXHooks(hooks)
+
+	// SessionStart hook — starts proxy if not already running.
+	sessionStart, _ := hooks["SessionStart"].([]interface{})
+	sessionStart = append(sessionStart, map[string]interface{}{
+		"matcher": "startup",
+		"hooks": []interface{}{
+			map[string]interface{}{
+				"type":    "command",
+				"command": "databricks-codex hooks session-start",
+				"timeout": 15,
+			},
+		},
+	})
+	hooks["SessionStart"] = sessionStart
+
+	doc["hooks"] = hooks
+	if err := writeHooksDoc(hooksPath, doc); err != nil {
+		return err
+	}
+
+	// Codex CLI requires [features] hooks = true to read hooks.json.
+	configPath := filepath.Join(filepath.Dir(hooksPath), "config.toml")
+	return ensureHooksFeatureFlag(configPath)
+}
+
+// uninstallHooks removes the databricks-codex hooks from ~/.codex/hooks.json.
+func uninstallHooks(hooksPath string) error {
+	doc, err := readHooksDoc(hooksPath)
+	if err != nil {
+		return nil // nothing to remove
+	}
+
+	hooks, _ := doc["hooks"].(map[string]interface{})
+	if hooks == nil {
+		return nil
+	}
+
+	removeDBXHooks(hooks)
+
+	// Clean up empty hook event keys.
+	for k, v := range hooks {
+		if arr, ok := v.([]interface{}); ok && len(arr) == 0 {
+			delete(hooks, k)
+		}
+	}
+	if len(hooks) == 0 {
+		delete(doc, "hooks")
+	} else {
+		doc["hooks"] = hooks
+	}
+
+	if err := writeHooksDoc(hooksPath, doc); err != nil {
+		return err
+	}
+
+	// Remove our `hooks = true` from config.toml. Legacy `codex_hooks =` lines
+	// are left untouched — we never migrate user-authored keys.
+	configPath := filepath.Join(filepath.Dir(hooksPath), "config.toml")
+	return removeHooksFeatureFlag(configPath)
+}
+
+// removeDBXHooks removes any hook entries that databricks-codex installed.
+func removeDBXHooks(hooks map[string]interface{}) {
+	for event, val := range hooks {
+		arr, _ := val.([]interface{})
+		filtered := arr[:0]
+		for _, entry := range arr {
+			if !isDBXHookEntry(entry) {
+				filtered = append(filtered, entry)
+			}
+		}
+		hooks[event] = filtered
+	}
+}
+
+// isDBXHookEntry returns true if any nested hook command was installed by
+// databricks-codex. Recognises both spellings so re-install / uninstall
+// stays idempotent across the #88 cutover:
+//   - "databricks-codex --headless..." — legacy entries written by the
+//     pre-#88 --install-hooks flag.
+//   - "databricks-codex hooks ..." — entries written by the new
+//     `hooks install` subcommand.
+func isDBXHookEntry(entry interface{}) bool {
+	m, ok := entry.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	inner, _ := m["hooks"].([]interface{})
+	for _, h := range inner {
+		hm, _ := h.(map[string]interface{})
+		cmd, _ := hm["command"].(string)
+		if cmd == "" {
+			continue
+		}
+		if strings.HasPrefix(cmd, "databricks-codex --headless") {
+			return true
+		}
+		if strings.HasPrefix(cmd, "databricks-codex hooks ") {
+			return true
+		}
+	}
+	return false
+}
+
+// readHooksDoc reads and parses hooks.json, returning the full document.
+func readHooksDoc(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+// writeHooksDoc writes a hooks document back to disk as indented JSON.
+func writeHooksDoc(path string, doc map[string]interface{}) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("creating hooks dir: %w", err)
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling hooks: %w", err)
+	}
+	data = append(data, '\n')
+	return atomicWriteFile(path, data, 0o600)
+}
+
+// atomicWriteFile writes data to a temp file in the same directory as path,
+// then renames it into place. This prevents partial-write
+// corruption from concurrent invocations or crashes mid-write. The temp file
+// is created in the destination directory so the rename is atomic on the same
+// filesystem.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".hooks-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+// ensureHooksFeatureFlag ensures config.toml contains `hooks = true`
+// inside a [features] section. Surgical: if the new `hooks` key is already
+// present it's a no-op; if [features] exists the key is appended inside it;
+// otherwise a new section is appended at the end.
+//
+// Detection is anchored — a legacy `codex_hooks = ...` line is NOT treated
+// as enabled, and is never read, rewritten, or removed by this function.
+// If both keys end up coexisting, upstream Codex tolerates that.
+//
+// TODO(#72 follow-up): This writes directly to the same config.toml that
+// tomlconfig.Manager owns, bypassing the manager's backup/restore bookkeeping.
+// There is a TOCTOU window if a session is patching config.toml concurrently.
+// Routing this through tomlconfig.Manager is out of scope for the atomic-write
+// fix and tracked as a separate follow-up.
+func ensureHooksFeatureFlag(configPath string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading config.toml: %w", err)
+	}
+	content := string(data)
+
+	// Already enabled — nothing to do. Anchored match so `codex_hooks` does
+	// not satisfy this check.
+	if hooksKeyRegexp.MatchString(content) {
+		return nil
+	}
+
+	// Find the [features] section header.
+	idx := strings.Index(content, "[features]")
+	if idx >= 0 {
+		// Insert the key right after the header line.
+		end := strings.Index(content[idx:], "\n")
+		if end < 0 {
+			end = len(content[idx:])
+		}
+		insertAt := idx + end
+		content = content[:insertAt] + "\nhooks = true" + content[insertAt:]
+	} else {
+		// Append a new [features] section.
+		sep := "\n"
+		if len(content) > 0 && !strings.HasSuffix(content, "\n") {
+			sep = "\n\n"
+		} else if len(content) > 0 {
+			sep = "\n"
+		}
+		content += sep + "[features]\nhooks = true\n"
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		return fmt.Errorf("creating config dir: %w", err)
+	}
+	return atomicWriteFile(configPath, []byte(content), 0o600)
+}
+
+// removeHooksFeatureFlag removes any line that assigns the new `hooks` key
+// inside config.toml. It performs an anchored, line-oriented match so the
+// legacy `codex_hooks =` key — and any other user-authored content — is
+// preserved byte-identical.
+//
+// If the file does not exist, or contains no matching line, this is a no-op.
+func removeHooksFeatureFlag(configPath string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading config.toml: %w", err)
+	}
+	content := string(data)
+	if !hooksKeyRegexp.MatchString(content) {
+		return nil
+	}
+
+	// Walk the file line by line and drop only the lines whose trimmed
+	// prefix is the new `hooks` key (followed by whitespace or `=`).
+	var b strings.Builder
+	b.Grow(len(content))
+	start := 0
+	for i := 0; i <= len(content); i++ {
+		if i == len(content) || content[i] == '\n' {
+			line := content[start:i]
+			if !isNewHooksAssignmentLine(line) {
+				b.WriteString(line)
+				if i < len(content) {
+					b.WriteByte('\n')
+				}
+			}
+			start = i + 1
+		}
+	}
+	out := b.String()
+	if out == content {
+		return nil
+	}
+	return atomicWriteFile(configPath, []byte(out), 0o600)
+}
+
+// isNewHooksAssignmentLine reports whether a single line (no trailing
+// newline) is an assignment of the new `hooks` feature flag. The check is
+// anchored so `codex_hooks = ...` returns false.
+func isNewHooksAssignmentLine(line string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(trimmed, "hooks") {
+		return false
+	}
+	rest := trimmed[len("hooks"):]
+	if len(rest) == 0 {
+		return false
+	}
+	c := rest[0]
+	return c == ' ' || c == '\t' || c == '='
+}

--- a/cmd/databricks-codex/hooks_cmd.go
+++ b/cmd/databricks-codex/hooks_cmd.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/IceRhymers/databricks-agents/internal/cmd"
+)
+
+// runHooksCommand dispatches `databricks-codex hooks <subcommand> [flags]`.
+// args is everything after the literal "hooks" token (e.g. ["install"] or
+// ["session-start", "--port", "49154"]).
+//
+// Each subcommand is a thin wrapper around the existing hooks.go logic:
+//   - install       → installHooks(~/.codex/hooks.json)
+//   - uninstall     → uninstallHooks(~/.codex/hooks.json)
+//   - session-start → headlessEnsure(resolved port)
+//
+// The dispatcher uses cmd.Command.Parse on the matching subcommand node so
+// flag parsing stays consistent with the tree's declared semantics
+// (TakesArg, Short aliases, --flag=value forms). The parity test in
+// main_test.go walks rootCommand.Subcommand("hooks").Subcommands and
+// confirms every child name has a case here — drift fails loudly.
+func runHooksCommand(args []string) error {
+	if len(args) == 0 {
+		printHooksHelp()
+		return fmt.Errorf("hooks: missing subcommand (expected: install, uninstall, session-start)")
+	}
+
+	sub := args[0]
+	rest := args[1:]
+
+	node := hooksCommand.Subcommand(sub)
+	if node == nil {
+		printHooksHelp()
+		return fmt.Errorf("hooks: unknown subcommand %q (expected: install, uninstall, session-start)", sub)
+	}
+
+	parsed, err := node.Parse(rest)
+	if err != nil {
+		return fmt.Errorf("hooks %s: %w", sub, err)
+	}
+	if parsed.Bools["help"] {
+		printSubHelp(*node)
+		return nil
+	}
+
+	switch sub {
+	case "install":
+		return runHooksInstall()
+	case "uninstall":
+		return runHooksUninstall()
+	case "session-start":
+		return runHooksSessionStart(parsed.Strings["port"], parsed.Set["port"])
+	default:
+		// Unreachable — Subcommand() lookup above already guards this, but
+		// the parity test still walks here so a forgotten case fails the
+		// build rather than silently no-opping.
+		return fmt.Errorf("hooks: unknown subcommand %q", sub)
+	}
+}
+
+// runHooksInstall is a thin wrapper around installHooks that resolves
+// ~/.codex/hooks.json from $HOME and prints the success message
+// previously emitted by main.go's --install-hooks branch.
+func runHooksInstall() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home dir: %w", err)
+	}
+	hp := filepath.Join(homeDir, ".codex", "hooks.json")
+	if err := installHooks(hp); err != nil {
+		return fmt.Errorf("install: %w", err)
+	}
+	fmt.Fprintln(os.Stderr, "databricks-codex: hooks installed — SessionStart hook added to ~/.codex/hooks.json")
+	return nil
+}
+
+// runHooksUninstall is a thin wrapper around uninstallHooks.
+func runHooksUninstall() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home dir: %w", err)
+	}
+	hp := filepath.Join(homeDir, ".codex", "hooks.json")
+	if err := uninstallHooks(hp); err != nil {
+		return fmt.Errorf("uninstall: %w", err)
+	}
+	fmt.Fprintln(os.Stderr, "databricks-codex: hooks removed from ~/.codex/hooks.json")
+	return nil
+}
+
+// runHooksSessionStart resolves the port and calls headlessEnsure.
+// MUST remain fast/fail-fast — no interactive auth flow.
+func runHooksSessionStart(portValue string, portSet bool) error {
+	state := loadState()
+	portFlag := 0
+	if portSet && portValue != "" {
+		n, err := strconv.Atoi(portValue)
+		if err != nil {
+			return fmt.Errorf("session-start: --port: %q is not an integer", portValue)
+		}
+		portFlag = n
+	}
+	port := resolvePort(portFlag, state)
+	return headlessEnsure(port)
+}
+
+// printHooksHelp prints the top-level `hooks` help body.
+func printHooksHelp() {
+	fmt.Fprint(os.Stderr, hooksHelpTemplate)
+}
+
+// printSubHelp prints a subcommand's Long body when --help is passed.
+// Falls back to programmatic rendering when Long is empty.
+func printSubHelp(c cmd.Command) {
+	if c.Long != "" {
+		fmt.Fprint(os.Stderr, c.Long)
+		return
+	}
+	_ = cmd.Render(os.Stderr, c, nil)
+}

--- a/cmd/databricks-codex/hooks_cmd_test.go
+++ b/cmd/databricks-codex/hooks_cmd_test.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHooksCommandTreeParity verifies bidirectional parity between the
+// hooksCommand subcommand declaration and runHooksCommand's dispatch
+// switch:
+//
+//   - tree → runner: every child name declared on hooksCommand must be
+//     accepted by runHooksCommand. We probe each with --help so the
+//     handler short-circuits before doing real work (no filesystem
+//     mutation, no proxy probe).
+//   - runner → tree: every dispatch keyword recognised by runHooksCommand
+//     must appear on the tree. The set is hard-coded here so a future
+//     dispatch addition without a tree entry trips the check.
+//
+// Bidirectional verification documented in #88 commit body: the test was
+// confirmed to fail when hooksCommand was temporarily removed from
+// rootCommand.Subcommands (parity flip) and again when a child was
+// removed from hooksCommand (tree shrink) — i.e. drift in either
+// direction trips this test.
+func TestHooksCommandTreeParity(t *testing.T) {
+	expected := map[string]bool{
+		"install":       true,
+		"uninstall":     true,
+		"session-start": true,
+	}
+
+	if len(hooksCommand.Subcommands) != len(expected) {
+		t.Errorf("hooksCommand has %d subcommands; expected %d (drift between tree and runHooksCommand)",
+			len(hooksCommand.Subcommands), len(expected))
+	}
+
+	for _, sub := range hooksCommand.Subcommands {
+		if !expected[sub.Name] {
+			t.Errorf("hooksCommand declares %q but runHooksCommand has no case for it", sub.Name)
+			continue
+		}
+		// --help short-circuits before doing real work.
+		err := runHooksCommand([]string{sub.Name, "--help"})
+		if err != nil {
+			t.Errorf("runHooksCommand([%q --help]) returned %v; the dispatcher should accept this name", sub.Name, err)
+		}
+	}
+
+	// Inverse: every dispatch keyword must appear on the tree.
+	for name := range expected {
+		if hooksCommand.Subcommand(name) == nil {
+			t.Errorf("runHooksCommand recognises %q but hooksCommand has no child for it", name)
+		}
+	}
+}
+
+// TestRunHooksCommand_UnknownSubcommand verifies the dispatcher rejects
+// unknown subcommands with a non-nil error and prints help to stderr.
+func TestRunHooksCommand_UnknownSubcommand(t *testing.T) {
+	err := runHooksCommand([]string{"bogus"})
+	if err == nil {
+		t.Fatal("expected error for unknown subcommand, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("error %q should mention the unknown subcommand", err)
+	}
+}
+
+// TestRunHooksCommand_MissingSubcommand verifies the dispatcher rejects
+// bare `hooks` with no subcommand.
+func TestRunHooksCommand_MissingSubcommand(t *testing.T) {
+	err := runHooksCommand(nil)
+	if err == nil {
+		t.Fatal("expected error for missing subcommand, got nil")
+	}
+}
+
+// TestHooksInstallUninstall_Idempotency verifies that
+// install → install → uninstall → uninstall produces a clean state with
+// no extraneous diff in ~/.codex/hooks.json. Drives the round-trip
+// through the dispatcher (runHooksCommand) rather than the lower-level
+// installHooks/uninstallHooks helpers so the wiring between subcommand
+// dispatch and the existing hooks.go logic is exercised.
+func TestHooksInstallUninstall_Idempotency(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+
+	// install x2 — second call must be idempotent.
+	if err := runHooksCommand([]string{"install"}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	first, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.json after first install: %v", err)
+	}
+	if err := runHooksCommand([]string{"install"}); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	second, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.json after second install: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("install is not idempotent — second install diffed:\nfirst:\n%s\nsecond:\n%s",
+			first, second)
+	}
+
+	// SessionStart count must be 1 (not 2) after double install.
+	var doc map[string]interface{}
+	if err := json.Unmarshal(second, &doc); err != nil {
+		t.Fatalf("parse hooks.json after double install: %v", err)
+	}
+	hooks := doc["hooks"].(map[string]interface{})
+	ss := hooks["SessionStart"].([]interface{})
+	if len(ss) != 1 {
+		t.Errorf("expected 1 SessionStart entry after install x2, got %d", len(ss))
+	}
+
+	// uninstall x2 — second call must be a no-op (no error, no panic).
+	if err := runHooksCommand([]string{"uninstall"}); err != nil {
+		t.Fatalf("first uninstall: %v", err)
+	}
+	if err := runHooksCommand([]string{"uninstall"}); err != nil {
+		t.Fatalf("second uninstall: %v", err)
+	}
+
+	// hooks.json should still parse and have no databricks-codex entries.
+	raw, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.json after double uninstall: %v", err)
+	}
+	var clean map[string]interface{}
+	if err := json.Unmarshal(raw, &clean); err != nil {
+		t.Fatalf("parse hooks.json after double uninstall: %v", err)
+	}
+	if _, ok := clean["hooks"]; ok {
+		t.Errorf("expected no hooks key after uninstall, got: %s", raw)
+	}
+}
+
+// TestHooksInstall_WritesNewSubcommandSpelling verifies that the entry
+// written by `hooks install` invokes the new subcommand spelling
+// (`databricks-codex hooks session-start`), not the legacy
+// `--headless-ensure` flag. Locks the hook JSON contract for #88.
+func TestHooksInstall_WritesNewSubcommandSpelling(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+
+	if err := runHooksCommand([]string{"install"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	raw, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.json: %v", err)
+	}
+	if !strings.Contains(string(raw), "databricks-codex hooks session-start") {
+		t.Errorf("expected hooks.json to invoke the new subcommand spelling, got:\n%s", raw)
+	}
+	if strings.Contains(string(raw), "--headless-ensure") {
+		t.Errorf("hooks.json still invokes the removed --headless-ensure flag:\n%s", raw)
+	}
+}
+
+// TestHooksRunCommand_LegacyDetectorReplacement verifies that an existing
+// hooks.json containing a legacy `--headless-ensure` entry is cleanly
+// replaced (not duplicated) by `hooks install`. Backstops the cutover —
+// users who installed via the pre-#88 binary get a clean re-install.
+func TestHooksRunCommand_LegacyDetectorReplacement(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+
+	// Seed hooks.json with the legacy entry.
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	legacy := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "startup",
+					"hooks": []interface{}{
+						map[string]interface{}{
+							"type":    "command",
+							"command": "databricks-codex --headless-ensure",
+							"timeout": float64(15),
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(legacy, "", "  ")
+	if err := os.WriteFile(hooksPath, data, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := runHooksCommand([]string{"install"}); err != nil {
+		t.Fatalf("install over legacy: %v", err)
+	}
+
+	raw, _ := os.ReadFile(hooksPath)
+	if strings.Contains(string(raw), "--headless-ensure") {
+		t.Errorf("legacy --headless-ensure entry survived re-install:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "databricks-codex hooks session-start") {
+		t.Errorf("expected new subcommand spelling after re-install, got:\n%s", raw)
+	}
+	// Exactly one SessionStart entry — no duplicates.
+	var doc map[string]interface{}
+	json.Unmarshal(raw, &doc)
+	hooks := doc["hooks"].(map[string]interface{})
+	ss := hooks["SessionStart"].([]interface{})
+	if len(ss) != 1 {
+		t.Errorf("expected 1 SessionStart entry after legacy replacement, got %d", len(ss))
+	}
+}
+
+// TestRootSubcommandsIncludeHooks verifies hooksCommand is registered on
+// the root tree. This is the parity hook for the bidirectional check
+// described in the issue: temporarily removing hooksCommand from
+// rootCommand.Subcommands flips this assertion to fail, confirming the
+// tree wiring is load-bearing.
+func TestRootSubcommandsIncludeHooks(t *testing.T) {
+	if rootCommand.Subcommand("hooks") == nil {
+		t.Fatal("rootCommand has no `hooks` subcommand — tree wiring lost")
+	}
+}

--- a/cmd/databricks-codex/hooks_test.go
+++ b/cmd/databricks-codex/hooks_test.go
@@ -1,0 +1,478 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestHeadlessEnsure_SkipManaged verifies that headlessEnsure returns
+// immediately when DATABRICKS_CODEX_MANAGED=1 is set, without attempting any
+// network calls.
+func TestHeadlessEnsure_SkipManaged(t *testing.T) {
+	t.Setenv("DATABRICKS_CODEX_MANAGED", "1")
+	// Should return immediately without error or network call.
+	headlessEnsure(49154)
+}
+
+// TestInstallHooks_CreatesFile verifies installHooks creates hooks.json
+// with the expected SessionStart hook.
+func TestInstallHooks_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+
+	if err := installHooks(hooksPath); err != nil {
+		t.Fatalf("installHooks: %v", err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.json: %v", err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse hooks.json: %v", err)
+	}
+
+	hooks, _ := doc["hooks"].(map[string]interface{})
+	if hooks == nil {
+		t.Fatal("expected hooks key in document")
+	}
+
+	// Check SessionStart
+	ss, _ := hooks["SessionStart"].([]interface{})
+	if len(ss) != 1 {
+		t.Fatalf("expected 1 SessionStart entry, got %d", len(ss))
+	}
+}
+
+// TestInstallHooks_Idempotent verifies running installHooks twice doesn't duplicate.
+func TestInstallHooks_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+
+	if err := installHooks(hooksPath); err != nil {
+		t.Fatalf("first installHooks: %v", err)
+	}
+	if err := installHooks(hooksPath); err != nil {
+		t.Fatalf("second installHooks: %v", err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.json: %v", err)
+	}
+
+	var doc map[string]interface{}
+	json.Unmarshal(data, &doc)
+
+	hooks := doc["hooks"].(map[string]interface{})
+	ss := hooks["SessionStart"].([]interface{})
+	if len(ss) != 1 {
+		t.Errorf("expected 1 SessionStart entry after double install, got %d", len(ss))
+	}
+}
+
+// TestUninstallHooks_RemovesEntries verifies uninstallHooks removes the hooks.
+func TestUninstallHooks_RemovesEntries(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+
+	if err := installHooks(hooksPath); err != nil {
+		t.Fatalf("installHooks: %v", err)
+	}
+	if err := uninstallHooks(hooksPath); err != nil {
+		t.Fatalf("uninstallHooks: %v", err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.json: %v", err)
+	}
+
+	var doc map[string]interface{}
+	json.Unmarshal(data, &doc)
+
+	// Hooks key should be removed entirely (empty).
+	if _, exists := doc["hooks"]; exists {
+		t.Error("expected hooks key to be removed after uninstall")
+	}
+}
+
+// TestUninstallHooks_PreservesOtherHooks verifies that uninstall only removes
+// databricks-codex hooks, leaving other hooks intact.
+func TestUninstallHooks_PreservesOtherHooks(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+
+	// Create a hooks.json with a custom hook.
+	os.MkdirAll(filepath.Dir(hooksPath), 0o700)
+	initial := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "startup",
+					"hooks": []interface{}{
+						map[string]interface{}{
+							"type":    "command",
+							"command": "my-custom-hook",
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	os.WriteFile(hooksPath, data, 0o600)
+
+	// Install then uninstall.
+	installHooks(hooksPath)
+	uninstallHooks(hooksPath)
+
+	raw, _ := os.ReadFile(hooksPath)
+	var doc map[string]interface{}
+	json.Unmarshal(raw, &doc)
+
+	hooks := doc["hooks"].(map[string]interface{})
+	ss := hooks["SessionStart"].([]interface{})
+	if len(ss) != 1 {
+		t.Errorf("expected 1 custom SessionStart entry preserved, got %d", len(ss))
+	}
+}
+
+// TestUninstallHooks_NoFile verifies uninstallHooks is a no-op when file doesn't exist.
+func TestUninstallHooks_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "nonexistent", "hooks.json")
+
+	if err := uninstallHooks(hooksPath); err != nil {
+		t.Fatalf("uninstallHooks on missing file should return nil, got: %v", err)
+	}
+}
+
+// TestAtomicWriteFile_NoTmpDebris verifies the helper leaves no temp file
+// behind after a successful write.
+func TestAtomicWriteFile_NoTmpDebris(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "hooks.json")
+
+	if err := atomicWriteFile(dest, []byte(`{"ok":true}`), 0o600); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if name == "hooks.json" {
+			continue
+		}
+		t.Errorf("unexpected leftover file in dir: %s", name)
+	}
+
+	// Permissions preserved.
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("expected 0o600 perms, got %v", info.Mode().Perm())
+	}
+}
+
+// TestAtomicWriteFile_PreservesOriginalOnRenameFailure verifies that if the
+// rename fails (simulated by making the destination a directory), the
+// original file at the destination path is untouched and no temp debris
+// is left behind.
+func TestAtomicWriteFile_PreservesOriginalOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Create a directory at the destination path — os.Rename of a regular
+	// file onto an existing non-empty directory fails on Linux, simulating
+	// a write failure mid-operation.
+	dest := filepath.Join(dir, "hooks.json")
+	if err := os.Mkdir(dest, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Put a file inside so the dir is non-empty (rename will fail).
+	if err := os.WriteFile(filepath.Join(dest, "marker"), []byte("orig"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := atomicWriteFile(dest, []byte("new content"), 0o600)
+	if err == nil {
+		t.Fatal("expected atomicWriteFile to fail when dest is a non-empty dir")
+	}
+
+	// The directory and its contents must still be intact.
+	got, err := os.ReadFile(filepath.Join(dest, "marker"))
+	if err != nil {
+		t.Fatalf("original marker missing after failed write: %v", err)
+	}
+	if string(got) != "orig" {
+		t.Errorf("original content corrupted: got %q", got)
+	}
+
+	// No .tmp debris left in dir.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.Name() == "hooks.json" {
+			continue
+		}
+		t.Errorf("unexpected leftover file: %s", e.Name())
+	}
+}
+
+// TestWriteHooksDoc_AtomicReplace verifies writeHooksDoc replaces an existing
+// file without leaving temp debris and preserves the new content.
+func TestWriteHooksDoc_AtomicReplace(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	// Seed with original content.
+	if err := writeHooksDoc(hooksPath, map[string]interface{}{"v": float64(1)}); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	// Overwrite.
+	if err := writeHooksDoc(hooksPath, map[string]interface{}{"v": float64(2)}); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	data, _ := os.ReadFile(hooksPath)
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if doc["v"].(float64) != 2 {
+		t.Errorf("expected v=2 after atomic replace, got %v", doc["v"])
+	}
+
+	// No .tmp debris.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.Name() == "hooks.json" {
+			continue
+		}
+		t.Errorf("unexpected leftover: %s", e.Name())
+	}
+}
+
+// TestEnsureHooksFeatureFlag_NoFeaturesSection verifies that if config.toml
+// has no [features] section, one is created with `hooks = true`.
+func TestEnsureHooksFeatureFlag_NoFeaturesSection(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	original := "model = \"gpt-5\"\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ensureHooksFeatureFlag(cfg); err != nil {
+		t.Fatalf("ensureHooksFeatureFlag: %v", err)
+	}
+	got, _ := os.ReadFile(cfg)
+	s := string(got)
+	if !containsLine(s, "[features]") {
+		t.Errorf("expected [features] section, got:\n%s", s)
+	}
+	if !hasNewHooksLine(s) {
+		t.Errorf("expected `hooks = true` line, got:\n%s", s)
+	}
+}
+
+// TestEnsureHooksFeatureFlag_FeaturesSectionWithOtherKey verifies that
+// `hooks = true` is inserted under an existing [features] section.
+func TestEnsureHooksFeatureFlag_FeaturesSectionWithOtherKey(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	original := "[features]\nfoo = true\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ensureHooksFeatureFlag(cfg); err != nil {
+		t.Fatalf("ensureHooksFeatureFlag: %v", err)
+	}
+	got, _ := os.ReadFile(cfg)
+	s := string(got)
+	if !containsLine(s, "foo = true") {
+		t.Errorf("expected foo = true preserved, got:\n%s", s)
+	}
+	if !hasNewHooksLine(s) {
+		t.Errorf("expected `hooks = true` line, got:\n%s", s)
+	}
+}
+
+// TestEnsureHooksFeatureFlag_AlreadyEnabled verifies no-op when `hooks = true`
+// already present.
+func TestEnsureHooksFeatureFlag_AlreadyEnabled(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	original := "[features]\nhooks = true\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ensureHooksFeatureFlag(cfg); err != nil {
+		t.Fatalf("ensureHooksFeatureFlag: %v", err)
+	}
+	got, _ := os.ReadFile(cfg)
+	if string(got) != original {
+		t.Errorf("expected no-op, got:\n%s", got)
+	}
+}
+
+// TestEnsureHooksFeatureFlag_LegacyOnlyAppendsNew verifies that if only the
+// legacy `codex_hooks = true` is present, `hooks = true` is appended and the
+// legacy line survives BYTE-IDENTICAL.
+func TestEnsureHooksFeatureFlag_LegacyOnlyAppendsNew(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	original := "[features]\ncodex_hooks = true\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ensureHooksFeatureFlag(cfg); err != nil {
+		t.Fatalf("ensureHooksFeatureFlag: %v", err)
+	}
+	got, _ := os.ReadFile(cfg)
+	s := string(got)
+	if !containsLine(s, "codex_hooks = true") {
+		t.Errorf("legacy codex_hooks line was modified or removed:\n%s", s)
+	}
+	if !hasNewHooksLine(s) {
+		t.Errorf("expected `hooks = true` line appended, got:\n%s", s)
+	}
+}
+
+// TestEnsureHooksFeatureFlag_BothKeys verifies no-op when both keys present.
+func TestEnsureHooksFeatureFlag_BothKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	original := "[features]\ncodex_hooks = true\nhooks = true\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := ensureHooksFeatureFlag(cfg); err != nil {
+		t.Fatalf("ensureHooksFeatureFlag: %v", err)
+	}
+	got, _ := os.ReadFile(cfg)
+	if string(got) != original {
+		t.Errorf("expected no-op, got:\n%s", got)
+	}
+}
+
+// TestUninstallHooks_RemovesNewKeyPreservesLegacy verifies that
+// --uninstall-hooks removes only `hooks =` from config.toml, leaving any
+// legacy `codex_hooks =` line untouched.
+func TestUninstallHooks_RemovesNewKeyPreservesLegacy(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".codex", "hooks.json")
+	cfg := filepath.Join(dir, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	original := "[features]\ncodex_hooks = true\nhooks = true\n"
+	if err := os.WriteFile(cfg, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := installHooks(hooksPath); err != nil {
+		t.Fatalf("installHooks: %v", err)
+	}
+	if err := uninstallHooks(hooksPath); err != nil {
+		t.Fatalf("uninstallHooks: %v", err)
+	}
+
+	got, _ := os.ReadFile(cfg)
+	s := string(got)
+	if !containsLine(s, "codex_hooks = true") {
+		t.Errorf("legacy codex_hooks line should survive uninstall, got:\n%s", s)
+	}
+	if hasNewHooksLine(s) {
+		t.Errorf("`hooks = true` line should be removed by uninstall, got:\n%s", s)
+	}
+}
+
+// containsLine returns true if any line of s exactly equals target after
+// trimming trailing whitespace.
+func containsLine(s, target string) bool {
+	for _, line := range splitLines(s) {
+		if line == target {
+			return true
+		}
+	}
+	return false
+}
+
+// hasNewHooksLine returns true if any line is the canonical `hooks = true`
+// (anchored — not matching `codex_hooks`).
+func hasNewHooksLine(s string) bool {
+	for _, line := range splitLines(s) {
+		trimmed := line
+		for len(trimmed) > 0 && (trimmed[0] == ' ' || trimmed[0] == '\t') {
+			trimmed = trimmed[1:]
+		}
+		if trimmed == "hooks = true" {
+			return true
+		}
+	}
+	return false
+}
+
+func splitLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}
+
+// TestIsDBXHookEntry verifies detection of databricks-codex hook entries.
+// Covers both the legacy --headless-* spellings (entries left over from
+// pre-#88 installs) and the new `hooks` subcommand spellings, so a
+// re-install or uninstall replaces both cleanly.
+func TestIsDBXHookEntry(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{"legacy ensure command", "databricks-codex --headless-ensure", true},
+		{"legacy release command", "databricks-codex --headless-release", true},
+		{"legacy headless base", "databricks-codex --headless", true},
+		{"new session-start command", "databricks-codex hooks session-start", true},
+		{"new install command", "databricks-codex hooks install", true},
+		{"unrelated command", "my-custom-hook", false},
+		{"partial match", "databricks-codex --help", false},
+		{"hooks-prefixed unrelated", "databricks-codex hooksy-thing", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := map[string]interface{}{
+				"hooks": []interface{}{
+					map[string]interface{}{
+						"type":    "command",
+						"command": tc.cmd,
+					},
+				},
+			}
+			got := isDBXHookEntry(entry)
+			if got != tc.want {
+				t.Errorf("isDBXHookEntry(%q) = %v, want %v", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/databricks-codex/launch_codex.go
+++ b/cmd/databricks-codex/launch_codex.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/IceRhymers/databricks-agents/internal/core"
+	"github.com/IceRhymers/databricks-agents/internal/core/authcheck"
+	"github.com/IceRhymers/databricks-agents/internal/core/proxy"
+)
+
+// buildCodexLaunchPlan performs the codex-specific pre-flight for wrapper mode
+// and returns a neutral core.LaunchPlan for core.Run to execute, together with
+// the field-bearing codexSettingsPatcher that CodexProfile wraps. It owns
+// everything up to (but not including) the proxy port bind: logging setup,
+// profile/model resolution (with state persistence), auth, port resolution,
+// TLS validation + state save, startup security warnings, token seeding, host
+// discovery, gateway URL construction, OTEL resolution, and the LookPath("codex")
+// guard.
+//
+// The patcher is returned rather than reconstructed in main because it carries
+// the exact resolved model / OTEL-table values this function computed; single-
+// sourcing them avoids config.toml parity drift between what the proxy headers
+// use and what config.toml is patched to. core.LaunchPlan has no codex-specific
+// field to carry it, and CodexProfile(patcher) needs it — hence the extra return.
+//
+// codex writes NO settings.json env block (its per-session config is the
+// surgical config.toml patch), so plan.BuildEnv is nil. Fatal conditions are
+// returned as errors WITHOUT the "databricks-codex:" prefix; the caller adds it
+// via log.Fatalf, preserving the silent-in-non-verbose / visible-in-verbose
+// behavior of the original inline Fatalfs via the shared log output global this
+// function configures.
+func buildCodexLaunchPlan(a *Args) (core.LaunchPlan, codexSettingsPatcher, error) {
+	var plan core.LaunchPlan
+	var patcher codexSettingsPatcher
+
+	// Default: discard all logs (silent wrapper — identical to vanilla codex).
+	log.SetOutput(io.Discard)
+	if a.Verbose {
+		log.SetOutput(os.Stderr)
+	}
+	if a.LogFile != "" {
+		f, err := os.OpenFile(a.LogFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if err != nil {
+			log.SetOutput(os.Stderr) // ensure this fatal is visible
+			return plan, patcher, fmt.Errorf("cannot open log file %q: %v", a.LogFile, err)
+		}
+		// Not closed explicitly: os.Exit skips defers and the process holds the
+		// file until exit (matching the original inline defer-that-never-runs).
+		if a.Verbose {
+			log.SetOutput(io.MultiWriter(os.Stderr, f))
+		} else {
+			log.SetOutput(f)
+		}
+	}
+
+	// --- Resolve profile (--profile flag saved to state) ---
+	profileExplicit := a.Profile != ""
+	profile := resolveProfile(a.Profile, loadState().Profile)
+	if profileExplicit {
+		saved := loadState()
+		saved.Profile = profile
+		if err := saveState(saved); err != nil {
+			log.Printf("databricks-codex: failed to save profile: %v", err)
+		} else {
+			log.Printf("databricks-codex: saved profile %q for future sessions", profile)
+		}
+	}
+	log.Printf("databricks-codex: using profile: %s", profile)
+
+	// --- Resolve model (--model flag saved to state) ---
+	modelExplicit := a.ModelSet
+	savedForModel := loadState()
+	model := resolveModel(a.Model, savedForModel.Model)
+	switch {
+	case a.Model != "":
+		// flag-supplied; logged below
+	case savedForModel.Model != "":
+		log.Printf("databricks-codex: using saved model: %s", savedForModel.Model)
+	}
+	if modelExplicit {
+		savedForModel.Model = model
+		if err := saveState(savedForModel); err != nil {
+			log.Printf("databricks-codex: failed to save model: %v", err)
+		} else {
+			log.Printf("databricks-codex: saved model %q for future sessions", model)
+		}
+	}
+	log.Printf("databricks-codex: using model: %s", model)
+
+	// --- Ensure the user is authenticated before proceeding ---
+	if err := authcheck.EnsureAuthenticated(profile, ""); err != nil {
+		return plan, patcher, fmt.Errorf("auth failed: %v", err)
+	}
+
+	// --- Load state and resolve port ---
+	state := loadState()
+	port := resolvePort(a.PortFlag, state)
+	if a.PortFlag > 0 {
+		state.Port = port
+		if err := saveState(state); err != nil {
+			log.Printf("databricks-codex: failed to save port: %v", err)
+		} else {
+			log.Printf("databricks-codex: saved port %d for future sessions", port)
+		}
+	}
+	log.Printf("databricks-codex: using port: %d", port)
+
+	// --- TLS validation ---
+	if err := proxy.ValidateTLSConfig(a.TLSCert, a.TLSKey); err != nil {
+		return plan, patcher, fmt.Errorf("%v", err)
+	}
+
+	// --- Save TLS config to state so headless-ensure can use the right scheme ---
+	{
+		s := loadState()
+		if s.TLSCert != a.TLSCert || s.TLSKey != a.TLSKey {
+			s.TLSCert = a.TLSCert
+			s.TLSKey = a.TLSKey
+			if err := saveState(s); err != nil {
+				log.Printf("databricks-codex: failed to save TLS config: %v", err)
+			}
+		}
+	}
+
+	// --- Startup security checks ---
+	for _, w := range proxy.SecurityChecks() {
+		fmt.Fprintln(os.Stderr, w)
+	}
+
+	// --- Seed token cache ---
+	tp := NewTokenProvider("", profile)
+	if _, err := tp.Token(context.Background()); err != nil {
+		return plan, patcher, fmt.Errorf("failed to fetch initial token: %v", err)
+	}
+
+	// --- Discover host + construct gateway URL ---
+	host, err := DiscoverHost("", profile)
+	if err != nil {
+		return plan, patcher, fmt.Errorf("failed to discover host: %v\nRun 'databricks auth login' first", err)
+	}
+	log.Printf("databricks-codex: discovered host: %s", host)
+
+	gatewayURL := a.Upstream
+	if gatewayURL == "" {
+		gatewayURL = ConstructGatewayURL(host)
+	}
+	log.Printf("databricks-codex: gateway URL: %s", gatewayURL)
+
+	// --- OTEL tables (read-only over state; the config editor is the only writer) ---
+	saved := loadState()
+	otel, otelMetricsTable, otelLogsTable := resolveOtel(saved)
+	if otelMetricsTable != "" {
+		log.Printf("databricks-codex: using saved otel-metrics-table: %s", otelMetricsTable)
+	}
+	if otelLogsTable != "" {
+		log.Printf("databricks-codex: using saved otel-logs-table: %s", otelLogsTable)
+	}
+
+	// Verify codex is on PATH before proxy startup. Kept at its original
+	// relative position (after host discovery) so "codex not found" surfaces
+	// only after auth/discovery errors. Excluded from serve mode and from
+	// core.Run (which launches ChildBinary blindly).
+	if _, err := exec.LookPath("codex"); err != nil {
+		return plan, patcher, fmt.Errorf("codex binary not found on PATH — install from https://openai.com/codex")
+	}
+
+	// --- Determine OTEL upstream (empty when OTEL is off, matching the
+	// pre-unification ProxyConfig.OTELUpstream) ---
+	otelUpstream := ""
+	if otel {
+		otelUpstream = host + "/api/2.0/otel"
+		log.Printf("databricks-codex: OTEL enabled, upstream: %s", otelUpstream)
+	}
+
+	patcher = newCodexPatcher(model, modelExplicit, otelMetricsTable, otelLogsTable, otel)
+
+	plan = core.LaunchPlan{
+		InferenceUpstream: gatewayURL,
+		OTELUpstream:      otelUpstream,
+		UCMetricsTable:    otelMetricsTable,
+		UCLogsTable:       otelLogsTable,
+		UCTracesTable:     "",
+		TokenProvider:     tp,
+		Port:              port,
+		PortFlag:          a.PortFlag,
+		ProfileName:       profile,
+		TLSCert:           a.TLSCert,
+		TLSKey:            a.TLSKey,
+		ProxyAPIKey:       a.ProxyAPIKey,
+		Verbose:           a.Verbose,
+		Version:           Version,
+		ToolName:          "databricks-codex",
+		RefcountPrefix:    ".databricks-codex-sessions",
+		ManagedEnvVar:     "DATABRICKS_CODEX_MANAGED=1",
+		NoUpdateCheck:     a.NoUpdateCheck,
+		UpdaterConfig:     buildUpdaterConfig(),
+		BuildEnv:          nil,
+	}
+	return plan, patcher, nil
+}

--- a/cmd/databricks-codex/main.go
+++ b/cmd/databricks-codex/main.go
@@ -1,0 +1,440 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/IceRhymers/databricks-agents/internal/core"
+	"github.com/IceRhymers/databricks-agents/internal/core/completion"
+	"github.com/IceRhymers/databricks-agents/internal/core/updater"
+)
+
+// Version is set at build time via -ldflags.
+var Version = "dev"
+
+func main() {
+	// completion <shell> — must be the very first check, before any flag parsing,
+	// auth, or state loading. Safe to call in the Homebrew install sandbox.
+	if len(os.Args) >= 2 && os.Args[1] == "completion" {
+		completion.Run(os.Args[2:], flagDefs, "databricks-codex", knownSubcommands...)
+		os.Exit(0)
+	}
+
+	// hooks <subcommand> — handled before auth/state setup since
+	// session-start is hot-path (called by every codex SessionStart) and
+	// install/uninstall must work in environments where the proxy is not
+	// yet configured. The dispatcher in hooks_cmd.go owns flag parsing.
+	if len(os.Args) >= 2 && os.Args[1] == "hooks" {
+		if err := runHooksCommand(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "databricks-codex:", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	// `config` subcommand — persistent config editor (OTEL signals,
+	// resolved-config diagnostic). Consolidates the 7 flags removed from the
+	// root in #87 — the flags that mutate state for FUTURE runs rather than
+	// affecting the current invocation. The transparent-proxy launcher path
+	// below is intentionally flag-driven and bare; persistent state mutation
+	// lives behind this tree.
+	if len(os.Args) >= 2 && os.Args[1] == "config" {
+		runConfigCommand(os.Args[2:])
+		return
+	}
+
+	// `serve` subcommand — runs the proxy in headless mode. A session/headless
+	// sibling entrypoint that does NOT route through core.Run (distinct
+	// lifecycle: lifecycle wrap + idle timeout, no child). The dispatcher in
+	// serve_codex.go owns flag parsing.
+	if len(os.Args) >= 2 && os.Args[1] == "serve" {
+		if err := runServeCommand(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "databricks-codex:", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	// update — force-check for a newer release and print instructions.
+	if len(os.Args) >= 2 && os.Args[1] == "update" {
+		if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
+			fmt.Fprintln(os.Stderr, "databricks-codex: update check disabled via DATABRICKS_NO_UPDATE_CHECK")
+			os.Exit(0)
+		}
+		cfg := buildUpdaterConfig()
+		cfg.CacheTTL = 0 // force fresh check
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		r, err := updater.Check(ctx, cfg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "databricks-codex: update check failed: %v\n", err)
+			os.Exit(1)
+		}
+		if !r.UpdateAvailable {
+			fmt.Fprintf(os.Stderr, "databricks-codex v%s is already the latest version\n", Version)
+			os.Exit(0)
+		}
+		if r.IsHomebrew {
+			fmt.Fprintf(os.Stderr, "Update available: v%s. Run: brew upgrade databricks-codex\n", r.LatestVersion)
+		} else {
+			fmt.Fprintf(os.Stderr, "Update available: v%s. Download from: %s\n", r.LatestVersion, r.ReleaseURL)
+		}
+		os.Exit(0)
+	}
+
+	a, err := parseArgs(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "databricks-codex:", err)
+		os.Exit(1)
+	}
+
+	if a.ShowHelp {
+		handleHelp()
+		os.Exit(0)
+	}
+
+	if a.Version {
+		fmt.Printf("databricks-codex %s\n", Version)
+		os.Exit(0)
+	}
+
+	// --- Assemble the codex launch plan and hand off to the shared engine ---
+	// buildCodexLaunchPlan owns all codex-specific pre-flight (logging,
+	// profile/model resolution + state saves, auth, port resolution, TLS
+	// validation, token seed, host discovery, gateway URL, OTEL resolution,
+	// LookPath("codex") guard) and returns a neutral core.LaunchPlan plus the
+	// field-bearing config.toml patcher. core.Run owns the generic proxy bind →
+	// serve/watch → settings-patch → child-launch → refcount-teardown lifecycle.
+	plan, patcher, err := buildCodexLaunchPlan(a)
+	if err != nil {
+		log.Fatalf("databricks-codex: %v", err)
+	}
+	os.Exit(core.Run(CodexProfile(patcher), plan, a.CodexArgs))
+}
+
+// Args holds all parsed databricks-codex flags plus the residual codex args.
+//
+// #89 removed the legacy --headless and --idle-timeout root flags. Their
+// effect now lives behind the `serve` subcommand. The Headless and
+// IdleTimeout fields stay on this struct because they are inputs to the serve
+// launch path — set by buildServeArgs (serve_codex.go) when the user invokes
+// `databricks-codex serve`. parseArgs never sets them; the transparent-wrapper
+// path leaves both at zero and routes through core.Run instead.
+type Args struct {
+	Verbose       bool
+	Version       bool
+	ShowHelp      bool
+	Upstream      string
+	LogFile       string
+	Profile       string
+	ProxyAPIKey   string
+	TLSCert       string
+	TLSKey        string
+	Model         string
+	ModelSet      bool
+	PortFlag      int
+	Headless      bool          // set by buildServeArgs only (#89)
+	IdleTimeout   time.Duration // set by buildServeArgs only (#89)
+	NoUpdateCheck bool
+	CodexArgs     []string
+}
+
+// parseArgs separates databricks-codex flags from codex flags. Recognises
+// only the root-flag set declared on rootCommand (commands.go); the legacy
+// --headless and --idle-timeout flags removed in #89 are intentionally NOT
+// recognised here — they will fall through to CodexArgs and be forwarded to
+// the wrapped codex binary. Users should migrate to `databricks-codex serve
+// [--idle-timeout D]`.
+func parseArgs(args []string) (*Args, error) {
+	a := &Args{}
+
+	// knownFlags is defined at package level in completion_flags.go,
+	// derived from flagDefs so completions and parsing stay in sync.
+
+	i := 0
+	for i < len(args) {
+		arg := args[i]
+
+		// Explicit separator: everything after "--" goes to codex.
+		if arg == "--" {
+			a.CodexArgs = append(a.CodexArgs, args[i+1:]...)
+			return a, nil
+		}
+
+		if arg == "-h" {
+			a.ShowHelp = true
+			i++
+			continue
+		}
+		if arg == "-v" {
+			a.Verbose = true
+			i++
+			continue
+		}
+
+		if strings.HasPrefix(arg, "--") {
+			name := arg
+			value := ""
+			if eqIdx := strings.Index(arg, "="); eqIdx >= 0 {
+				name = arg[:eqIdx]
+				value = arg[eqIdx+1:]
+			}
+
+			if knownFlags[name] {
+				switch name {
+				case "--upstream":
+					if value != "" {
+						a.Upstream = value
+					} else if i+1 < len(args) {
+						i++
+						a.Upstream = args[i]
+					}
+				case "--log-file":
+					if value != "" {
+						a.LogFile = value
+					} else if i+1 < len(args) {
+						i++
+						a.LogFile = args[i]
+					}
+				case "--profile":
+					if value != "" {
+						a.Profile = value
+					} else if i+1 < len(args) {
+						i++
+						a.Profile = args[i]
+					}
+				case "--proxy-api-key":
+					if value != "" {
+						a.ProxyAPIKey = value
+					} else if i+1 < len(args) {
+						i++
+						a.ProxyAPIKey = args[i]
+					}
+				case "--tls-cert":
+					if value != "" {
+						a.TLSCert = value
+					} else if i+1 < len(args) {
+						i++
+						a.TLSCert = args[i]
+					}
+				case "--tls-key":
+					if value != "" {
+						a.TLSKey = value
+					} else if i+1 < len(args) {
+						i++
+						a.TLSKey = args[i]
+					}
+				case "--model":
+					if value != "" {
+						a.Model = value
+						a.ModelSet = true
+					} else if i+1 < len(args) {
+						i++
+						a.Model = args[i]
+						a.ModelSet = true
+					}
+				case "--verbose":
+					a.Verbose = true
+				case "--version":
+					a.Version = true
+				case "--help":
+					a.ShowHelp = true
+				case "--port":
+					if value != "" {
+						a.PortFlag, _ = strconv.Atoi(value)
+					} else if i+1 < len(args) {
+						i++
+						a.PortFlag, _ = strconv.Atoi(args[i])
+					}
+				case "--no-update-check":
+					a.NoUpdateCheck = true
+				default:
+					// A name in knownFlags must have a corresponding case
+					// above; this arm catches the case where rootCommand
+					// declares a new flag but parseArgs hasn't been updated.
+					// Loud failure beats silent passthrough — the bidirectional
+					// parity test in main_test.go also detects this drift,
+					// but a runtime check catches it for any caller path the
+					// test doesn't exercise.
+					return nil, fmt.Errorf("internal: %s is a known flag but parseArgs has no case for it", name)
+				}
+				i++
+				continue
+			}
+		}
+
+		// Not a known flag — pass through to codex.
+		a.CodexArgs = append(a.CodexArgs, arg)
+		i++
+	}
+	return a, nil
+}
+
+// handleHelp prints the databricks-codex help. It does NOT exec
+// `codex --help` — appending the agent's help below the wrapper's made it
+// impossible to tell which flags the wrapper owns vs which it forwards.
+// Codex's own help is reachable via the existing `--` separator:
+//
+//	databricks-codex -- --help
+func handleHelp() {
+	fmt.Printf(`databricks-codex v%s — Databricks AI Gateway wrapper for OpenAI Codex CLI
+
+Patches ~/.codex/config.toml and runs a local proxy so the Codex CLI
+authenticates through a Databricks AI Gateway endpoint with live token refresh.
+
+Usage:
+  databricks-codex [databricks-codex flags] [codex flags] [codex args]
+
+Databricks-Codex Flags:
+  --profile string      Databricks CLI profile (saved for future sessions; default: env or "DEFAULT")
+  --model string        Model name (saved for future sessions; default: "databricks-gpt-5-5")
+  --upstream string     Override the AI Gateway URL (default: auto-discovered)
+  --verbose, -v         Enable debug logging to stderr
+  --log-file string     Write debug logs to a file (combinable with --verbose)
+  --proxy-api-key string    Require this API key on all proxy requests (default: disabled)
+  --tls-cert string         Path to TLS certificate file (requires --tls-key)
+  --tls-key string          Path to TLS private key file (requires --tls-cert)
+  --port int                Fixed proxy port (default: 49154, saved to state)
+  --no-update-check         Skip the automatic update check on startup
+  --version             Print version and exit
+  --help, -h            Show this help message
+
+Subcommands:
+  config                       Persistent config editor (otel enable/disable, show)
+  completion <shell>           Generate shell completions (bash, zsh, fish)
+  update                       Check for a newer release and print upgrade instructions
+  hooks <subcommand>           Install/uninstall SessionStart hooks (install, uninstall, session-start)
+  serve [flags]                Run the proxy in headless mode (consolidates the deleted root flags)
+
+Passthrough to codex:
+  Anything after a "--" separator is forwarded to the codex CLI unchanged.
+  Examples:
+    databricks-codex -- --help                # show codex's own help
+    databricks-codex -- --model o3 -p "hi"    # run codex with extra flags
+`, Version)
+}
+
+// buildUpdaterConfig returns the standard updater.Config for databricks-codex.
+func buildUpdaterConfig() updater.Config {
+	home, _ := os.UserHomeDir()
+	return updater.Config{
+		RepoSlug:       "IceRhymers/databricks-codex",
+		CurrentVersion: Version,
+		BinaryName:     "databricks-codex",
+		CacheFile:      filepath.Join(home, ".codex", ".update-check.json"),
+		CacheTTL:       24 * time.Hour,
+	}
+}
+
+// handlePrintEnv prints resolved configuration with the token redacted.
+// Redaction is applied unconditionally — never branch on token shape, since any
+// branch leaks information about the token format.
+func handlePrintEnv(databricksHost, openaiBaseURL, token, profile, model, otelMetricsTable, otelLogsTable string) {
+	_ = token // intentionally unused: we never print the token
+	redacted := "**** (redacted)"
+
+	codexPath := "(not found)"
+	if p, err := exec.LookPath("codex"); err == nil {
+		codexPath = p
+	}
+
+	metricsLine := otelMetricsTable
+	if metricsLine == "" {
+		metricsLine = "(disabled)"
+	}
+	logsLine := otelLogsTable
+	if logsLine == "" {
+		logsLine = "(disabled)"
+	}
+
+	fmt.Printf(`databricks-codex configuration:
+  Profile:             %s
+  Model:               %s
+  DATABRICKS_HOST:     %s
+  OPENAI_BASE_URL:     %s
+  Auth Token:          %s
+  OTEL Metrics Table:  %s
+  OTEL Logs Table:     %s
+  Codex binary:        %s
+`, profile, model, databricksHost, openaiBaseURL, redacted, metricsLine, logsLine, codexPath)
+}
+
+// defaultModel returns the built-in default model name used when nothing else
+// (flag, env, saved state) is set. Centralised so tests can lock the default
+// against silent drift.
+func defaultModel() string { return "databricks-gpt-5-5" }
+
+// resolveModel returns the model name using the resolution chain:
+// --model flag → saved state → built-in default. The built-in default is
+// the only value that changes when the project bumps its default model.
+func resolveModel(flagValue string, savedValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if savedValue != "" {
+		return savedValue
+	}
+	return defaultModel()
+}
+
+// resolveProfile returns the Databricks CLI profile using the resolution chain:
+// --profile flag → saved state → "DEFAULT".
+// The env var DATABRICKS_CONFIG_PROFILE is intentionally skipped; injected env
+// vars would silently override the user's saved proxy profile.
+func resolveProfile(flagValue string, savedValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if savedValue != "" {
+		return savedValue
+	}
+	return "DEFAULT"
+}
+
+// resolveOtel reads the persistent state and returns the (otel, metrics,
+// logs) tuple the regular session path uses to drive proxy + config.toml
+// patching. Pure function over state — no flag input — because #87 removed
+// the session-time OTEL flags. The persistent-config editor
+// (`databricks-codex config otel enable/disable`) is the only writer; the
+// session is a read-only consumer.
+//
+// Semantics:
+//
+//   - A signal is on iff the corresponding *Disabled bit is unset AND the
+//     corresponding table name is non-empty in state.
+//   - Returned table strings are empty when their signal is off (so the
+//     proxy's tomlconfig.Patch removes the [otel] section when both are
+//     empty rather than leaving stale exporter lines).
+//   - OTel as a whole is on iff at least one signal is on.
+func resolveOtel(saved persistentState) (otel bool, metricsTable string, logsTable string) {
+	if !saved.OtelMetricsDisabled && saved.OtelMetricsTable != "" {
+		metricsTable = saved.OtelMetricsTable
+	}
+	if !saved.OtelLogsDisabled && saved.OtelLogsTable != "" {
+		logsTable = saved.OtelLogsTable
+	}
+	otel = metricsTable != "" || logsTable != ""
+	return otel, metricsTable, logsTable
+}
+
+// deriveLogsTable derives the OTEL logs table name from a metrics table name.
+// If the metrics table ends with "_otel_metrics", replace that suffix with
+// "_otel_logs". Otherwise append "_otel_logs". Kept exported (within-package)
+// so cli_config.go's resolver can reuse it for the `config otel enable
+// --metrics-table` derivation.
+func deriveLogsTable(metricsTable string) string {
+	if metricsTable == "" {
+		return ""
+	}
+	if strings.HasSuffix(metricsTable, "_otel_metrics") {
+		return strings.TrimSuffix(metricsTable, "_otel_metrics") + "_otel_logs"
+	}
+	return metricsTable + "_otel_logs"
+}

--- a/cmd/databricks-codex/main_test.go
+++ b/cmd/databricks-codex/main_test.go
@@ -1,0 +1,923 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// mustParseArgs is a test helper that calls parseArgs and fails the test on error.
+func mustParseArgs(t *testing.T, args []string) *Args {
+	t.Helper()
+	a, err := parseArgs(args)
+	if err != nil {
+		t.Fatalf("parseArgs(%v) returned unexpected error: %v", args, err)
+	}
+	return a
+}
+
+// equalStringSlice reports whether a and b have the same length and same
+// elements in order. nil and empty slices are treated equal.
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// --- parseArgs tests ---
+
+func TestParseArgs_HelpLong(t *testing.T) {
+	a := mustParseArgs(t, []string{"--help"})
+	if !a.ShowHelp {
+		t.Error("expected ShowHelp=true for --help")
+	}
+	if a.Verbose || a.Version || a.Upstream != "" || a.LogFile != "" || a.Profile != "" || len(a.CodexArgs) != 0 {
+		t.Error("unexpected non-default values alongside --help")
+	}
+}
+
+func TestParseArgs_HelpShort(t *testing.T) {
+	a := mustParseArgs(t, []string{"-h"})
+	if !a.ShowHelp {
+		t.Error("expected ShowHelp=true for -h")
+	}
+}
+
+func TestParseArgs_Version(t *testing.T) {
+	a := mustParseArgs(t, []string{"--version"})
+	if !a.Version {
+		t.Error("expected Version=true for --version")
+	}
+}
+
+func TestParseArgs_Verbose(t *testing.T) {
+	a := mustParseArgs(t, []string{"--verbose"})
+	if !a.Verbose {
+		t.Error("expected Verbose=true for --verbose")
+	}
+}
+
+func TestParseArgs_VerboseShort(t *testing.T) {
+	a := mustParseArgs(t, []string{"-v"})
+	if !a.Verbose {
+		t.Error("expected Verbose=true for -v")
+	}
+}
+
+func TestParseArgs_LogFile(t *testing.T) {
+	a := mustParseArgs(t, []string{"--log-file", "/tmp/test.log"})
+	if a.LogFile != "/tmp/test.log" {
+		t.Errorf("expected LogFile=%q, got %q", "/tmp/test.log", a.LogFile)
+	}
+}
+
+func TestParseArgs_LogFileEquals(t *testing.T) {
+	a := mustParseArgs(t, []string{"--log-file=/tmp/test.log"})
+	if a.LogFile != "/tmp/test.log" {
+		t.Errorf("expected LogFile=%q, got %q", "/tmp/test.log", a.LogFile)
+	}
+}
+
+func TestParseArgs_Upstream(t *testing.T) {
+	a := mustParseArgs(t, []string{"--upstream", "https://gw.example.com/openai/v1"})
+	if a.Upstream != "https://gw.example.com/openai/v1" {
+		t.Errorf("expected Upstream=%q, got %q", "https://gw.example.com/openai/v1", a.Upstream)
+	}
+}
+
+func TestParseArgs_UpstreamEquals(t *testing.T) {
+	a := mustParseArgs(t, []string{"--upstream=https://gw.example.com/openai/v1"})
+	if a.Upstream != "https://gw.example.com/openai/v1" {
+		t.Errorf("expected Upstream=%q, got %q", "https://gw.example.com/openai/v1", a.Upstream)
+	}
+}
+
+// #87 removed --no-otel*/--otel-*-table; coverage moved to TestResolveConfigOTEL_*
+// (state-driven resolver) and TestRootTreeFlagsAreParseRecognised (shrink-side
+// of the bidirectional parity check).
+
+func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
+	a := mustParseArgs(t, []string{"--unknown"})
+	if len(a.CodexArgs) != 1 || a.CodexArgs[0] != "--unknown" {
+		t.Errorf("expected CodexArgs=[\"--unknown\"], got %v", a.CodexArgs)
+	}
+}
+
+func TestParseArgs_EmptyArgs(t *testing.T) {
+	a := mustParseArgs(t, []string{})
+	if a.Verbose || a.Version || a.ShowHelp {
+		t.Error("expected all bool flags false for empty args")
+	}
+	if a.Upstream != "" {
+		t.Errorf("expected empty Upstream, got %q", a.Upstream)
+	}
+	if a.LogFile != "" {
+		t.Errorf("expected empty LogFile, got %q", a.LogFile)
+	}
+	if a.Profile != "" {
+		t.Errorf("expected empty Profile, got %q", a.Profile)
+	}
+	if len(a.CodexArgs) != 0 {
+		t.Errorf("expected no CodexArgs, got %v", a.CodexArgs)
+	}
+	// #89 removed the --idle-timeout root flag; parseArgs no longer
+	// initialises Args.IdleTimeout. The default 30m default is now
+	// applied by buildServeArgs (serve_cmd.go); see
+	// TestBuildServeArgs_DefaultIdleTimeout.
+	if a.IdleTimeout != 0 {
+		t.Errorf("expected zero IdleTimeout from parseArgs (no longer parsed), got %v", a.IdleTimeout)
+	}
+	if a.Headless {
+		t.Error("expected Headless=false from parseArgs (no longer parsed; set only by runServeCommand)")
+	}
+}
+
+func TestParseArgs_Mixed(t *testing.T) {
+	a := mustParseArgs(t, []string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
+	if !a.ShowHelp {
+		t.Error("expected ShowHelp=true")
+	}
+	if !a.Verbose {
+		t.Error("expected Verbose=true")
+	}
+	if a.Upstream != "https://gw.example.com" {
+		t.Errorf("expected Upstream=%q, got %q", "https://gw.example.com", a.Upstream)
+	}
+}
+
+func TestParseArgs_Separator(t *testing.T) {
+	a := mustParseArgs(t, []string{"--verbose", "--", "--unknown", "arg1"})
+	if !a.Verbose {
+		t.Error("expected Verbose=true before separator")
+	}
+	if len(a.CodexArgs) != 2 || a.CodexArgs[0] != "--unknown" || a.CodexArgs[1] != "arg1" {
+		t.Errorf("expected CodexArgs=[\"--unknown\", \"arg1\"], got %v", a.CodexArgs)
+	}
+}
+
+// TestParseArgs_SeparatorForwardsHelp locks #95: "--" terminates wrapper
+// flag parsing, so "-- --help" must NOT trigger the wrapper's help and must
+// forward "--help" to codex verbatim. Together with handleHelp no longer
+// shelling out to `codex --help`, this is how users reach codex's own help.
+func TestParseArgs_SeparatorForwardsHelp(t *testing.T) {
+	a := mustParseArgs(t, []string{"--", "--help"})
+	if a.ShowHelp {
+		t.Error("expected ShowHelp=false when --help appears after --")
+	}
+	if len(a.CodexArgs) != 1 || a.CodexArgs[0] != "--help" {
+		t.Errorf("expected CodexArgs=[--help], got %v", a.CodexArgs)
+	}
+}
+
+func TestParseArgs_PassthroughArgs(t *testing.T) {
+	a := mustParseArgs(t, []string{"prompt text", "--unknown-flag", "gpt-4"})
+	if len(a.CodexArgs) != 3 {
+		t.Errorf("expected 3 CodexArgs, got %d: %v", len(a.CodexArgs), a.CodexArgs)
+	}
+}
+
+// --- Model flag tests ---
+
+func TestParseArgs_Model(t *testing.T) {
+	a := mustParseArgs(t, []string{"--model", "databricks-gpt-5-4-mini"})
+	if !a.ModelSet {
+		t.Error("expected ModelSet=true when --model is passed")
+	}
+	if a.Model != "databricks-gpt-5-4-mini" {
+		t.Errorf("expected Model=%q, got %q", "databricks-gpt-5-4-mini", a.Model)
+	}
+}
+
+func TestParseArgs_ModelEquals(t *testing.T) {
+	a := mustParseArgs(t, []string{"--model=custom-model"})
+	if !a.ModelSet {
+		t.Error("expected ModelSet=true when --model=value is passed")
+	}
+	if a.Model != "custom-model" {
+		t.Errorf("expected Model=%q, got %q", "custom-model", a.Model)
+	}
+}
+
+func TestParseArgs_ModelDefault(t *testing.T) {
+	a := mustParseArgs(t, []string{})
+	if a.ModelSet {
+		t.Error("expected ModelSet=false when --model is not passed")
+	}
+	if a.Model != "" {
+		t.Errorf("expected empty Model from parseArgs, got %q", a.Model)
+	}
+}
+
+func TestParseArgs_ModelNotPassedThrough(t *testing.T) {
+	a := mustParseArgs(t, []string{"--model", "my-model", "prompt"})
+	if !a.ModelSet {
+		t.Error("expected ModelSet=true")
+	}
+	if a.Model != "my-model" {
+		t.Errorf("expected Model=%q, got %q", "my-model", a.Model)
+	}
+	if len(a.CodexArgs) != 1 || a.CodexArgs[0] != "prompt" {
+		t.Errorf("expected CodexArgs=[\"prompt\"], got %v", a.CodexArgs)
+	}
+}
+
+// --- --idle-timeout strict parsing tests ---
+//
+// #89 removed --idle-timeout from the root flag set; parseArgs no longer
+// recognises it. The duration-parsing strict-validation surface (seconds /
+// minutes / hours / equals / bare-int rejected / garbage rejected / empty
+// rejected) lives on the serve subcommand now and is exercised by
+// TestBuildServeArgs_IdleTimeout* in serve_cmd_test.go. The legacy
+// --idle-timeout root flag falls through to CodexArgs (verified by
+// TestParseArgs_Table's "legacy --idle-timeout passes through" case).
+
+// Table-driven comprehensive test for parseArgs.
+func TestParseArgs_Table(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want Args
+	}{
+		{name: "--help sets showHelp", args: []string{"--help"}, want: Args{ShowHelp: true}},
+		{name: "-h sets showHelp", args: []string{"-h"}, want: Args{ShowHelp: true}},
+		{name: "--version sets version", args: []string{"--version"}, want: Args{Version: true}},
+		{name: "--verbose sets verbose", args: []string{"--verbose"}, want: Args{Verbose: true}},
+		{name: "-v sets verbose", args: []string{"-v"}, want: Args{Verbose: true}},
+		{name: "--log-file sets logFile", args: []string{"--log-file", "/tmp/test.log"}, want: Args{LogFile: "/tmp/test.log"}},
+		{name: "--log-file=value", args: []string{"--log-file=/tmp/test.log"}, want: Args{LogFile: "/tmp/test.log"}},
+		{name: "--upstream sets upstream", args: []string{"--upstream", "https://gw.example.com"}, want: Args{Upstream: "https://gw.example.com"}},
+		{name: "empty args all defaults", args: []string{}, want: Args{}},
+		{name: "--profile", args: []string{"--profile", "aidev"}, want: Args{Profile: "aidev"}},
+		{name: "--profile=value", args: []string{"--profile=aidev"}, want: Args{Profile: "aidev"}},
+		{name: "--model", args: []string{"--model", "my-model"}, want: Args{Model: "my-model", ModelSet: true}},
+		{name: "--port", args: []string{"--port", "9999"}, want: Args{PortFlag: 9999}},
+		{name: "--no-update-check", args: []string{"--no-update-check"}, want: Args{NoUpdateCheck: true}},
+		{
+			// #88 removed --install-hooks; the legacy flag is no longer in
+			// knownFlags, so parseArgs forwards it to codex unchanged.
+			name: "legacy --install-hooks now passes through to codex",
+			args: []string{"--install-hooks"},
+			want: Args{CodexArgs: []string{"--install-hooks"}},
+		},
+		{
+			name: "legacy --uninstall-hooks now passes through to codex",
+			args: []string{"--uninstall-hooks"},
+			want: Args{CodexArgs: []string{"--uninstall-hooks"}},
+		},
+		{
+			name: "legacy --headless-ensure now passes through to codex",
+			args: []string{"--headless-ensure"},
+			want: Args{CodexArgs: []string{"--headless-ensure"}},
+		},
+		{
+			// #89 removed --headless; the legacy flag is no longer in
+			// knownFlags, so parseArgs forwards it to codex unchanged.
+			// Users should migrate to `databricks-codex serve`.
+			name: "legacy --headless now passes through to codex",
+			args: []string{"--headless"},
+			want: Args{CodexArgs: []string{"--headless"}},
+		},
+		{
+			// #89 removed --idle-timeout. parseArgs forwards both the
+			// flag name and its value as separate codex args (it has no
+			// way to know the flag took a value).
+			name: "legacy --idle-timeout now passes through to codex",
+			args: []string{"--idle-timeout", "5m"},
+			want: Args{CodexArgs: []string{"--idle-timeout", "5m"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseArgs(tc.args)
+			if err != nil {
+				t.Fatalf("parseArgs unexpected error: %v", err)
+			}
+			if got.Verbose != tc.want.Verbose {
+				t.Errorf("Verbose: got %v, want %v", got.Verbose, tc.want.Verbose)
+			}
+			if got.Version != tc.want.Version {
+				t.Errorf("Version: got %v, want %v", got.Version, tc.want.Version)
+			}
+			if got.ShowHelp != tc.want.ShowHelp {
+				t.Errorf("ShowHelp: got %v, want %v", got.ShowHelp, tc.want.ShowHelp)
+			}
+			if got.Upstream != tc.want.Upstream {
+				t.Errorf("Upstream: got %q, want %q", got.Upstream, tc.want.Upstream)
+			}
+			if got.LogFile != tc.want.LogFile {
+				t.Errorf("LogFile: got %q, want %q", got.LogFile, tc.want.LogFile)
+			}
+			if got.Profile != tc.want.Profile {
+				t.Errorf("Profile: got %q, want %q", got.Profile, tc.want.Profile)
+			}
+			if got.Model != tc.want.Model {
+				t.Errorf("Model: got %q, want %q", got.Model, tc.want.Model)
+			}
+			if got.ModelSet != tc.want.ModelSet {
+				t.Errorf("ModelSet: got %v, want %v", got.ModelSet, tc.want.ModelSet)
+			}
+			if got.PortFlag != tc.want.PortFlag {
+				t.Errorf("PortFlag: got %d, want %d", got.PortFlag, tc.want.PortFlag)
+			}
+			if got.Headless != tc.want.Headless {
+				t.Errorf("Headless: got %v, want %v", got.Headless, tc.want.Headless)
+			}
+			if got.NoUpdateCheck != tc.want.NoUpdateCheck {
+				t.Errorf("NoUpdateCheck: got %v, want %v", got.NoUpdateCheck, tc.want.NoUpdateCheck)
+			}
+			if !equalStringSlice(got.CodexArgs, tc.want.CodexArgs) {
+				t.Errorf("CodexArgs: got %v, want %v", got.CodexArgs, tc.want.CodexArgs)
+			}
+		})
+	}
+}
+
+// --- default log discard test ---
+
+func TestDefaultLogDiscard(t *testing.T) {
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(os.Stderr)
+
+	var buf bytes.Buffer
+	log.SetOutput(io.Discard)
+	log.Print("this should be discarded")
+
+	log.SetOutput(&buf)
+	log.Print("this should appear")
+
+	if !strings.Contains(buf.String(), "this should appear") {
+		t.Error("expected log output after switching from Discard")
+	}
+}
+
+// --- handlePrintEnv tests ---
+
+func captureStdout(fn func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+// TestHandlePrintEnv_RedactsAllTokenShapes ensures that no matter the token
+// shape (legacy dapi-, no-hyphen dapi, JWT, empty), the literal token bytes
+// never appear in the printed output.
+func TestHandlePrintEnv_RedactsAllTokenShapes(t *testing.T) {
+	tokens := []string{
+		"dapi-abc123secret", // legacy hyphenated
+		"dapiabc123secret",  // no hyphen
+		"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig", // JWT-shaped
+		"", // empty
+	}
+	for _, token := range tokens {
+		t.Run(fmt.Sprintf("token=%q", token), func(t *testing.T) {
+			out := captureStdout(func() {
+				handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", token, "DEFAULT", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
+			})
+			if !strings.Contains(out, "**** (redacted)") {
+				t.Errorf("expected '**** (redacted)' in output, got:\n%s", out)
+			}
+			if token != "" && strings.Contains(out, token) {
+				t.Errorf("raw token %q should not appear in output, got:\n%s", token, out)
+			}
+		})
+	}
+}
+
+func TestHandlePrintEnv_NoLegacyDapiPrefix(t *testing.T) {
+	// Per #71, the legacy "dapi-***" branch was removed in favour of a single
+	// fixed redaction. Make sure no output ever contains the legacy form.
+	out := captureStdout(func() {
+		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "dapi-abc123", "DEFAULT", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
+	})
+	if strings.Contains(out, "dapi-***") {
+		t.Errorf("legacy 'dapi-***' redaction marker should be gone, got:\n%s", out)
+	}
+}
+
+func TestHandlePrintEnv_ContainsProfile(t *testing.T) {
+	out := captureStdout(func() {
+		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "aidev", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
+	})
+	if !strings.Contains(out, "aidev") {
+		t.Errorf("expected output to contain profile 'aidev', got:\n%s", out)
+	}
+}
+
+func TestHandlePrintEnv_ContainsDatabricksHost(t *testing.T) {
+	host := "https://dbc-abc123.cloud.databricks.com"
+	out := captureStdout(func() {
+		handlePrintEnv(host, "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
+	})
+	if !strings.Contains(out, host) {
+		t.Errorf("expected output to contain DATABRICKS_HOST %q, got:\n%s", host, out)
+	}
+}
+
+func TestHandlePrintEnv_ContainsOpenAIBaseURL(t *testing.T) {
+	baseURL := "https://gw.example.com/openai/v1"
+	out := captureStdout(func() {
+		handlePrintEnv("https://dbc.example.com", baseURL, "tok", "DEFAULT", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
+	})
+	if !strings.Contains(out, baseURL) {
+		t.Errorf("expected output to contain OPENAI_BASE_URL %q, got:\n%s", baseURL, out)
+	}
+}
+
+func TestHandlePrintEnv_ContainsModel(t *testing.T) {
+	out := captureStdout(func() {
+		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-4-mini", "main.codex_telemetry.codex_otel_metrics", "main.codex_telemetry.codex_otel_logs")
+	})
+	if !strings.Contains(out, "databricks-gpt-5-4-mini") {
+		t.Errorf("expected output to contain model 'databricks-gpt-5-4-mini', got:\n%s", out)
+	}
+	if !strings.Contains(out, "Model:") {
+		t.Errorf("expected output to contain 'Model:' label, got:\n%s", out)
+	}
+}
+
+// --- handleHelp tests ---
+
+func TestHandleHelp_ContainsDatabricksCodex(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp()
+	})
+	if !strings.Contains(out, "databricks-codex") {
+		t.Errorf("expected help output to contain 'databricks-codex', got:\n%s", out)
+	}
+}
+
+func TestHandleHelp_ContainsConfigSubcommand(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp()
+	})
+	if !strings.Contains(out, "config") {
+		t.Errorf("expected help output to advertise the config subcommand, got:\n%s", out)
+	}
+}
+
+// TestHandleHelp_DocumentsPassthrough locks #95: wrapper help must NOT
+// append codex's own --help, and MUST document the `--` passthrough escape
+// hatch so users still know how to reach codex's flags.
+func TestHandleHelp_DocumentsPassthrough(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp()
+	})
+	if strings.Contains(out, "Codex CLI Options:") {
+		t.Errorf("wrapper help must not append codex --help under a 'Codex CLI Options:' divider, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Passthrough to codex:") {
+		t.Errorf("expected help output to document the -- passthrough, got:\n%s", out)
+	}
+	if !strings.Contains(out, "databricks-codex -- --help") {
+		t.Errorf("expected help output to show the `-- --help` example, got:\n%s", out)
+	}
+}
+
+func TestHandleHelp_NoBareNumberMinutesWording(t *testing.T) {
+	// Per #70: help text must not advertise the bare-int minutes shortcut.
+	out := captureStdout(func() {
+		handleHelp()
+	})
+	if strings.Contains(out, "bare number = minutes") {
+		t.Errorf("help text should no longer advertise 'bare number = minutes', got:\n%s", out)
+	}
+}
+
+func TestParseArgs_Profile(t *testing.T) {
+	a := mustParseArgs(t, []string{"--profile", "aidev"})
+	if a.Profile != "aidev" {
+		t.Errorf("expected Profile=%q, got %q", "aidev", a.Profile)
+	}
+}
+
+func TestParseArgs_ProfileEquals(t *testing.T) {
+	a := mustParseArgs(t, []string{"--profile=production"})
+	if a.Profile != "production" {
+		t.Errorf("expected Profile=%q, got %q", "production", a.Profile)
+	}
+}
+
+// TestParseArgs_LegacyHeadlessPassthrough locks the breaking surface from
+// #89: the deleted --headless root flag must NOT be recognised by parseArgs;
+// it forwards to CodexArgs unchanged. Catches the regression where someone
+// re-adds the case in parseArgs without bringing back the flag.
+func TestParseArgs_LegacyHeadlessPassthrough(t *testing.T) {
+	a := mustParseArgs(t, []string{"--headless"})
+	if a.Headless {
+		t.Error("Args.Headless must NOT be set by parseArgs after #89; only runServeCommand sets it")
+	}
+	if len(a.CodexArgs) != 1 || a.CodexArgs[0] != "--headless" {
+		t.Errorf("legacy --headless must pass through to CodexArgs, got %v", a.CodexArgs)
+	}
+}
+
+// TestParseArgs_LegacyIdleTimeoutPassthrough is the symmetric check for
+// the deleted --idle-timeout root flag.
+func TestParseArgs_LegacyIdleTimeoutPassthrough(t *testing.T) {
+	a := mustParseArgs(t, []string{"--idle-timeout", "5m"})
+	if a.IdleTimeout != 0 {
+		t.Errorf("Args.IdleTimeout must NOT be set by parseArgs after #89, got %v", a.IdleTimeout)
+	}
+	// The flag name and its value both fall through as positional args
+	// because parseArgs has no metadata to tell it the legacy flag took a
+	// value. Both tokens land in CodexArgs.
+	if len(a.CodexArgs) != 2 || a.CodexArgs[0] != "--idle-timeout" || a.CodexArgs[1] != "5m" {
+		t.Errorf("legacy --idle-timeout must pass through to CodexArgs, got %v", a.CodexArgs)
+	}
+}
+
+func TestParseArgs_NoUpdateCheck(t *testing.T) {
+	a := mustParseArgs(t, []string{"--no-update-check"})
+	if !a.NoUpdateCheck {
+		t.Error("expected NoUpdateCheck=true for --no-update-check")
+	}
+}
+
+func TestHandleHelp_AllFlagsPresent(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp()
+	})
+	// Legacy hook flags (--install-hooks / --uninstall-hooks /
+	// --headless-ensure) were lifted to the `hooks` subcommand in #88; the
+	// OTEL/--print-env flags moved to `config otel`/`config show` in #87.
+	// --headless / --idle-timeout were lifted to the `serve` subcommand in
+	// #89. The help text now lists `config`, `hooks`, and `serve` instead.
+	flags := []string{"--profile", "--model", "--upstream", "--verbose", "-v", "--log-file", "--port", "--no-update-check", "--version", "--help", "config", "hooks", "serve"}
+	for _, flag := range flags {
+		if !strings.Contains(out, flag) {
+			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)
+		}
+	}
+}
+
+// TestHandleHelp_LegacyHeadlessFlagsAbsent locks the breaking surface
+// change from #89: --headless and --idle-timeout must NOT appear in the
+// root help text. If a future refactor re-adds them, this test fires.
+func TestHandleHelp_LegacyHeadlessFlagsAbsent(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp()
+	})
+	for _, flag := range []string{"--headless", "--idle-timeout"} {
+		if strings.Contains(out, flag) {
+			t.Errorf("root help still mentions %q after #89 migration; users will discover the dead flag", flag)
+		}
+	}
+}
+
+func TestHandleHelp_LegacyOtelFlagsAbsent(t *testing.T) {
+	// Locks the breaking surface: #87 removed these from the root.
+	out := captureStdout(func() {
+		handleHelp()
+	})
+	for _, flag := range []string{"--otel", "--no-otel", "--no-otel-metrics", "--no-otel-logs", "--otel-metrics-table", "--otel-logs-table", "--print-env"} {
+		if strings.Contains(out, flag) {
+			t.Errorf("root help still mentions %q after #87 migration; users will discover the dead flag", flag)
+		}
+	}
+}
+
+func TestHandleHelp_ContainsVersion(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp()
+	})
+	if !strings.Contains(out, fmt.Sprintf("databricks-codex v%s", Version)) {
+		t.Errorf("expected help output to contain version string, got:\n%s", out)
+	}
+}
+
+// --- deriveLogsTable test ---
+//
+// resolveOtelLogsTable / resolveOtelMetricsTable were inlined into the
+// `config otel enable` resolver in #87; their unit tests folded into
+// TestResolveConfigOTEL_OrchestrationMatrix in cli_config_test.go.
+
+func TestDeriveLogsTable(t *testing.T) {
+	tests := []struct {
+		name    string
+		metrics string
+		want    string
+	}{
+		{name: "standard _otel_metrics suffix is replaced", metrics: "main.tel.codex_otel_metrics", want: "main.tel.codex_otel_logs"},
+		{name: "custom suffix gets _otel_logs appended", metrics: "cat.schema.custom", want: "cat.schema.custom_otel_logs"},
+		{name: "empty metrics returns empty", metrics: "", want: ""},
+		{name: "bare _otel_metrics replaced", metrics: "_otel_metrics", want: "_otel_logs"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveLogsTable(tc.metrics)
+			if got != tc.want {
+				t.Errorf("deriveLogsTable(%q) = %q, want %q", tc.metrics, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- resolveOtel integration tests (state-only signature, post-#87) ---
+//
+// #87 turned resolveOtel into a pure read-only consumer of saved state.
+// The session-time flag combinations that drove the legacy resolveOtel
+// matrix moved to TestResolveConfigOTEL_OrchestrationMatrix
+// (cli_config_test.go) — that's the writer side. resolveOtel is the
+// reader side and is much smaller now.
+
+func TestResolveOtel(t *testing.T) {
+	const customMetrics = "cat.schema.codex_otel_metrics"
+	const customLogs = "cat.schema.codex_otel_logs"
+
+	tests := []struct {
+		name        string
+		saved       persistentState
+		wantOtel    bool
+		wantMetrics string
+		wantLogs    string
+	}{
+		{
+			name:     "empty state: otel off, both tables empty",
+			saved:    persistentState{},
+			wantOtel: false, wantMetrics: "", wantLogs: "",
+		},
+		{
+			name:        "saved tables, no disables: otel on, both tables flow through",
+			saved:       persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs},
+			wantOtel:    true,
+			wantMetrics: customMetrics,
+			wantLogs:    customLogs,
+		},
+		{
+			name:     "saved tables but both Disabled bits set: hard off (the post-`config otel disable` shape)",
+			saved:    persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs, OtelMetricsDisabled: true, OtelLogsDisabled: true},
+			wantOtel: false, wantMetrics: "", wantLogs: "",
+		},
+		{
+			name:        "saved tables with metrics disabled only: logs preserved (the per-signal disable shape)",
+			saved:       persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs, OtelMetricsDisabled: true},
+			wantOtel:    true,
+			wantMetrics: "",
+			wantLogs:    customLogs,
+		},
+		{
+			name:        "saved tables with logs disabled only: metrics preserved",
+			saved:       persistentState{OtelMetricsTable: customMetrics, OtelLogsTable: customLogs, OtelLogsDisabled: true},
+			wantOtel:    true,
+			wantMetrics: customMetrics,
+			wantLogs:    "",
+		},
+		{
+			name:        "saved metrics only: otel on, logs empty",
+			saved:       persistentState{OtelMetricsTable: customMetrics},
+			wantOtel:    true,
+			wantMetrics: customMetrics,
+			wantLogs:    "",
+		},
+		{
+			name:     "Disabled bits set on empty tables: still off (no-op)",
+			saved:    persistentState{OtelMetricsDisabled: true, OtelLogsDisabled: true},
+			wantOtel: false, wantMetrics: "", wantLogs: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			otel, metrics, logs := resolveOtel(tc.saved)
+			if otel != tc.wantOtel {
+				t.Errorf("otel: got %v, want %v", otel, tc.wantOtel)
+			}
+			if metrics != tc.wantMetrics {
+				t.Errorf("metricsTable: got %q, want %q", metrics, tc.wantMetrics)
+			}
+			if logs != tc.wantLogs {
+				t.Errorf("logsTable: got %q, want %q", logs, tc.wantLogs)
+			}
+		})
+	}
+}
+
+func TestHandlePrintEnv_ContainsOtelLogsTable(t *testing.T) {
+	table := "main.custom.otel_logs"
+	out := captureStdout(func() {
+		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-5", "main.codex_telemetry.codex_otel_metrics", table)
+	})
+	if !strings.Contains(out, table) {
+		t.Errorf("expected output to contain OTEL Logs Table %q, got:\n%s", table, out)
+	}
+	if !strings.Contains(out, "OTEL Logs Table:") {
+		t.Errorf("expected output to contain 'OTEL Logs Table:' label, got:\n%s", out)
+	}
+}
+
+func TestHandlePrintEnv_ContainsOtelMetricsTable(t *testing.T) {
+	table := "main.custom.otel_metrics"
+	out := captureStdout(func() {
+		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-5", table, "main.codex_telemetry.codex_otel_logs")
+	})
+	if !strings.Contains(out, table) {
+		t.Errorf("expected output to contain OTEL Metrics Table %q, got:\n%s", table, out)
+	}
+	if !strings.Contains(out, "OTEL Metrics Table:") {
+		t.Errorf("expected output to contain 'OTEL Metrics Table:' label, got:\n%s", out)
+	}
+}
+
+func TestHandlePrintEnv_DisabledTablesRenderAsDisabled(t *testing.T) {
+	out := captureStdout(func() {
+		handlePrintEnv("https://dbc.example.com", "https://gw.example.com/openai/v1", "tok", "DEFAULT", "databricks-gpt-5-5", "", "")
+	})
+	if !strings.Contains(out, "OTEL Metrics Table:  (disabled)") {
+		t.Errorf("expected '(disabled)' for metrics table when empty, got:\n%s", out)
+	}
+	if !strings.Contains(out, "OTEL Logs Table:     (disabled)") {
+		t.Errorf("expected '(disabled)' for logs table when empty, got:\n%s", out)
+	}
+}
+
+// --- resolveProfile tests ---
+
+func TestResolveProfile_FlagWinsOverStateFile(t *testing.T) {
+	got := resolveProfile("from-flag", "from-state")
+	if got != "from-flag" {
+		t.Errorf("expected flag value %q, got %q", "from-flag", got)
+	}
+}
+
+func TestResolveProfile_StateFileWinsOverEnvVar(t *testing.T) {
+	t.Setenv("DATABRICKS_CONFIG_PROFILE", "from-env")
+	got := resolveProfile("", "from-state")
+	if got != "from-state" {
+		t.Errorf("expected state file value %q, got %q — env var should be ignored", "from-state", got)
+	}
+}
+
+func TestResolveProfile_FallsBackToDefault(t *testing.T) {
+	got := resolveProfile("", "")
+	if got != "DEFAULT" {
+		t.Errorf("expected %q, got %q", "DEFAULT", got)
+	}
+}
+
+func TestResolveProfile_FlagWinsOverStateFile_Integration(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	saveState(persistentState{Profile: "saved-profile"})
+
+	got := resolveProfile("flag-profile", loadState().Profile)
+	if got != "flag-profile" {
+		t.Errorf("expected flag profile %q, got %q", "flag-profile", got)
+	}
+}
+
+func TestResolveProfile_StateFileUsedWhenNoFlag(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	saveState(persistentState{Profile: "saved-profile"})
+
+	got := resolveProfile("", loadState().Profile)
+	if got != "saved-profile" {
+		t.Errorf("expected saved profile %q, got %q", "saved-profile", got)
+	}
+}
+
+func TestResolveProfile_DefaultWhenNoStateFile(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "nonexistent.json") }
+	defer func() { statePath = orig }()
+
+	got := resolveProfile("", loadState().Profile)
+	if got != "DEFAULT" {
+		t.Errorf("expected %q, got %q", "DEFAULT", got)
+	}
+}
+
+func TestResolveProfile_Table(t *testing.T) {
+	tests := []struct {
+		name       string
+		flagValue  string
+		savedValue string
+		want       string
+	}{
+		{"flag wins over saved", "flag-profile", "saved-profile", "flag-profile"},
+		{"saved wins over default", "", "saved-profile", "saved-profile"},
+		{"default when both empty", "", "", "DEFAULT"},
+		{"flag wins over empty saved", "flag-profile", "", "flag-profile"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveProfile(tc.flagValue, tc.savedValue)
+			if got != tc.want {
+				t.Errorf("resolveProfile(%q, %q) = %q, want %q",
+					tc.flagValue, tc.savedValue, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCompletionFlagsCoverAllKnownFlags ensures every flag in knownFlags has a
+// corresponding entry in flagDefs — prevents silent drift between the real CLI
+// and the generated shell completions.
+func TestCompletionFlagsCoverAllKnownFlags(t *testing.T) {
+	covered := make(map[string]bool, len(flagDefs))
+	for _, f := range flagDefs {
+		covered["--"+f.Name] = true
+	}
+	for flag := range knownFlags {
+		if !covered[flag] {
+			t.Errorf("flag %s is in knownFlags but missing from flagDefs in completion_flags.go", flag)
+		}
+	}
+}
+
+// TestKnownFlagsCoverAllFlagDefs is the inverse: every FlagDef must appear in
+// knownFlags so the parser actually recognises it.
+func TestKnownFlagsCoverAllFlagDefs(t *testing.T) {
+	for _, f := range flagDefs {
+		name := "--" + f.Name
+		if !knownFlags[name] {
+			t.Errorf("flagDef %q is missing from knownFlags in completion_flags.go", name)
+		}
+	}
+}
+
+// TestRootTreeFlagsAreParseRecognised verifies that every flag declared on
+// rootCommand (the source of truth for the binary's CLI surface) is actually
+// handled by parseArgs. Catches the case where a flag is added to the tree
+// in commands.go but the matching switch case is forgotten in main.go's
+// parseArgs — the explicit default arm in parseArgs returns an error in
+// that scenario, which this test surfaces as a per-flag failure.
+//
+// This is the "tree → parser" half of the bidirectional parity check;
+// TestParseArgsRecognisedFlagsAreInTree below covers the inverse direction.
+func TestRootTreeFlagsAreParseRecognised(t *testing.T) {
+	for _, f := range rootCommand.AllFlags() {
+		var args []string
+		if f.TakesArg {
+			args = []string{"--" + f.Name, "value"}
+		} else {
+			args = []string{"--" + f.Name}
+		}
+		if _, err := parseArgs(args); err != nil {
+			t.Errorf("parseArgs(%v) returned error %v — flag %q is declared on rootCommand but parseArgs has no case for it", args, err, f.Name)
+		}
+	}
+}
+
+// TestParseArgsRecognisedFlagsAreInTree is the inverse parity check: every
+// flag the parser thinks it owns (knownFlags) must appear in rootCommand.
+// Since knownFlags is now derived from rootCommand, this is structurally
+// guaranteed — the test is here to document the contract and to fail
+// loudly if a future refactor decouples the two.
+func TestParseArgsRecognisedFlagsAreInTree(t *testing.T) {
+	treeNames := map[string]bool{}
+	for _, f := range rootCommand.AllFlags() {
+		treeNames["--"+f.Name] = true
+	}
+	for name := range knownFlags {
+		if !treeNames[name] {
+			t.Errorf("knownFlags contains %q but it is not declared on rootCommand", name)
+		}
+	}
+}
+
+// TestResolveModel_DefaultIsGpt5_5 locks the built-in default model against
+// silent drift. When no flag is passed and saved state is empty, resolveModel
+// must return databricks-gpt-5-5. Bumping the default requires updating this
+// test in the same commit, which serves as an explicit checkpoint.
+func TestResolveModel_DefaultIsGpt5_5(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	// Empty saved state + no flag + no env → built-in default fires.
+	got := resolveModel("", loadState().Model)
+	want := "databricks-gpt-5-5"
+	if got != want {
+		t.Errorf("resolveModel default = %q, want %q", got, want)
+	}
+}

--- a/cmd/databricks-codex/profile_codex.go
+++ b/cmd/databricks-codex/profile_codex.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/IceRhymers/databricks-agents/internal/codex/tomlconfig"
+	"github.com/IceRhymers/databricks-agents/internal/profile"
+)
+
+// ProfileName is the stable identifier for the databricks-codex profile. Live
+// wiring references CodexProfile() by this typed constructor rather than a
+// string Registry.Lookup, so the compiler proves the seam is connected.
+const ProfileName = "databricks-codex"
+
+// codexConfigPath resolves ~/.codex/config.toml. Unlike claude (whose settings
+// file is a JSON env block), codex's "settings file" is the TOML config the
+// tomlconfig.Manager surgically patches. core.Run never reads Profile.ConfigPath
+// (it drives patching through PatchSettings), so this is informational metadata
+// mirroring the claudeSettingsPath seam.
+func codexConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".codex", "config.toml"), nil
+}
+
+// codexSettingsPatcher implements profile.SettingsPatcher for codex. Unlike
+// claude — which writes an env block into settings.json — codex has NO
+// settings.json env block; its per-session configuration is the surgical
+// patch of ~/.codex/config.toml performed by tomlconfig.Manager. That is why
+// the LaunchPlan sets BuildEnv = nil and this patcher carries the launch-time
+// static values (model, OTEL tables) as fields (Option A): only base_url +
+// the OTEL exporter endpoints are proxyURL-dependent, and those are computed
+// from req.ProxyURL here at patch time.
+//
+// The zero value is a valid profile.SettingsPatcher (satisfies the compile
+// assertion and the Registry's API-shape usage); Patch lazily constructs a
+// default Manager when mgr is nil so the zero value never nil-derefs. The
+// launch path always supplies a field-bearing value via buildCodexLaunchPlan.
+type codexSettingsPatcher struct {
+	mgr              *tomlconfig.Manager
+	model            string
+	modelExplicit    bool
+	otelMetricsTable string
+	otelLogsTable    string
+	otelEnabled      bool
+}
+
+// newCodexPatcher is the single constructor for a field-bearing
+// codexSettingsPatcher. Both config.toml writers — wrapper-mode
+// (buildCodexLaunchPlan → core.Run) and the serve sibling (runServeSession) —
+// build their patcher HERE so their fields cannot drift apart; that is the
+// structural half of the F2 byte-parity guarantee (TestCodexConfig_CrossPathByteIdentical
+// is the behavioral half). Every call site passes a fresh tomlconfig.NewManager("").
+func newCodexPatcher(model string, modelExplicit bool, otelMetricsTable, otelLogsTable string, otelEnabled bool) codexSettingsPatcher {
+	return codexSettingsPatcher{
+		mgr:              tomlconfig.NewManager(""),
+		model:            model,
+		modelExplicit:    modelExplicit,
+		otelMetricsTable: otelMetricsTable,
+		otelLogsTable:    otelLogsTable,
+		otelEnabled:      otelEnabled,
+	}
+}
+
+// Patch surgically rewrites ~/.codex/config.toml so codex authenticates through
+// the local proxy. It computes base_url + the OTEL exporter endpoints from
+// req.ProxyURL and delegates to tomlconfig.Patch — the SAME writer the serve
+// sibling calls (F2), so both entrypoints emit byte-identical config.toml for
+// identical inputs. The OTEL endpoint gating mirrors the pre-unification inline
+// EnsureConfig: an endpoint is emitted only when OTEL is enabled AND its table
+// is non-empty (an empty endpoint makes tomlconfig remove the [otel] section
+// rather than leave stale exporter lines).
+//
+// Patch is invoked exactly once per process (once by core.Run in wrapper mode,
+// once by runServeSession in serve mode) and never concurrently, so the
+// in-process sync.Mutex the pre-unification ConfigManager.EnsureConfig held is
+// not needed here.
+func (p codexSettingsPatcher) Patch(req profile.PatchRequest) error {
+	mgr := p.mgr
+	if mgr == nil {
+		mgr = tomlconfig.NewManager("")
+	}
+
+	otelLogsEndpoint := ""
+	otelMetricsEndpoint := ""
+	if p.otelEnabled {
+		if p.otelLogsTable != "" {
+			otelLogsEndpoint = req.ProxyURL + "/otel/v1/logs"
+		}
+		if p.otelMetricsTable != "" {
+			otelMetricsEndpoint = req.ProxyURL + "/otel/v1/metrics"
+		}
+	}
+
+	if err := mgr.Patch(tomlconfig.PatchConfig{
+		ProxyURL:            req.ProxyURL,
+		Model:               p.model,
+		ModelExplicit:       p.modelExplicit,
+		OTELLogsEndpoint:    otelLogsEndpoint,
+		OTELMetricsEndpoint: otelMetricsEndpoint,
+	}); err != nil {
+		return err
+	}
+
+	// Clean up any stale backup from pre-v0.6.0 crash recovery (parity with
+	// the pre-unification ConfigManager.EnsureConfig side effect).
+	os.Remove(mgr.ConfigPath() + ".databricks-codex-backup")
+
+	log.Printf("databricks-codex: ensured config.toml (proxy: %s)", req.ProxyURL)
+	return nil
+}
+
+// Restore is an explicit unwired no-op scoped to #E, matching the claude
+// profile: there is no config.toml restore free function to delegate to on
+// this branch. Kept for interface-shape stability only.
+func (codexSettingsPatcher) Restore(profile.RestoreRequest) error {
+	return nil
+}
+
+// codexDaemon implements profile.DaemonStrategy for codex as an INERT
+// API-shape conformance. Codex has no long-lived OS service: its `serve`
+// subcommand is a session/headless leaf with no install/uninstall/status
+// (no LaunchAgent/systemd/schtasks). These methods are never invoked at
+// runtime; they exist only so codex fills the same Profile slots as claude.
+// Install/Uninstall return the ErrDaemonUnsupported sentinel; Status and
+// Diagnostics return zero values.
+type codexDaemon struct{}
+
+func (codexDaemon) Install(profile.DaemonInstallRequest) error {
+	return profile.ErrDaemonUnsupported
+}
+
+func (codexDaemon) Uninstall() error {
+	return profile.ErrDaemonUnsupported
+}
+
+func (codexDaemon) Status(int) (profile.DaemonStatus, error) {
+	return profile.DaemonStatus{}, nil
+}
+
+func (codexDaemon) Diagnostics() (string, error) {
+	return "", nil
+}
+
+// codexHooks implements profile.HookInstaller for codex by delegating to the
+// installHooks / uninstallHooks free functions against ~/.codex/hooks.json.
+// It carries the config.toml [features] hooks=true side effect (and its
+// documented TOCTOU) forward unchanged from the standalone repo.
+type codexHooks struct{}
+
+func codexHooksPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".codex", "hooks.json"), nil
+}
+
+func (codexHooks) Install() error {
+	path, err := codexHooksPath()
+	if err != nil {
+		return err
+	}
+	return installHooks(path)
+}
+
+func (codexHooks) Uninstall() error {
+	path, err := codexHooksPath()
+	if err != nil {
+		return err
+	}
+	return uninstallHooks(path)
+}
+
+// Compile-time conformance assertions. The zero-value patcher satisfies the
+// interface so Registry / tests can register a representative Profile.
+var (
+	_ profile.SettingsPatcher = codexSettingsPatcher{}
+	_ profile.DaemonStrategy  = codexDaemon{}
+	_ profile.HookInstaller   = codexHooks{}
+)
+
+// CodexProfile constructs the databricks-codex profile.Profile. It is a
+// one-arg factory (Option A): the launch path passes the field-bearing
+// codexSettingsPatcher built by buildCodexLaunchPlan; Registry/tests pass a
+// zero-value codexSettingsPatcher{}. Built in package main (not
+// internal/profile) so Profile construction never drags tomlconfig or other
+// launcher-only deps into internal/profile.
+func CodexProfile(patcher profile.SettingsPatcher) profile.Profile {
+	return profile.Profile{
+		Name:           ProfileName,
+		ChildBinary:    "codex",
+		ConfigPath:     codexConfigPath,
+		GatewayPath:    "/ai-gateway/openai/v1",
+		PatchSettings:  patcher,
+		DaemonStrategy: codexDaemon{},
+		HookInstaller:  codexHooks{},
+	}
+}

--- a/cmd/databricks-codex/profile_codex_test.go
+++ b/cmd/databricks-codex/profile_codex_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/IceRhymers/databricks-agents/internal/profile"
+)
+
+// Compile-time conformance for the three codex implementations. Mirrors the
+// claude profile_claude_test.go asserts so the seam types stay interface-shaped.
+var (
+	_ profile.SettingsPatcher = codexSettingsPatcher{}
+	_ profile.DaemonStrategy  = codexDaemon{}
+	_ profile.HookInstaller   = codexHooks{}
+)
+
+// TestCodexProfile_Fields asserts the constructed Profile carries the expected
+// scalar fields and non-nil interface implementations. Locks the two codex
+// deviations from claude: ChildBinary="codex" and the OpenAI gateway path.
+func TestCodexProfile_Fields(t *testing.T) {
+	p := CodexProfile(codexSettingsPatcher{})
+	if p.Name != ProfileName {
+		t.Errorf("Name = %q, want %q", p.Name, ProfileName)
+	}
+	if p.Name != "databricks-codex" {
+		t.Errorf("ProfileName = %q, want %q", p.Name, "databricks-codex")
+	}
+	if p.ChildBinary != "codex" {
+		t.Errorf("ChildBinary = %q, want %q", p.ChildBinary, "codex")
+	}
+	if p.GatewayPath != "/ai-gateway/openai/v1" {
+		t.Errorf("GatewayPath = %q, want %q", p.GatewayPath, "/ai-gateway/openai/v1")
+	}
+	if p.ConfigPath == nil {
+		t.Error("ConfigPath must be non-nil")
+	}
+	if p.PatchSettings == nil {
+		t.Error("PatchSettings must be non-nil")
+	}
+	if p.DaemonStrategy == nil {
+		t.Error("DaemonStrategy must be non-nil")
+	}
+	if p.HookInstaller == nil {
+		t.Error("HookInstaller must be non-nil")
+	}
+}
+
+// TestCodexProfile_PatcherIsWired asserts CodexProfile threads the supplied
+// field-bearing patcher through as PatchSettings (not a fresh zero value). A
+// same-typed swap that dropped the argument would silently mis-route config.toml
+// patching, so the test drives a distinguishing value through the seam.
+func TestCodexProfile_PatcherIsWired(t *testing.T) {
+	inTempCodexHome(t, func(home string) {
+		patcher := codexSettingsPatcher{
+			model:         "sentinel-model",
+			modelExplicit: true,
+		}
+		p := CodexProfile(patcher)
+		if err := p.PatchSettings.Patch(profile.PatchRequest{ProxyURL: "http://127.0.0.1:49154"}); err != nil {
+			t.Fatalf("Patch through profile seam: %v", err)
+		}
+		got := readCodexConfig(t, home)
+		if !strings.Contains(got, `model = "sentinel-model"`) {
+			t.Errorf("field-bearing patcher was not wired through CodexProfile; config.toml:\n%s", got)
+		}
+	})
+}
+
+// TestCodexDaemon_UnsupportedSentinel asserts codexDaemon is an INERT
+// API-shape conformance: Install/Uninstall return the ErrDaemonUnsupported
+// sentinel (codex has no LaunchAgent/systemd/schtasks), and Status/Diagnostics
+// return zero values without error. Codex's `serve` is a leaf; these methods
+// must never succeed silently as if a daemon were installed.
+func TestCodexDaemon_UnsupportedSentinel(t *testing.T) {
+	var d codexDaemon
+
+	if err := d.Install(profile.DaemonInstallRequest{}); !errors.Is(err, profile.ErrDaemonUnsupported) {
+		t.Errorf("Install err = %v, want ErrDaemonUnsupported", err)
+	}
+	if err := d.Uninstall(); !errors.Is(err, profile.ErrDaemonUnsupported) {
+		t.Errorf("Uninstall err = %v, want ErrDaemonUnsupported", err)
+	}
+
+	st, err := d.Status(49154)
+	if err != nil {
+		t.Errorf("Status err = %v, want nil", err)
+	}
+	if st != (profile.DaemonStatus{}) {
+		t.Errorf("Status = %+v, want zero value", st)
+	}
+
+	diag, err := d.Diagnostics()
+	if err != nil {
+		t.Errorf("Diagnostics err = %v, want nil", err)
+	}
+	if diag != "" {
+		t.Errorf("Diagnostics = %q, want empty", diag)
+	}
+}
+
+// TestCodexHooks_ParityWithFreeFunctions asserts codexHooks.Install produces
+// byte-identical hooks.json to the installHooks free function, and
+// codexHooks.Uninstall round-trips (uninstall after install matches
+// uninstallHooks output). Mirrors claude's TestClaudeHooks_ParityWithFreeFunctions.
+func TestCodexHooks_ParityWithFreeFunctions(t *testing.T) {
+	// Install parity: fresh install via free function vs interface impl.
+	dir := t.TempDir()
+	directPath := dir + "/.codex/hooks.json"
+	if err := installHooks(directPath); err != nil {
+		t.Fatalf("installHooks: %v", err)
+	}
+	directInstalled := readFile(t, directPath)
+
+	var viaInterface string
+	inTempCodexHome(t, func(home string) {
+		if err := (codexHooks{}).Install(); err != nil {
+			t.Fatalf("codexHooks.Install: %v", err)
+		}
+		viaInterface = readFile(t, home+"/.codex/hooks.json")
+	})
+
+	if directInstalled != viaInterface {
+		t.Errorf("install bytes differ:\n--- installHooks ---\n%s\n--- codexHooks.Install ---\n%s",
+			directInstalled, viaInterface)
+	}
+
+	// Uninstall parity + round-trip.
+	if err := uninstallHooks(directPath); err != nil {
+		t.Fatalf("uninstallHooks: %v", err)
+	}
+	directAfterUninstall := readFile(t, directPath)
+
+	var viaInterfaceUninstall string
+	inTempCodexHome(t, func(home string) {
+		if err := (codexHooks{}).Install(); err != nil {
+			t.Fatalf("codexHooks.Install (round-trip): %v", err)
+		}
+		if err := (codexHooks{}).Uninstall(); err != nil {
+			t.Fatalf("codexHooks.Uninstall: %v", err)
+		}
+		viaInterfaceUninstall = readFile(t, home+"/.codex/hooks.json")
+	})
+
+	if directAfterUninstall != viaInterfaceUninstall {
+		t.Errorf("uninstall bytes differ:\n--- uninstallHooks ---\n%s\n--- codexHooks.Uninstall ---\n%s",
+			directAfterUninstall, viaInterfaceUninstall)
+	}
+}
+
+// TestCodexSettingsPatcher_RestoreIsNoOp locks the documented #E scope: Restore
+// is an explicit unwired no-op for codex (no config.toml restore free function
+// on this branch). It must never error.
+func TestCodexSettingsPatcher_RestoreIsNoOp(t *testing.T) {
+	if err := (codexSettingsPatcher{}).Restore(profile.RestoreRequest{}); err != nil {
+		t.Errorf("Restore err = %v, want nil", err)
+	}
+}

--- a/cmd/databricks-codex/profile_patch_golden_test.go
+++ b/cmd/databricks-codex/profile_patch_golden_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/IceRhymers/databricks-agents/internal/codex/tomlconfig"
+	"github.com/IceRhymers/databricks-agents/internal/profile"
+)
+
+// Golden config.toml outputs, captured from the ported tomlconfig.Patch (which
+// is byte-identical to the standalone databricks-codex repo — the package was
+// copied verbatim). These pins guard against any future edit to tomlconfig or
+// codexSettingsPatcher that would change the observable config.toml wire shape:
+// base_url, wire_api="responses", the model_providers.databricks-proxy block,
+// and the [otel] section when endpoints are set.
+const (
+	goldenProxyURL = "http://127.0.0.1:49154"
+
+	// Fresh install, OTEL off, explicit model.
+	goldenFreshNoOTEL = "\nprofile = \"databricks-proxy\"\n\n" +
+		"[profiles.databricks-proxy]\n" +
+		"model_provider = \"databricks-proxy\"\n" +
+		"model = \"databricks-gpt-5-5\"\n\n" +
+		"[model_providers.databricks-proxy]\n" +
+		"name = \"Databricks Proxy\"\n" +
+		"base_url = \"http://127.0.0.1:49154\"\n" +
+		"api_key = \"databricks-proxy\"\n" +
+		"wire_api = \"responses\"\n"
+
+	// Fresh install, OTEL on (both metrics + logs endpoints).
+	goldenFreshOTEL = "\nprofile = \"databricks-proxy\"\n\n" +
+		"[profiles.databricks-proxy]\n" +
+		"model_provider = \"databricks-proxy\"\n" +
+		"model = \"databricks-gpt-5-5\"\n\n" +
+		"[model_providers.databricks-proxy]\n" +
+		"name = \"Databricks Proxy\"\n" +
+		"base_url = \"http://127.0.0.1:49154\"\n" +
+		"api_key = \"databricks-proxy\"\n" +
+		"wire_api = \"responses\"\n\n" +
+		"[otel]\n" +
+		"environment = \"production\"\n" +
+		"exporter = { otlp-http = { endpoint = \"http://127.0.0.1:49154/otel/v1/logs\", protocol = \"binary\" } }\n" +
+		"metrics_exporter = { otlp-http = { endpoint = \"http://127.0.0.1:49154/otel/v1/metrics\", protocol = \"binary\" } }\n"
+)
+
+// newCodexPatcherAt builds the field-bearing patcher pointed at a test cfgPath,
+// mirroring the production newCodexPatcher (which targets the default
+// ~/.codex/config.toml) but injecting a temp-file path so goldens are hermetic.
+func newCodexPatcherAt(cfgPath, model string, modelExplicit bool, metricsTable, logsTable string, otelEnabled bool) codexSettingsPatcher {
+	return codexSettingsPatcher{
+		mgr:              tomlconfig.NewManager(cfgPath),
+		model:            model,
+		modelExplicit:    modelExplicit,
+		otelMetricsTable: metricsTable,
+		otelLogsTable:    logsTable,
+		otelEnabled:      otelEnabled,
+	}
+}
+
+// TestCodexPatch_GoldenFreshNoOTEL asserts a fresh-install patch (no prior
+// config.toml, OTEL off) produces the pinned config.toml byte-for-byte.
+func TestCodexPatch_GoldenFreshNoOTEL(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	p := newCodexPatcherAt(cfgPath, "databricks-gpt-5-5", true, "", "", false)
+	if err := p.Patch(profile.PatchRequest{ProxyURL: goldenProxyURL}); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	got := readFile(t, cfgPath)
+	if got != goldenFreshNoOTEL {
+		t.Errorf("config.toml not byte-identical to golden\n--- got ---\n%q\n--- want ---\n%q", got, goldenFreshNoOTEL)
+	}
+}
+
+// TestCodexPatch_GoldenFreshOTEL asserts the OTEL-on patch emits the [otel]
+// section (both exporter + metrics_exporter) byte-for-byte.
+func TestCodexPatch_GoldenFreshOTEL(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	p := newCodexPatcherAt(cfgPath, "databricks-gpt-5-5", true,
+		"main.codex_telemetry.codex_otel_metrics",
+		"main.codex_telemetry.codex_otel_logs", true)
+	if err := p.Patch(profile.PatchRequest{ProxyURL: goldenProxyURL}); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	got := readFile(t, cfgPath)
+	if got != goldenFreshOTEL {
+		t.Errorf("config.toml not byte-identical to golden\n--- got ---\n%q\n--- want ---\n%q", got, goldenFreshOTEL)
+	}
+}
+
+// TestCodexPatch_StaleBaseURLSelfHeal asserts a dead prior proxy's base_url is
+// replaced idempotently on the next patch: patching over a config that already
+// points at a stale, dead port heals base_url to the live proxy URL, and a
+// second identical patch is a no-op (byte-stable).
+func TestCodexPatch_StaleBaseURLSelfHeal(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	stale := "profile = \"databricks-proxy\"\n\n" +
+		"[profiles.databricks-proxy]\n" +
+		"model_provider = \"databricks-proxy\"\n" +
+		"model = \"databricks-gpt-5-5\"\n\n" +
+		"[model_providers.databricks-proxy]\n" +
+		"name = \"Databricks Proxy\"\n" +
+		"base_url = \"http://127.0.0.1:59998\"\n" +
+		"api_key = \"databricks-proxy\"\n" +
+		"wire_api = \"responses\"\n"
+	if err := os.WriteFile(cfgPath, []byte(stale), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// A fresh Manager per patch, as the launch path constructs.
+	patchOnce := func() string {
+		p := newCodexPatcherAt(cfgPath, "databricks-gpt-5-5", true, "", "", false)
+		if err := p.Patch(profile.PatchRequest{ProxyURL: goldenProxyURL}); err != nil {
+			t.Fatalf("Patch: %v", err)
+		}
+		return readFile(t, cfgPath)
+	}
+
+	first := patchOnce()
+	if strings.Contains(first, "59998") {
+		t.Errorf("stale base_url 59998 was not self-healed:\n%s", first)
+	}
+	if !strings.Contains(first, `base_url = "http://127.0.0.1:49154"`) {
+		t.Errorf("live base_url not written after self-heal:\n%s", first)
+	}
+
+	// Idempotency: patching again with the same live URL must not drift.
+	second := patchOnce()
+	if first != second {
+		t.Errorf("re-patch is not idempotent:\n--- first ---\n%q\n--- second ---\n%q", first, second)
+	}
+}
+
+// TestCodexPatch_OTELEraseParity asserts the config.toml-level erase semantics
+// the two-store model promises: enabling OTEL emits the [otel] section,
+// disabling it (otelEnabled=false → empty endpoints → tomlconfig.removeSection)
+// erases the section, and re-enabling restores it. This is the codex analog of
+// claude's OTEL-section-removal invariant.
+func TestCodexPatch_OTELEraseParity(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+
+	patch := func(otelEnabled bool) string {
+		p := newCodexPatcherAt(cfgPath, "databricks-gpt-5-5", true,
+			"main.codex_telemetry.codex_otel_metrics",
+			"main.codex_telemetry.codex_otel_logs", otelEnabled)
+		if err := p.Patch(profile.PatchRequest{ProxyURL: goldenProxyURL}); err != nil {
+			t.Fatalf("Patch: %v", err)
+		}
+		return readFile(t, cfgPath)
+	}
+
+	// 1. Enable → [otel] present.
+	enabled := patch(true)
+	if !strings.Contains(enabled, "[otel]") {
+		t.Fatalf("expected [otel] section after enable:\n%s", enabled)
+	}
+
+	// 2. Disable → [otel] erased entirely (not just stale exporter lines).
+	disabled := patch(false)
+	if strings.Contains(disabled, "[otel]") {
+		t.Errorf("expected [otel] section erased after disable:\n%s", disabled)
+	}
+	if strings.Contains(disabled, "otel/v1/") {
+		t.Errorf("expected all OTEL exporter endpoints erased after disable:\n%s", disabled)
+	}
+	// The rest of config.toml (provider block) must survive the erase.
+	if !strings.Contains(disabled, `base_url = "http://127.0.0.1:49154"`) {
+		t.Errorf("provider block must survive [otel] erase:\n%s", disabled)
+	}
+
+	// 3. Re-enable → [otel] section restored with both exporter endpoints.
+	// (Whole-file bytes differ from the very first enable because the first
+	// enable APPENDS the sections onto an empty file — emitting inter-section
+	// blank lines — while every subsequent patch REPLACES the existing blocks;
+	// that blank-line handling is documented surgical-patcher behavior. The
+	// parity claim is that the section round-trips, and that steady-state
+	// re-patches are idempotent.)
+	reEnabled := patch(true)
+	if !strings.Contains(reEnabled, "[otel]") {
+		t.Errorf("re-enable did not restore the [otel] section:\n%s", reEnabled)
+	}
+	if !strings.Contains(reEnabled, `endpoint = "http://127.0.0.1:49154/otel/v1/logs"`) ||
+		!strings.Contains(reEnabled, `endpoint = "http://127.0.0.1:49154/otel/v1/metrics"`) {
+		t.Errorf("re-enabled [otel] missing exporter endpoints:\n%s", reEnabled)
+	}
+	// The provider block still survives the disable→re-enable round trip.
+	if !strings.Contains(reEnabled, `base_url = "http://127.0.0.1:49154"`) {
+		t.Errorf("provider block lost across OTEL round trip:\n%s", reEnabled)
+	}
+}
+
+// TestCodexConfig_CrossPathByteIdentical is the F2 guarantee: wrapper mode
+// (core.Run drives PatchSettings.Patch with a fully-populated PatchRequest —
+// PortFlag/ProfileName/Env set) and the serve entrypoint (serve_codex.go builds
+// profile2Request, only ProxyURL set) must emit byte-identical config.toml for
+// identical resolved inputs. Codex's patcher reads ONLY req.ProxyURL, so the
+// extra wrapper-side fields must not perturb the output.
+func TestCodexConfig_CrossPathByteIdentical(t *testing.T) {
+	const model = "databricks-gpt-5-5"
+	const metrics = "main.codex_telemetry.codex_otel_metrics"
+	const logs = "main.codex_telemetry.codex_otel_logs"
+
+	writeVia := func(req profile.PatchRequest) string {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "config.toml")
+		p := newCodexPatcherAt(cfgPath, model, true, metrics, logs, true)
+		if err := p.Patch(req); err != nil {
+			t.Fatalf("Patch: %v", err)
+		}
+		return readFile(t, cfgPath)
+	}
+
+	// Wrapper path: core.Run populates all PatchRequest fields.
+	wrapper := writeVia(profile.PatchRequest{
+		PortFlag:    49154,
+		ProfileName: "aidev",
+		ProxyURL:    goldenProxyURL,
+		Env:         map[string]string{"IGNORED": "by-codex"},
+	})
+
+	// Serve path: the real profile2Request helper (only ProxyURL).
+	serve := writeVia(profile2Request(goldenProxyURL))
+
+	if wrapper != serve {
+		t.Errorf("wrapper-mode and serve-mode config.toml differ (F2 byte-parity broken)\n--- wrapper ---\n%q\n--- serve ---\n%q", wrapper, serve)
+	}
+	// And both must equal the OTEL golden.
+	if wrapper != goldenFreshOTEL {
+		t.Errorf("cross-path output drifted from OTEL golden\n--- got ---\n%q\n--- want ---\n%q", wrapper, goldenFreshOTEL)
+	}
+}
+
+// --- shared helpers ---
+
+// inTempCodexHome runs fn with HOME and statePath redirected to a fresh temp
+// dir, restoring both before returning. tomlconfig.NewManager("") and
+// codexHooksPath() both resolve under HOME, so this isolates the whole codex
+// dotfile tree.
+func inTempCodexHome(t *testing.T, fn func(home string)) {
+	t.Helper()
+	dir := t.TempDir()
+	origHome, hadHome := os.LookupEnv("HOME")
+	if err := os.Setenv("HOME", dir); err != nil {
+		t.Fatalf("setenv HOME: %v", err)
+	}
+	origState := statePath
+	statePath = func() string { return filepath.Join(dir, ".codex", ".databricks-codex.json") }
+	defer func() {
+		if hadHome {
+			os.Setenv("HOME", origHome)
+		} else {
+			os.Unsetenv("HOME")
+		}
+		statePath = origState
+	}()
+	fn(dir)
+}
+
+// readCodexConfig reads ~/.codex/config.toml under the given home.
+func readCodexConfig(t *testing.T, home string) string {
+	t.Helper()
+	return readFile(t, filepath.Join(home, ".codex", "config.toml"))
+}
+
+// readFile reads a file as a string, failing the test on error.
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/cmd/databricks-codex/proxy.go
+++ b/cmd/databricks-codex/proxy.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/IceRhymers/databricks-agents/internal/core/proxy"
+	"github.com/IceRhymers/databricks-agents/internal/core/tokencache"
+)
+
+// ProxyConfig holds the configuration for the proxy server.
+type ProxyConfig struct {
+	InferenceUpstream string
+	OTELUpstream      string
+	UCMetricsTable    string
+	UCLogsTable       string
+	TokenProvider     *tokencache.TokenProvider
+	Verbose           bool
+	APIKey            string
+	TLSCertFile       string
+	TLSKeyFile        string
+	ToolName          string // reported by /health endpoint
+	Version           string // reported by /health endpoint
+}
+
+// NewProxyServer returns an http.Handler that routes requests to the
+// inference upstream (default) and the OTEL upstream (/otel/).
+func NewProxyServer(config *ProxyConfig) (http.Handler, error) {
+	return proxy.NewServer(&proxy.Config{
+		InferenceUpstream: config.InferenceUpstream,
+		OTELUpstream:      config.OTELUpstream,
+		UCMetricsTable:    config.UCMetricsTable,
+		UCLogsTable:       config.UCLogsTable,
+		TokenSource:       config.TokenProvider,
+		Verbose:           config.Verbose,
+		APIKey:            config.APIKey,
+		TLSCertFile:       config.TLSCertFile,
+		TLSKeyFile:        config.TLSKeyFile,
+		ToolName:          config.ToolName,
+		Version:           config.Version,
+	})
+}
+
+// ServeProxy starts the proxy on the given listener.
+// When config.TLSCertFile and config.TLSKeyFile are both set, the listener serves TLS.
+func ServeProxy(config *ProxyConfig, handler http.Handler, ln net.Listener) error {
+	_, err := proxy.Serve(ln, handler, config.TLSCertFile, config.TLSKeyFile)
+	return err
+}
+
+// StartProxy binds to 127.0.0.1:0, starts serving, and returns the listener.
+// Callers read l.Addr() to discover the assigned port.
+// When certFile and keyFile are both non-empty, the listener serves TLS.
+func StartProxy(handler http.Handler, certFile, keyFile string) (net.Listener, error) {
+	return proxy.Start(handler, certFile, keyFile)
+}

--- a/cmd/databricks-codex/proxy_test.go
+++ b/cmd/databricks-codex/proxy_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/IceRhymers/databricks-agents/internal/core/tokencache"
+)
+
+// warmToken returns a *TokenProvider whose cache is pre-loaded with the given
+// token so that no subprocess invocation ever occurs during tests.
+func warmToken(token string) *tokencache.TokenProvider {
+	tp := tokencache.NewTokenProvider(nil) // fetcher unused — cache is pre-warmed
+	tp.SetCache(token, time.Now().Add(24*time.Hour))
+	return tp
+}
+
+// TestProxy_InjectsAuthHeader verifies that the Authorization header is set.
+func TestProxy_InjectsAuthHeader(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &ProxyConfig{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCLogsTable:       "main.t.l",
+		TokenProvider:     warmToken("test-token-123"),
+	}
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if gotAuth != "Bearer test-token-123" {
+		t.Errorf("got Authorization %q, want %q", gotAuth, "Bearer test-token-123")
+	}
+}
+
+// TestProxy_RoutesDefaultToInference verifies that non-/otel requests reach
+// the inference upstream.
+func TestProxy_RoutesDefaultToInference(t *testing.T) {
+	inferenceCalled := false
+	inference := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inferenceCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer inference.Close()
+
+	otel := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("otel upstream called unexpectedly")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer otel.Close()
+
+	cfg := &ProxyConfig{
+		InferenceUpstream: inference.URL,
+		OTELUpstream:      otel.URL,
+		UCLogsTable:       "main.t.l",
+		TokenProvider:     warmToken("tok"),
+	}
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !inferenceCalled {
+		t.Error("inference upstream was not called")
+	}
+}
+
+// TestProxy_RoutesOTELPath verifies that /otel/* requests reach the OTEL upstream.
+func TestProxy_RoutesOTELPath(t *testing.T) {
+	otelCalled := false
+	otel := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		otelCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer otel.Close()
+
+	inference := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("inference upstream called unexpectedly for /otel/ request")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer inference.Close()
+
+	cfg := &ProxyConfig{
+		InferenceUpstream: inference.URL,
+		OTELUpstream:      otel.URL,
+		UCLogsTable:       "main.t.l",
+		TokenProvider:     warmToken("tok"),
+	}
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/otel/v1/metrics", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !otelCalled {
+		t.Error("otel upstream was not called")
+	}
+}
+
+// TestProxy_OTELTableName_Metrics verifies that /otel/v1/metrics gets the metrics table header.
+
+// TestProxy_OTELTableName_Logs verifies that /otel/v1/logs gets the logs table header.
+func TestProxy_OTELTableName_Logs(t *testing.T) {
+	var gotTable string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTable = r.Header.Get("X-Databricks-UC-Table-Name")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &ProxyConfig{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCLogsTable:       "main.telemetry.codex_otel_logs",
+		TokenProvider:     warmToken("tok"),
+	}
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/otel/v1/logs", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if gotTable != "main.telemetry.codex_otel_logs" {
+		t.Errorf("got table %q, want %q", gotTable, "main.telemetry.codex_otel_logs")
+	}
+}
+
+// TestProxy_PreservesRequestBody verifies that POST bodies are forwarded intact.
+func TestProxy_PreservesRequestBody(t *testing.T) {
+	body := `{"model":"o3-mini","input":"hello"}`
+	var gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &ProxyConfig{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCLogsTable:       "main.t.l",
+		TokenProvider:     warmToken("tok"),
+	}
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if gotBody != body {
+		t.Errorf("got body %q, want %q", gotBody, body)
+	}
+}
+
+// TestProxy_SSEStreaming verifies that chunked/streamed responses are not buffered.
+func TestProxy_SSEStreaming(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream ResponseWriter does not implement Flusher")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+
+		for i := 0; i < 3; i++ {
+			_, _ = io.WriteString(w, "data: chunk\n\n")
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	cfg := &ProxyConfig{
+		InferenceUpstream: upstream.URL,
+		OTELUpstream:      upstream.URL,
+		UCLogsTable:       "main.t.l",
+		TokenProvider:     warmToken("tok"),
+	}
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
+
+	l, err := StartProxy(handler, "", "")
+	if err != nil {
+		t.Fatalf("StartProxy: %v", err)
+	}
+	defer l.Close()
+
+	resp, err := http.Get("http://" + l.Addr().String() + "/v1/responses")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+
+	want := "data: chunk\n\n"
+	if !strings.Contains(string(respBody), want) {
+		t.Errorf("response body %q does not contain %q", string(respBody), want)
+	}
+}

--- a/cmd/databricks-codex/serve_codex.go
+++ b/cmd/databricks-codex/serve_codex.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/IceRhymers/databricks-agents/internal/cmd"
+	"github.com/IceRhymers/databricks-agents/internal/core/authcheck"
+	"github.com/IceRhymers/databricks-agents/internal/core/health"
+	"github.com/IceRhymers/databricks-agents/internal/core/lifecycle"
+	"github.com/IceRhymers/databricks-agents/internal/core/portbind"
+	"github.com/IceRhymers/databricks-agents/internal/core/proxy"
+	"github.com/IceRhymers/databricks-agents/internal/core/refcount"
+	"github.com/IceRhymers/databricks-agents/internal/profile"
+)
+
+// runServeCommand dispatches `databricks-codex serve [flags]`. args is
+// everything after the literal "serve" token (e.g. ["--idle-timeout", "5m"]).
+//
+// serve is codex's session/headless entrypoint — a leaf with no sub-subcommands
+// (codex has no daemon mode: no LaunchAgent / systemd-user / schtasks
+// equivalent). It does NOT route through core.Run: its lifecycle (lifecycle
+// wrap + idle timeout, no child process) is a distinct sibling shape. It DOES
+// share the exact config.toml writer with wrapper mode (codexSettingsPatcher),
+// so both paths emit byte-identical config.toml for identical inputs.
+//
+// Flag parsing is driven by serveCommand.Parse so the tree is the single
+// source of truth for the flag set.
+func runServeCommand(args []string) error {
+	parsed, err := serveCommand.Parse(args)
+	if err != nil {
+		return fmt.Errorf("serve: %w", err)
+	}
+	if parsed.Bools["help"] {
+		_ = cmd.Render(os.Stdout, serveCommand, nil)
+		return nil
+	}
+
+	a, err := buildServeArgs(parsed)
+	if err != nil {
+		return err
+	}
+
+	runServeProxy(a)
+	return nil
+}
+
+// runServeProxy is the proxy-launch hook that runServeCommand invokes after
+// flag parsing. Replaceable from tests so serve_cmd_test.go can spy on the
+// Args struct without actually starting the proxy. In production it points at
+// runServeSession.
+var runServeProxy = func(a *Args) {
+	runServeSession(a)
+}
+
+// buildServeArgs maps a parsed cmd.ParseResult into the Args struct that
+// runServeSession consumes. The mapping is exhaustive over the flags declared
+// on serveCommand in commands.go; a flag-set parity test (serve_cmd_test.go)
+// catches drift in either direction.
+//
+// --idle-timeout is the only flag with strict parsing: an invalid duration
+// is returned as a fail-loud error (matching the legacy --idle-timeout root
+// flag's behaviour, including rejection of bare ints like "30" and empty
+// values like "--idle-timeout=").
+func buildServeArgs(r *cmd.ParseResult) (*Args, error) {
+	a := &Args{
+		Headless:    true,             // serve always runs headless
+		IdleTimeout: 30 * time.Minute, // matches the pre-#89 default
+	}
+
+	if r.Set["idle-timeout"] {
+		raw := r.Strings["idle-timeout"]
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("serve: --idle-timeout: %q is not a valid duration (use e.g. 30s, 5m, 1h)", raw)
+		}
+		a.IdleTimeout = d
+	}
+
+	a.Profile = r.Strings["profile"]
+	a.Verbose = r.Bools["verbose"]
+	a.LogFile = r.Strings["log-file"]
+	a.Upstream = r.Strings["upstream"]
+	a.ProxyAPIKey = r.Strings["proxy-api-key"]
+	a.TLSCert = r.Strings["tls-cert"]
+	a.TLSKey = r.Strings["tls-key"]
+	a.NoUpdateCheck = r.Bools["no-update-check"]
+
+	if r.Set["model"] {
+		a.Model = r.Strings["model"]
+		a.ModelSet = true
+	}
+
+	if r.Set["port"] {
+		raw := r.Strings["port"]
+		if raw != "" {
+			n, err := strconv.Atoi(raw)
+			if err != nil {
+				return nil, fmt.Errorf("serve: --port: %q is not an integer", raw)
+			}
+			a.PortFlag = n
+		}
+	}
+
+	return a, nil
+}
+
+// runServeSession runs the proxy in headless mode without launching codex.
+// It replicates the codex resolution the wrapper path performs, but keeps the
+// distinct headless lifecycle (lifecycle wrap + idle timeout, no child) rather
+// than routing through core.Run. The config.toml write goes through the SAME
+// codexSettingsPatcher.Patch used by wrapper mode (F2), so both paths emit
+// byte-identical config.toml.
+func runServeSession(a *Args) {
+	// Default: discard all logs (silent wrapper).
+	log.SetOutput(io.Discard)
+	if a.Verbose {
+		log.SetOutput(os.Stderr)
+	}
+	if a.LogFile != "" {
+		f, err := os.OpenFile(a.LogFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if err != nil {
+			log.SetOutput(os.Stderr)
+			log.Fatalf("databricks-codex: cannot open log file %q: %v", a.LogFile, err)
+		}
+		defer f.Close()
+		if a.Verbose {
+			log.SetOutput(io.MultiWriter(os.Stderr, f))
+		} else {
+			log.SetOutput(f)
+		}
+	}
+
+	// --- Resolve profile ---
+	profileExplicit := a.Profile != ""
+	profile := resolveProfile(a.Profile, loadState().Profile)
+	if profileExplicit {
+		saved := loadState()
+		saved.Profile = profile
+		if err := saveState(saved); err != nil {
+			log.Printf("databricks-codex: failed to save profile: %v", err)
+		} else {
+			log.Printf("databricks-codex: saved profile %q for future sessions", profile)
+		}
+	}
+	log.Printf("databricks-codex: using profile: %s", profile)
+
+	// --- Resolve model ---
+	modelExplicit := a.ModelSet
+	savedForModel := loadState()
+	model := resolveModel(a.Model, savedForModel.Model)
+	if modelExplicit {
+		savedForModel.Model = model
+		if err := saveState(savedForModel); err != nil {
+			log.Printf("databricks-codex: failed to save model: %v", err)
+		}
+	}
+	log.Printf("databricks-codex: using model: %s", model)
+
+	// --- Ensure the user is authenticated before proceeding ---
+	if err := authcheck.EnsureAuthenticated(profile, ""); err != nil {
+		log.Fatalf("databricks-codex: auth failed: %v", err)
+	}
+
+	// --- Load state and resolve port ---
+	state := loadState()
+	port := resolvePort(a.PortFlag, state)
+	if a.PortFlag > 0 {
+		state.Port = port
+		if err := saveState(state); err != nil {
+			log.Printf("databricks-codex: failed to save port: %v", err)
+		}
+	}
+	log.Printf("databricks-codex: using port: %d", port)
+
+	// --- TLS validation ---
+	if err := proxy.ValidateTLSConfig(a.TLSCert, a.TLSKey); err != nil {
+		log.Fatalf("databricks-codex: %v", err)
+	}
+
+	// --- Save TLS config to state so headless-ensure can use the right scheme ---
+	{
+		s := loadState()
+		if s.TLSCert != a.TLSCert || s.TLSKey != a.TLSKey {
+			s.TLSCert = a.TLSCert
+			s.TLSKey = a.TLSKey
+			if err := saveState(s); err != nil {
+				log.Printf("databricks-codex: failed to save TLS config: %v", err)
+			}
+		}
+	}
+
+	// --- Startup security checks ---
+	for _, w := range proxy.SecurityChecks() {
+		fmt.Fprintln(os.Stderr, w)
+	}
+
+	// --- Seed token cache ---
+	tp := NewTokenProvider("", profile)
+	if _, err := tp.Token(context.Background()); err != nil {
+		log.Fatalf("databricks-codex: failed to fetch initial token: %v", err)
+	}
+
+	// --- Discover host + construct gateway URL ---
+	host, err := DiscoverHost("", profile)
+	if err != nil {
+		log.Fatalf("databricks-codex: failed to discover host: %v\nRun 'databricks auth login' first", err)
+	}
+	log.Printf("databricks-codex: discovered host: %s", host)
+
+	gatewayURL := a.Upstream
+	if gatewayURL == "" {
+		gatewayURL = ConstructGatewayURL(host)
+	}
+	log.Printf("databricks-codex: gateway URL: %s", gatewayURL)
+
+	// --- OTEL tables (read-only over state) ---
+	saved := loadState()
+	otel, otelMetricsTable, otelLogsTable := resolveOtel(saved)
+	if otelMetricsTable != "" {
+		log.Printf("databricks-codex: using saved otel-metrics-table: %s", otelMetricsTable)
+	}
+	if otelLogsTable != "" {
+		log.Printf("databricks-codex: using saved otel-logs-table: %s", otelLogsTable)
+	}
+	// serve mode deliberately skips the LookPath("codex") guard — it never
+	// launches codex.
+
+	// --- Determine OTEL upstream ---
+	otelUpstream := ""
+	if otel {
+		otelUpstream = host + "/api/2.0/otel"
+		log.Printf("databricks-codex: OTEL enabled, upstream: %s", otelUpstream)
+	}
+
+	// --- Bind proxy port ---
+	listener, isOwner, err := portbind.Bind("databricks-codex", port)
+	if err != nil {
+		log.Fatalf("databricks-codex: %v", err)
+	}
+
+	scheme := "http"
+	if a.TLSCert != "" && a.TLSKey != "" {
+		scheme = "https"
+		fmt.Fprintln(os.Stderr, "databricks-codex: TLS enabled")
+	}
+	proxyURL := fmt.Sprintf("%s://127.0.0.1:%d", scheme, portbind.ListenerPort(listener, port))
+
+	// --- Proxy handler (needed by owner and recovery goroutine) ---
+	if a.ProxyAPIKey != "" {
+		fmt.Fprintln(os.Stderr, "databricks-codex: proxy API key authentication enabled")
+	}
+	proxyHandler, err := NewProxyServer(&ProxyConfig{
+		InferenceUpstream: gatewayURL,
+		OTELUpstream:      otelUpstream,
+		UCMetricsTable:    otelMetricsTable,
+		UCLogsTable:       otelLogsTable,
+		TokenProvider:     tp,
+		Verbose:           a.Verbose,
+		APIKey:            a.ProxyAPIKey,
+		TLSCertFile:       a.TLSCert,
+		TLSKeyFile:        a.TLSKey,
+		ToolName:          "databricks-codex",
+		Version:           Version,
+	})
+	if err != nil {
+		log.Fatalf("databricks-codex: failed to create proxy: %v", err)
+	}
+
+	// --- Reference counting ---
+	// Headless mode does NOT acquire (the spawning session already accounted
+	// for this proxy via headless.Ensure); it wraps with /shutdown + idle
+	// timeout and releases on exit.
+	refcountPath := refcount.PathForPort(".databricks-codex-sessions", port)
+	doneCh := make(chan struct{})
+	proxyHandler = lifecycle.WrapWithLifecycle(lifecycle.Config{
+		Inner:        proxyHandler,
+		RefcountPath: refcountPath,
+		IsOwner:      isOwner,
+		IdleTimeout:  a.IdleTimeout,
+		APIKey:       a.ProxyAPIKey,
+		DoneCh:       doneCh,
+		LogPrefix:    "databricks-codex",
+	})
+
+	// --- Start proxy if we own the port ---
+	if isOwner {
+		servedLn, err := proxy.Serve(listener, proxyHandler, a.TLSCert, a.TLSKey)
+		if err != nil {
+			log.Fatalf("databricks-codex: failed to start proxy: %v", err)
+		}
+		listener = servedLn
+		log.Printf("databricks-codex: proxy owner on :%d", port)
+	} else {
+		log.Printf("databricks-codex: joining existing proxy on :%d", port)
+		go health.WatchProxy(port, proxyHandler, a.TLSCert, a.TLSKey, "databricks-codex", nil)
+	}
+	log.Printf("databricks-codex: proxy on %s (owner=%v)", proxyURL, isOwner)
+
+	// --- Write config.toml through the SHARED writer (F2 byte-parity) ---
+	patcher := newCodexPatcher(model, modelExplicit, otelMetricsTable, otelLogsTable, otel)
+	if err := patcher.Patch(profile2Request(proxyURL)); err != nil {
+		log.Printf("databricks-codex: warning: failed to write config.toml: %v", err)
+	}
+
+	// --- Headless mode: print proxy URL and wait for signal ---
+	runHeadless(proxyURL, listener, isOwner, refcountPath, doneCh)
+}
+
+// profile2Request builds the neutral profile.PatchRequest for the shared
+// codexSettingsPatcher.Patch. Only ProxyURL is load-bearing for codex (the
+// patcher computes base_url + OTEL endpoints from it); the other fields are
+// unused by codex's config.toml writer.
+func profile2Request(proxyURL string) profile.PatchRequest {
+	return profile.PatchRequest{ProxyURL: proxyURL}
+}
+
+// runHeadless runs the proxy without launching a codex child process.
+// It prints the proxy URL to stdout, then blocks until SIGINT/SIGTERM
+// or until doneCh is closed (by /shutdown or idle timeout). The watchProxy
+// goroutine (for non-owner sessions) is already started before this is called.
+func runHeadless(proxyURL string, ln net.Listener, isOwner bool, refcountPath string, doneCh chan struct{}) {
+	fmt.Printf("PROXY_URL=%s\n", proxyURL)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case <-sigCh:
+		signal.Stop(sigCh)
+	case <-doneCh:
+		// Triggered by /shutdown or idle timeout.
+	}
+
+	// Release refcount. If /shutdown already released, Release floors at 0.
+	n, _ := refcount.Release(refcountPath)
+	if n == 0 && isOwner {
+		ln.Close()
+	}
+}

--- a/cmd/databricks-codex/serve_codex_test.go
+++ b/cmd/databricks-codex/serve_codex_test.go
@@ -1,0 +1,478 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestServeCommandTreeParity verifies bidirectional parity between the
+// serveCommand declaration (commands.go) and the buildServeArgs mapping
+// (serve_cmd.go). Mirrors hooks_cmd_test.go's TestHooksCommandTreeParity
+// shape, adapted for a leaf command (no sub-subcommands).
+//
+// Bidirectional contract:
+//   - tree → mapper: every flag on serveCommand must be consumed by
+//     buildServeArgs (or by runServeCommand's --help short-circuit).
+//   - mapper → tree: every flag buildServeArgs consumes must be declared
+//     on serveCommand. Drift fails the test loudly.
+//
+// The expected set is hard-coded so adding a flag to serveCommand without
+// wiring it into buildServeArgs trips this check on the next test run.
+func TestServeCommandTreeParity(t *testing.T) {
+	expected := map[string]bool{
+		"idle-timeout":    true,
+		"profile":         true,
+		"port":            true,
+		"model":           true,
+		"upstream":        true,
+		"log-file":        true,
+		"verbose":         true,
+		"proxy-api-key":   true,
+		"tls-cert":        true,
+		"tls-key":         true,
+		"no-update-check": true,
+		"help":            true,
+	}
+
+	got := make(map[string]bool, len(serveCommand.Flags))
+	for _, f := range serveCommand.AllFlags() {
+		got[f.Name] = true
+	}
+
+	for name := range expected {
+		if !got[name] {
+			t.Errorf("serveCommand should declare --%s but does not", name)
+		}
+	}
+	for name := range got {
+		if !expected[name] {
+			t.Errorf("serveCommand declares --%s but the parity contract does not list it (add to expected, or remove from tree)", name)
+		}
+	}
+}
+
+// TestRootSubcommandsIncludeServe is the structural counterpart to the
+// breaking change in #89: rootCommand must declare serve so dispatch from
+// main.go (and shell completion) finds it. Removing serveCommand from
+// rootCommand.Subcommands flips this assertion to fail.
+func TestRootSubcommandsIncludeServe(t *testing.T) {
+	if rootCommand.Subcommand("serve") == nil {
+		t.Fatal("rootCommand has no `serve` subcommand — tree wiring lost")
+	}
+}
+
+// TestRootCommandLegacyHeadlessFlagsRemoved locks the breaking surface
+// change from #89: --headless and --idle-timeout must NOT appear on
+// rootCommand any more. If a future refactor accidentally re-adds one,
+// this test fires and points at the migration sub-issue.
+func TestRootCommandLegacyHeadlessFlagsRemoved(t *testing.T) {
+	declared := make(map[string]bool)
+	for _, f := range rootCommand.AllFlags() {
+		declared[f.Name] = true
+	}
+	for _, flag := range []string{"headless", "idle-timeout"} {
+		if declared[flag] {
+			t.Errorf("rootCommand still declares --%s after #89 migration; the user-facing flag must move to `serve`", flag)
+		}
+	}
+}
+
+// --- buildServeArgs unit tests ---
+//
+// These exercise the parsed-flag → Args mapping directly. Together with
+// TestServeCommandTreeParity, they form the safety net for "drift between
+// what the tree advertises and what the runner actually wires through".
+
+func TestBuildServeArgs_DefaultIdleTimeout(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if !a.Headless {
+		t.Error("expected Headless=true (serve always runs headless)")
+	}
+	if a.IdleTimeout != 30*time.Minute {
+		t.Errorf("expected default IdleTimeout=30m, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutSeconds(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "30s"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 30*time.Second {
+		t.Errorf("expected 30s, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutMinutes(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "5m"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 5*time.Minute {
+		t.Errorf("expected 5m, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutHours(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "1h"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != time.Hour {
+		t.Errorf("expected 1h, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutEquals(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout=2h30m"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 2*time.Hour+30*time.Minute {
+		t.Errorf("expected 2h30m, got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutZeroDisables(t *testing.T) {
+	// Per AC: --idle-timeout 0 disables idle shutdown. time.ParseDuration
+	// accepts "0" as a zero-value duration.
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "0"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.IdleTimeout != 0 {
+		t.Errorf("expected 0 (disabled), got %v", a.IdleTimeout)
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutBareIntRejected(t *testing.T) {
+	// Matches the legacy --idle-timeout root-flag behaviour: bare ints
+	// like "30" (no unit) are rejected as ambiguous.
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "30"})
+	if _, err := buildServeArgs(r); err == nil {
+		t.Error("expected error for bare-int --idle-timeout, got nil")
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutGarbageRejected(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout", "30mins"})
+	if _, err := buildServeArgs(r); err == nil {
+		t.Error("expected error for '30mins' --idle-timeout, got nil")
+	}
+}
+
+func TestBuildServeArgs_IdleTimeoutEmptyRejected(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--idle-timeout="})
+	if _, err := buildServeArgs(r); err == nil {
+		t.Error("expected error for empty --idle-timeout, got nil")
+	}
+}
+
+func TestBuildServeArgs_Profile(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--profile", "aidev"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.Profile != "aidev" {
+		t.Errorf("expected Profile=%q, got %q", "aidev", a.Profile)
+	}
+}
+
+func TestBuildServeArgs_Port(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--port", "9999"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.PortFlag != 9999 {
+		t.Errorf("expected PortFlag=9999, got %d", a.PortFlag)
+	}
+}
+
+func TestBuildServeArgs_Verbose(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"-v"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if !a.Verbose {
+		t.Error("expected Verbose=true for -v")
+	}
+}
+
+func TestBuildServeArgs_TLSPair(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--tls-cert", "/tmp/c.pem", "--tls-key", "/tmp/k.pem"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if a.TLSCert != "/tmp/c.pem" || a.TLSKey != "/tmp/k.pem" {
+		t.Errorf("expected TLS cert/key wired, got cert=%q key=%q", a.TLSCert, a.TLSKey)
+	}
+}
+
+func TestBuildServeArgs_Model(t *testing.T) {
+	r, _ := serveCommand.Parse([]string{"--model", "databricks-gpt-5-4-mini"})
+	a, err := buildServeArgs(r)
+	if err != nil {
+		t.Fatalf("buildServeArgs returned error: %v", err)
+	}
+	if !a.ModelSet {
+		t.Error("expected ModelSet=true when --model is passed")
+	}
+	if a.Model != "databricks-gpt-5-4-mini" {
+		t.Errorf("expected Model=%q, got %q", "databricks-gpt-5-4-mini", a.Model)
+	}
+}
+
+// TestBuildServeArgs_HeadlessAlwaysTrue is the AC-positive assertion: the
+// serve subcommand MUST set Headless=true on the Args it constructs. If
+// a future refactor accidentally drops this, runProxyMode would launch
+// codex as a child instead of running the proxy headlessly — the exact
+// silent-degradation hazard the issue's "byte-identical behavior" AC
+// guards against.
+func TestBuildServeArgs_HeadlessAlwaysTrue(t *testing.T) {
+	cases := [][]string{
+		{},                                     // bare serve
+		{"--idle-timeout", "5m"},               // typical IDE invocation
+		{"--profile", "aidev", "--port", "0"},  // edge values
+		{"--verbose"},                          // debug toggle
+	}
+	for _, args := range cases {
+		r, _ := serveCommand.Parse(args)
+		a, err := buildServeArgs(r)
+		if err != nil {
+			t.Errorf("buildServeArgs(%v) error: %v", args, err)
+			continue
+		}
+		if !a.Headless {
+			t.Errorf("buildServeArgs(%v): Headless should be true; serve always runs headless", args)
+		}
+	}
+}
+
+// --- runServeCommand integration tests (with spy) ---
+//
+// runServeCommand calls runServeProxy → runProxyMode. The latter does I/O
+// (proxy bind, auth check, codex lookup) we don't want in unit tests, so
+// these tests swap runServeProxy for a spy that captures the Args struct.
+// This is the "AC-positive" pattern called out in the issue's pitfalls
+// section: assert what the new code path actually does, not just "no
+// error raised".
+
+func TestRunServeCommand_HelpReturnsNilWithoutLaunching(t *testing.T) {
+	called := false
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { called = true }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{"--help"}); err != nil {
+		t.Errorf("runServeCommand([--help]) returned error: %v", err)
+	}
+	if called {
+		t.Error("--help short-circuit must NOT call runServeProxy")
+	}
+}
+
+func TestRunServeCommand_HelpShortAliasReturnsNil(t *testing.T) {
+	called := false
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { called = true }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{"-h"}); err != nil {
+		t.Errorf("runServeCommand([-h]) returned error: %v", err)
+	}
+	if called {
+		t.Error("-h short-circuit must NOT call runServeProxy")
+	}
+}
+
+func TestRunServeCommand_InvalidIdleTimeoutReturnsError(t *testing.T) {
+	called := false
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { called = true }
+	defer func() { runServeProxy = orig }()
+
+	err := runServeCommand([]string{"--idle-timeout", "not-a-duration"})
+	if err == nil {
+		t.Fatal("expected error for invalid --idle-timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "idle-timeout") {
+		t.Errorf("error %q should mention idle-timeout", err)
+	}
+	if called {
+		t.Error("invalid flag must NOT call runServeProxy")
+	}
+}
+
+// TestRunServeCommand_BareServeInvokesProxyWithDefaults exercises the
+// happy path: bare `databricks-codex serve` (no flags) must call
+// runProxyMode with Headless=true and the default 30m idle timeout. Catches
+// the regression where runServeCommand returns early without invoking the
+// launcher.
+func TestRunServeCommand_BareServeInvokesProxyWithDefaults(t *testing.T) {
+	var captured *Args
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { captured = a }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{}); err != nil {
+		t.Fatalf("runServeCommand([]) returned error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("runServeProxy was never invoked")
+	}
+	if !captured.Headless {
+		t.Error("Args.Headless must be true on the serve path")
+	}
+	if captured.IdleTimeout != 30*time.Minute {
+		t.Errorf("Args.IdleTimeout: got %v, want 30m (default)", captured.IdleTimeout)
+	}
+}
+
+// TestRunServeCommand_PassesIdleTimeoutThrough is the headline AC test:
+// `databricks-codex serve --idle-timeout 5m` must reach runProxyMode with
+// IdleTimeout=5m. Asserts the FULL pipeline (parse → buildServeArgs →
+// runServeProxy) — a regression in any step fails this. This is the
+// positive assertion the issue's pitfalls section calls out: "serve
+// invokes runHeadless with idle-timeout=5m via a fake/spy, not 'no error
+// raised'".
+func TestRunServeCommand_PassesIdleTimeoutThrough(t *testing.T) {
+	var captured *Args
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { captured = a }
+	defer func() { runServeProxy = orig }()
+
+	if err := runServeCommand([]string{"--idle-timeout", "5m"}); err != nil {
+		t.Fatalf("runServeCommand returned error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("runServeProxy was never invoked")
+	}
+	if !captured.Headless {
+		t.Error("Args.Headless must be true on the serve path")
+	}
+	if captured.IdleTimeout != 5*time.Minute {
+		t.Errorf("Args.IdleTimeout: got %v, want 5m", captured.IdleTimeout)
+	}
+}
+
+// TestRunServeCommand_PassesAllFlagsThrough exercises the full mapping:
+// every serve flag (except --help) must reach the Args struct. Catches
+// the case where a flag is added to serveCommand and the parity test
+// passes (because buildServeArgs has a corresponding name lookup) but the
+// value silently drops on the floor.
+func TestRunServeCommand_PassesAllFlagsThrough(t *testing.T) {
+	var captured *Args
+	orig := runServeProxy
+	runServeProxy = func(a *Args) { captured = a }
+	defer func() { runServeProxy = orig }()
+
+	args := []string{
+		"--idle-timeout", "10m",
+		"--profile", "aidev",
+		"--port", "55555",
+		"--model", "test-model",
+		"--upstream", "https://gw.example.com/openai/v1",
+		"--log-file", "/tmp/serve.log",
+		"--verbose",
+		"--proxy-api-key", "secret",
+		"--tls-cert", "/tmp/c.pem",
+		"--tls-key", "/tmp/k.pem",
+		"--no-update-check",
+	}
+	if err := runServeCommand(args); err != nil {
+		t.Fatalf("runServeCommand returned error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("runServeProxy was never invoked")
+	}
+
+	checks := []struct {
+		name      string
+		got, want interface{}
+	}{
+		{"Headless", captured.Headless, true},
+		{"IdleTimeout", captured.IdleTimeout, 10 * time.Minute},
+		{"Profile", captured.Profile, "aidev"},
+		{"PortFlag", captured.PortFlag, 55555},
+		{"Model", captured.Model, "test-model"},
+		{"ModelSet", captured.ModelSet, true},
+		{"Upstream", captured.Upstream, "https://gw.example.com/openai/v1"},
+		{"LogFile", captured.LogFile, "/tmp/serve.log"},
+		{"Verbose", captured.Verbose, true},
+		{"ProxyAPIKey", captured.ProxyAPIKey, "secret"},
+		{"TLSCert", captured.TLSCert, "/tmp/c.pem"},
+		{"TLSKey", captured.TLSKey, "/tmp/k.pem"},
+		{"NoUpdateCheck", captured.NoUpdateCheck, true},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("Args.%s: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// TestHeadlessEnsureConfig_UsesServeSubcommand is the load-bearing test
+// for AC #5: "Hook entry must continue to bring the proxy up correctly —
+// the headlessEnsure-equivalent path now reuses the `serve` codepath
+// internally, not the removed --headless flag."
+//
+// pkg/headless.buildArgs uses Config.EnsureCommand as the prefix. With
+// EnsureCommand=["serve"], the spawned subprocess is `databricks-codex
+// serve --port=N [--tls-cert=... --tls-key=...]`. With EnsureCommand
+// empty, it would default back to `databricks-codex --headless ...` —
+// which would IMMEDIATELY fail since #89 deletes that flag. This test
+// fails loudly if a future refactor drops the EnsureCommand field.
+func TestHeadlessEnsureConfig_UsesServeSubcommand(t *testing.T) {
+	cfg := headlessEnsureConfig(49154, persistentState{})
+	if len(cfg.EnsureCommand) == 0 {
+		t.Fatal("headlessEnsureConfig must set EnsureCommand so the spawned subprocess invokes a real subcommand (not the removed --headless flag)")
+	}
+	if cfg.EnsureCommand[0] != "serve" {
+		t.Errorf("expected EnsureCommand[0]=%q, got %q (#89: hook spawn must invoke `serve`)", "serve", cfg.EnsureCommand[0])
+	}
+}
+
+// TestHeadlessEnsureConfig_TLSPropagated verifies the TLS knobs from
+// persistent state reach the headless.Config so the spawned subprocess
+// gets --tls-cert / --tls-key flags. Locks the existing semantics — the
+// #89 EnsureCommand change must NOT regress TLS plumbing.
+func TestHeadlessEnsureConfig_TLSPropagated(t *testing.T) {
+	cfg := headlessEnsureConfig(49154, persistentState{TLSCert: "/tmp/c.pem", TLSKey: "/tmp/k.pem"})
+	if cfg.TLSCert != "/tmp/c.pem" || cfg.TLSKey != "/tmp/k.pem" {
+		t.Errorf("TLS state must reach headless.Config; got cert=%q key=%q", cfg.TLSCert, cfg.TLSKey)
+	}
+	if cfg.Scheme != "https" {
+		t.Errorf("Scheme should be https when TLSCert is set, got %q", cfg.Scheme)
+	}
+}
+
+// TestServeHelpRendersAllFlags is a smoke check that the serveHelpTemplate
+// string mentions each of the flag names declared on serveCommand.
+// Prevents the help text from drifting silently when a flag is added or
+// renamed in commands.go.
+func TestServeHelpRendersAllFlags(t *testing.T) {
+	for _, name := range []string{
+		"--idle-timeout", "--profile", "--port", "--model",
+		"--upstream", "--log-file", "--verbose",
+		"--proxy-api-key", "--tls-cert", "--tls-key",
+		"--no-update-check", "--help",
+	} {
+		if !strings.Contains(serveHelpTemplate, name) {
+			t.Errorf("serveHelpTemplate missing %q", name)
+		}
+	}
+}

--- a/cmd/databricks-codex/state.go
+++ b/cmd/databricks-codex/state.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/IceRhymers/databricks-agents/internal/core/state"
+)
+
+// persistentState is the JSON schema for ~/.codex/.databricks-codex.json.
+// This file survives config.toml restore and persists across sessions.
+//
+// OtelMetricsDisabled / OtelLogsDisabled (added in #87) are the explicit
+// "user has run `config otel disable`" markers. They exist so the `config
+// otel disable` UX can preserve the table-name preferences for a future
+// re-enable while still suppressing OTEL export on the next session — the
+// two-store equivalent of databricks-claude's "settings.json absence means
+// off, state file holds preferences" model, adapted for codex where there
+// is no settings.json env block (config.toml is owned by the proxy
+// lifecycle and rewritten at every session start).
+type persistentState struct {
+	Profile             string `json:"profile,omitempty"`
+	OtelLogsTable       string `json:"otel_logs_table,omitempty"`
+	OtelMetricsTable    string `json:"otel_metrics_table,omitempty"`
+	OtelMetricsDisabled bool   `json:"otel_metrics_disabled,omitempty"`
+	OtelLogsDisabled    bool   `json:"otel_logs_disabled,omitempty"`
+	Model               string `json:"model,omitempty"`
+	Port                int    `json:"port,omitempty"`
+	TLSCert             string `json:"tls_cert,omitempty"`
+	TLSKey              string `json:"tls_key,omitempty"`
+}
+
+const defaultPort = 49154
+
+// resolvePort returns the port to use, following the resolution chain:
+// 1. --port flag (portFlag > 0)
+// 2. Saved state value (non-zero)
+// 3. Default 49154
+func resolvePort(portFlag int, s persistentState) int {
+	return state.ResolvePort(portFlag, s.Port, defaultPort)
+}
+
+// statePath returns the path to the persistent state file.
+// It is a variable so tests can override it.
+var statePath = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".codex/.databricks-codex.json"
+	}
+	return filepath.Join(home, ".codex", ".databricks-codex.json")
+}
+
+// loadState reads the persistent state file. Returns zero-value state if
+// the file doesn't exist or can't be parsed.
+func loadState() persistentState {
+	s, _ := state.Load[persistentState](statePath())
+	return s
+}
+
+// saveState writes the persistent state file atomically.
+func saveState(s persistentState) error {
+	return state.Save(statePath(), s)
+}

--- a/cmd/databricks-codex/state_test.go
+++ b/cmd/databricks-codex/state_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveAndLoadState(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	// Save a profile.
+	if err := saveState(persistentState{Profile: "aidev"}); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+
+	// Load it back.
+	s := loadState()
+	if s.Profile != "aidev" {
+		t.Errorf("got profile %q, want %q", s.Profile, "aidev")
+	}
+}
+
+func TestLoadState_Missing(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "nonexistent.json") }
+	defer func() { statePath = orig }()
+
+	s := loadState()
+	if s.Profile != "" {
+		t.Errorf("expected empty profile from missing file, got %q", s.Profile)
+	}
+}
+
+func TestLoadState_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "bad.json")
+	os.WriteFile(p, []byte("not json"), 0o644)
+
+	orig := statePath
+	statePath = func() string { return p }
+	defer func() { statePath = orig }()
+
+	s := loadState()
+	if s.Profile != "" {
+		t.Errorf("expected empty profile from invalid JSON, got %q", s.Profile)
+	}
+}
+
+func TestSaveState_OverwritesPrevious(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	saveState(persistentState{Profile: "first"})
+	saveState(persistentState{Profile: "second"})
+
+	s := loadState()
+	if s.Profile != "second" {
+		t.Errorf("got profile %q, want %q", s.Profile, "second")
+	}
+}
+
+func TestSaveAndLoadState_OtelLogsTable(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	if err := saveState(persistentState{OtelLogsTable: "custom.db.logs"}); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+
+	s := loadState()
+	if s.OtelLogsTable != "custom.db.logs" {
+		t.Errorf("got OtelLogsTable %q, want %q", s.OtelLogsTable, "custom.db.logs")
+	}
+}
+
+func TestSaveAndLoadState_OtelMetricsTable(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	if err := saveState(persistentState{OtelMetricsTable: "custom.db.metrics"}); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+
+	s := loadState()
+	if s.OtelMetricsTable != "custom.db.metrics" {
+		t.Errorf("got OtelMetricsTable %q, want %q", s.OtelMetricsTable, "custom.db.metrics")
+	}
+}
+
+func TestSaveState_PreservesExistingFields(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	// Save with profile only.
+	saveState(persistentState{Profile: "aidev"})
+
+	// Read-modify-write: add OtelLogsTable while preserving Profile.
+	s := loadState()
+	s.OtelLogsTable = "custom.db.logs"
+	saveState(s)
+
+	// Verify both fields survive.
+	s = loadState()
+	if s.Profile != "aidev" {
+		t.Errorf("got Profile %q, want %q", s.Profile, "aidev")
+	}
+	if s.OtelLogsTable != "custom.db.logs" {
+		t.Errorf("got OtelLogsTable %q, want %q", s.OtelLogsTable, "custom.db.logs")
+	}
+}
+
+func TestSaveState_OverwritesOtelLogsTable(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	saveState(persistentState{OtelLogsTable: "first.table"})
+	saveState(persistentState{OtelLogsTable: "second.table"})
+
+	s := loadState()
+	if s.OtelLogsTable != "second.table" {
+		t.Errorf("got OtelLogsTable %q, want %q", s.OtelLogsTable, "second.table")
+	}
+}
+
+func TestSaveAndLoadState_Model(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	if err := saveState(persistentState{Model: "databricks-gpt-5-4-mini"}); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+
+	s := loadState()
+	if s.Model != "databricks-gpt-5-4-mini" {
+		t.Errorf("got Model %q, want %q", s.Model, "databricks-gpt-5-4-mini")
+	}
+}
+
+func TestSaveState_ModelPreservesOtherFields(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	saveState(persistentState{Profile: "aidev", OtelLogsTable: "my.table"})
+
+	s := loadState()
+	s.Model = "custom-model"
+	saveState(s)
+
+	s = loadState()
+	if s.Profile != "aidev" {
+		t.Errorf("got Profile %q, want %q", s.Profile, "aidev")
+	}
+	if s.OtelLogsTable != "my.table" {
+		t.Errorf("got OtelLogsTable %q, want %q", s.OtelLogsTable, "my.table")
+	}
+	if s.Model != "custom-model" {
+		t.Errorf("got Model %q, want %q", s.Model, "custom-model")
+	}
+}
+
+func TestResolvePort(t *testing.T) {
+	tests := []struct {
+		name     string
+		portFlag int
+		state    persistentState
+		want     int
+	}{
+		{"flag wins", 9999, persistentState{Port: 8080}, 9999},
+		{"state wins over default", 0, persistentState{Port: 8080}, 8080},
+		{"default when no flag and no state", 0, persistentState{}, defaultPort},
+		{"flag wins over default", 5555, persistentState{}, 5555},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolvePort(tc.portFlag, tc.state)
+			if got != tc.want {
+				t.Errorf("resolvePort(%d, %+v) = %d, want %d", tc.portFlag, tc.state, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSaveAndLoadState_Port(t *testing.T) {
+	dir := t.TempDir()
+	orig := statePath
+	statePath = func() string { return filepath.Join(dir, "state.json") }
+	defer func() { statePath = orig }()
+
+	if err := saveState(persistentState{Port: 49154}); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+
+	s := loadState()
+	if s.Port != 49154 {
+		t.Errorf("got Port %d, want %d", s.Port, 49154)
+	}
+}

--- a/cmd/databricks-codex/token.go
+++ b/cmd/databricks-codex/token.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/IceRhymers/databricks-agents/internal/core/tokencache"
+)
+
+// TokenProvider is an alias to the pkg type for backward compatibility.
+type TokenProvider = tokencache.TokenProvider
+
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	Expiry      string `json:"expiry"` // RFC3339 or Unix timestamp
+}
+
+// databricksFetcher implements tokencache.TokenFetcher using the Databricks CLI.
+type databricksFetcher struct {
+	cmdName string
+	profile string
+}
+
+func (f *databricksFetcher) FetchToken(ctx context.Context) (string, time.Time, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(fetchCtx, f.cmdName, "auth", "token", "--profile", f.profile)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("databricks auth token failed: %w", err)
+	}
+
+	resp, err := parseTokenResponse(out)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	return resp.AccessToken, resp.expiryTime(), nil
+}
+
+// NewTokenProvider creates a new TokenProvider backed by the Databricks CLI.
+// cmdName defaults to "databricks" if empty; profile defaults to "DEFAULT".
+func NewTokenProvider(cmdName, profile string) *TokenProvider {
+	if cmdName == "" {
+		cmdName = "databricks"
+	}
+	if profile == "" {
+		profile = "DEFAULT"
+	}
+	return tokencache.NewTokenProvider(&databricksFetcher{
+		cmdName: cmdName,
+		profile: profile,
+	})
+}
+
+// parseTokenResponse decodes the JSON output from "databricks auth token".
+func parseTokenResponse(data []byte) (*tokenResponse, error) {
+	var resp tokenResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if resp.AccessToken == "" {
+		return nil, fmt.Errorf("empty access_token in response")
+	}
+	return &resp, nil
+}
+
+// expiryTime parses the Expiry field, falling back to 55 minutes from now.
+func (r *tokenResponse) expiryTime() time.Time {
+	if r.Expiry != "" {
+		// Try RFC3339 first
+		if t, err := time.Parse(time.RFC3339, r.Expiry); err == nil {
+			return t
+		}
+		// Try Unix timestamp (seconds)
+		if secs, err := strconv.ParseInt(r.Expiry, 10, 64); err == nil {
+			return time.Unix(secs, 0)
+		}
+	}
+	// Conservative default: 55-minute expiry
+	return time.Now().Add(55 * time.Minute)
+}
+
+type authEnvResponse struct {
+	Env map[string]string `json:"env"`
+}
+
+// DiscoverHost calls "databricks auth env --output json"
+// and extracts the DATABRICKS_HOST value from the response.
+func DiscoverHost(cmdName, profile string) (string, error) {
+	if cmdName == "" {
+		cmdName = "databricks"
+	}
+	if profile == "" {
+		profile = "DEFAULT"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, cmdName, "auth", "env", "--profile", profile, "--output", "json")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("databricks auth env failed: %w", err)
+	}
+
+	var resp authEnvResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse auth env response: %w", err)
+	}
+
+	host, ok := resp.Env["DATABRICKS_HOST"]
+	if !ok || host == "" {
+		return "", fmt.Errorf("DATABRICKS_HOST not found in auth env response")
+	}
+	return host, nil
+}
+
+// ConstructGatewayURL builds the AI Gateway URL for the Codex proxy endpoint.
+// Format: {host}/ai-gateway/openai/v1
+func ConstructGatewayURL(host string) string {
+	return strings.TrimRight(host, "/") + "/ai-gateway/openai/v1"
+}

--- a/cmd/databricks-codex/token_test.go
+++ b/cmd/databricks-codex/token_test.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// buildHelperBinary compiles a small helper binary that prints a fixed JSON response
+// and exits with a given code. Returns the path to the binary.
+func buildHelperBinary(t *testing.T, jsonPayload string, exitCode int) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	src := filepath.Join(dir, "main.go")
+	bin := filepath.Join(dir, "helper")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+
+	payloadLiteral, _ := json.Marshal(jsonPayload)
+
+	code := fmt.Sprintf(`package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Print(%s)
+	os.Exit(%d)
+}
+`, string(payloadLiteral), exitCode)
+
+	if err := os.WriteFile(src, []byte(code), 0600); err != nil {
+		t.Fatalf("write helper src: %v", err)
+	}
+
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build helper: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// buildSlowBinary compiles a binary that sleeps for a long time before responding.
+func buildSlowBinary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	src := filepath.Join(dir, "main.go")
+	bin := filepath.Join(dir, "slow")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+
+	code := `package main
+
+import "time"
+
+func main() {
+	time.Sleep(30 * time.Second)
+}
+`
+	if err := os.WriteFile(src, []byte(code), 0600); err != nil {
+		t.Fatalf("write slow src: %v", err)
+	}
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build slow: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func validTokenJSON(token, expiry string) string {
+	return fmt.Sprintf(`{"access_token":%q,"token_type":"Bearer","expiry":%q}`, token, expiry)
+}
+
+func futureExpiry() string {
+	return time.Now().Add(60 * time.Minute).Format(time.RFC3339)
+}
+
+// TestTokenProvider_FreshToken: subprocess returns valid JSON -> token is cached.
+func TestTokenProvider_FreshToken(t *testing.T) {
+	bin := buildHelperBinary(t, validTokenJSON("tok-fresh", futureExpiry()), 0)
+	tp := NewTokenProvider(bin, "")
+
+	tok, err := tp.Token(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "tok-fresh" {
+		t.Errorf("got token %q, want %q", tok, "tok-fresh")
+	}
+	if tp.CachedToken() != "tok-fresh" {
+		t.Error("token not cached after fresh fetch")
+	}
+}
+
+// TestTokenProvider_CacheHit: second call within expiry window skips subprocess.
+func TestTokenProvider_CacheHit(t *testing.T) {
+	bin := buildHelperBinary(t, validTokenJSON("tok-cached", futureExpiry()), 0)
+	tp := NewTokenProvider(bin, "")
+
+	if _, err := tp.Token(context.Background()); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	tok, err := tp.Token(context.Background())
+	if err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+	if tok != "tok-cached" {
+		t.Errorf("got %q, want cached token", tok)
+	}
+}
+
+// TestTokenProvider_RefreshNearExpiry: token within 5 min of expiry triggers refresh.
+func TestTokenProvider_RefreshNearExpiry(t *testing.T) {
+	bin := buildHelperBinary(t, validTokenJSON("tok-refreshed", futureExpiry()), 0)
+	tp := NewTokenProvider(bin, "")
+	tp.SetCache("tok-old", time.Now().Add(3*time.Minute)) // within 5-minute buffer
+
+	tok, err := tp.Token(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "tok-refreshed" {
+		t.Errorf("expected refresh; got %q", tok)
+	}
+}
+
+// TestTokenProvider_FallbackOnError: subprocess fails -> last cached token returned.
+func TestTokenProvider_FallbackOnError(t *testing.T) {
+	failBin := buildHelperBinary(t, "", 1)
+	tp := NewTokenProvider(failBin, "")
+	tp.SetCache("tok-last-good", time.Now().Add(-1*time.Minute))
+
+	tok, err := tp.Token(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error with cached fallback: %v", err)
+	}
+	if tok != "tok-last-good" {
+		t.Errorf("got %q, want last-good cached token", tok)
+	}
+}
+
+// TestTokenProvider_NoCachedTokenError: first call fails with no cache -> returns error.
+func TestTokenProvider_NoCachedTokenError(t *testing.T) {
+	failBin := buildHelperBinary(t, "", 1)
+	tp := NewTokenProvider(failBin, "")
+
+	_, err := tp.Token(context.Background())
+	if err == nil {
+		t.Fatal("expected error on first-call failure with no cache, got nil")
+	}
+}
+
+// TestTokenProvider_SubprocessTimeout: slow subprocess doesn't block forever.
+func TestTokenProvider_SubprocessTimeout(t *testing.T) {
+	slowBin := buildSlowBinary(t)
+	tp := NewTokenProvider(slowBin, "")
+
+	start := time.Now()
+	_, err := tp.Token(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if elapsed > 15*time.Second {
+		t.Errorf("token fetch took %v, expected timeout within 15s", elapsed)
+	}
+}
+
+// TestParseTokenResponse_RFC3339: parses RFC3339 expiry correctly.
+func TestParseTokenResponse_RFC3339(t *testing.T) {
+	expiry := time.Now().Add(1 * time.Hour).UTC().Round(time.Second)
+	payload := []byte(fmt.Sprintf(`{"access_token":"tok","token_type":"Bearer","expiry":%q}`,
+		expiry.Format(time.RFC3339)))
+
+	resp, err := parseTokenResponse(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := resp.expiryTime().UTC().Round(time.Second)
+	if !got.Equal(expiry) {
+		t.Errorf("expiry: got %v, want %v", got, expiry)
+	}
+}
+
+// TestParseTokenResponse_UnixTimestamp: parses Unix timestamp expiry.
+func TestParseTokenResponse_UnixTimestamp(t *testing.T) {
+	expiry := time.Now().Add(1 * time.Hour).UTC().Round(time.Second)
+	unixStr := strconv.FormatInt(expiry.Unix(), 10)
+	payload := []byte(fmt.Sprintf(`{"access_token":"tok","token_type":"Bearer","expiry":%q}`, unixStr))
+
+	resp, err := parseTokenResponse(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := resp.expiryTime().UTC().Round(time.Second)
+	if !got.Equal(expiry) {
+		t.Errorf("expiry: got %v, want %v", got, expiry)
+	}
+}
+
+// TestParseTokenResponse_MissingExpiry: defaults to ~55-minute expiry.
+func TestParseTokenResponse_MissingExpiry(t *testing.T) {
+	payload := []byte(`{"access_token":"tok","token_type":"Bearer"}`)
+	resp, err := parseTokenResponse(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := resp.expiryTime()
+	lower := time.Now().Add(54 * time.Minute)
+	upper := time.Now().Add(56 * time.Minute)
+	if got.Before(lower) || got.After(upper) {
+		t.Errorf("default expiry %v not in [54m, 56m] from now", got)
+	}
+}
+
+// TestParseTokenResponse_MalformedJSON: returns error on bad input.
+func TestParseTokenResponse_MalformedJSON(t *testing.T) {
+	_, err := parseTokenResponse([]byte("not json"))
+	if err == nil {
+		t.Fatal("expected error on malformed JSON, got nil")
+	}
+}
+
+// TestParseTokenResponse_EmptyToken: returns error on empty access_token.
+func TestParseTokenResponse_EmptyToken(t *testing.T) {
+	_, err := parseTokenResponse([]byte(`{"access_token":"","token_type":"Bearer"}`))
+	if err == nil {
+		t.Fatal("expected error on empty access_token, got nil")
+	}
+}
+
+// buildAuthEnvBinary builds a helper binary that prints the given JSON and exits with exitCode.
+func buildAuthEnvBinary(t *testing.T, jsonPayload string, exitCode int) string {
+	return buildHelperBinary(t, jsonPayload, exitCode)
+}
+
+// TestDiscoverHost_Success: mock command returns valid JSON -> host extracted.
+func TestDiscoverHost_Success(t *testing.T) {
+	payload := `{"env":{"DATABRICKS_HOST":"https://dbc-abc123.cloud.databricks.com"}}`
+	bin := buildAuthEnvBinary(t, payload, 0)
+
+	host, err := DiscoverHost(bin, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://dbc-abc123.cloud.databricks.com"
+	if host != want {
+		t.Errorf("got %q, want %q", host, want)
+	}
+}
+
+// TestDiscoverHost_MissingHost: JSON missing DATABRICKS_HOST -> error.
+func TestDiscoverHost_MissingHost(t *testing.T) {
+	payload := `{"env":{"DATABRICKS_TOKEN":"some-token"}}`
+	bin := buildAuthEnvBinary(t, payload, 0)
+
+	_, err := DiscoverHost(bin, "")
+	if err == nil {
+		t.Fatal("expected error when DATABRICKS_HOST missing, got nil")
+	}
+}
+
+// TestDiscoverHost_CommandFails: command exits non-zero -> error.
+func TestDiscoverHost_CommandFails(t *testing.T) {
+	bin := buildAuthEnvBinary(t, "", 1)
+
+	_, err := DiscoverHost(bin, "")
+	if err == nil {
+		t.Fatal("expected error when command fails, got nil")
+	}
+}
+
+// TestConstructGatewayURL: verifies the host-relative AI Gateway URL format.
+func TestConstructGatewayURL(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "plain host",
+			host: "https://dbc-abc123.cloud.databricks.com",
+			want: "https://dbc-abc123.cloud.databricks.com/ai-gateway/openai/v1",
+		},
+		{
+			name: "host with trailing slash is trimmed",
+			host: "https://dbc-abc123.cloud.databricks.com/",
+			want: "https://dbc-abc123.cloud.databricks.com/ai-gateway/openai/v1",
+		},
+		{
+			name: "host with multiple trailing slashes is trimmed",
+			host: "https://dbc-abc123.cloud.databricks.com///",
+			want: "https://dbc-abc123.cloud.databricks.com/ai-gateway/openai/v1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ConstructGatewayURL(tc.host)
+			if got != tc.want {
+				t.Errorf("ConstructGatewayURL(%q) = %q, want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/codex/AGENTS.md
+++ b/internal/codex/AGENTS.md
@@ -1,0 +1,32 @@
+<!-- Parent: ../../AGENTS.md -->
+<!-- Generated: 2026-07-15 | Updated: 2026-07-15 -->
+
+# internal/codex
+
+## Purpose
+Holds codex-specific libraries that are neither tool-agnostic (so they don't belong in `internal/core/`) nor imported by more than one launcher (so they don't belong in `pkg/`). Folded in via #201 alongside `cmd/databricks-codex`. Mirrors the role `pkg/` plays for claude's Claude-coupled libraries (`modeldiscovery`, `mdmprofile`, `websearch`), just under `internal/` instead, since it must be importable from `cmd/databricks-codex` (`package main`) while staying module-private.
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `tomlconfig/` | String-based surgical patcher for `~/.codex/config.toml` — `Manager.Patch`/`Backup`/`Restore`/`RestoreFromBackup`/`UpdateProxyURL`. See `tomlconfig/AGENTS.md`. |
+
+## For AI Agents
+
+### Working In This Directory
+- Each package here must remain **zero external dependencies** -- Go stdlib only.
+- Only `cmd/databricks-codex` should import from here. If a future launcher needs the same functionality, promote the shared parts into `internal/core/` rather than importing across launcher-specific trees.
+
+### Testing Requirements
+- Each package has co-located `*_test.go` files. Run `go test ./internal/codex/...` to test these, or `go test ./...` for the whole module.
+
+## Dependencies
+
+### Internal
+- No cross-package dependencies within `internal/codex/`.
+
+### External
+- None (pure Go stdlib)
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/internal/codex/tomlconfig/AGENTS.md
+++ b/internal/codex/tomlconfig/AGENTS.md
@@ -1,0 +1,47 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-06 | Updated: 2026-07-15 -->
+
+# tomlconfig
+
+## Purpose
+String-based surgical TOML manipulation for `~/.codex/config.toml`. Avoids any TOML parser dependency by operating on raw lines. Handles backup/restore, atomic writes, crash recovery, and multi-session proxy URL handoff. The "surgical" approach means only managed keys and sections are modified — all other user content is preserved byte-for-byte.
+
+Import path: `github.com/IceRhymers/databricks-agents/internal/codex/tomlconfig`. Lives under the module-root `internal/codex/` tree so it is importable from `cmd/databricks-codex` (`package main`) while staying codex-specific (not tool-agnostic like `internal/core`).
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `tomlconfig.go` | `Manager` struct with `Backup`, `Patch`, `Restore`, `RestoreFromBackup`, `UpdateProxyURL`; all patching helpers |
+| `tomlconfig_test.go` | Tests for patch/restore round-trips, surgical preservation, model resolution, crash recovery |
+
+## For AI Agents
+
+### Working In This Directory
+- **No external dependencies** — this package must stay zero-dependency; use only stdlib
+- Managed root keys: `profile`. Managed sections: `profiles.databricks-proxy`, `model_providers.databricks-proxy`, `otel`
+- The `sentinel` constant (`\x00nil`) marks keys/sections that were absent before patching so they can be fully removed on restore
+- `origRootKeys` and `origSections` maps track what was changed; `Restore` only undoes those changes
+- Model line handling is special: `origModelLine` / `patchedModelVal` track the preserve-if-present logic for `model =` inside `[profiles.databricks-proxy]`
+- `inAnySection` scans backward for a `[section]` header to avoid mistaking section-level keys for root-level keys
+- **Byte-parity required** — patch/restore output must stay byte-identical with the standalone `databricks-codex` repo; the `cmd/databricks-codex` config.toml golden depends on it. Do not "improve" the patch/restore logic.
+
+### Testing Requirements
+- Run with `go test ./internal/codex/tomlconfig/... -v`
+- Tests use in-memory TOML strings and temp files — no mocking needed
+- Cover: round-trip (patch then restore produces identical original), surgical preservation (non-managed keys untouched), crash recovery (`RestoreFromBackup`), multi-session handoff (`UpdateProxyURL`)
+
+### Common Patterns
+- `atomicWrite`: write to `.config-*.tmp`, chmod 0600, then `os.Rename` into place
+- Section boundary detection: next line starting with `[` (but not `[[`) ends the current section
+- Backup file: `config.toml.databricks-codex-backup` — written on `Backup()`, removed on successful `Restore()`
+
+## Dependencies
+
+### Internal
+- None (standalone package)
+
+### External
+- None (stdlib only: `fmt`, `log`, `os`, `path/filepath`, `strings`)
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/internal/codex/tomlconfig/tomlconfig.go
+++ b/internal/codex/tomlconfig/tomlconfig.go
@@ -1,0 +1,688 @@
+// Package tomlconfig manages the Codex CLI config.toml file.
+// It uses simple string-based manipulation rather than a full TOML parser,
+// keeping the zero-external-dependency constraint.
+package tomlconfig
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PatchConfig holds the values to inject into config.toml.
+type PatchConfig struct {
+	ProxyURL            string // e.g., "http://127.0.0.1:54321"
+	Model               string // e.g., "databricks-gpt-5-5"
+	ModelExplicit       bool   // true when --model was explicitly passed
+	OTELLogsEndpoint    string // e.g., "http://127.0.0.1:54321/otel/v1/logs"
+	OTELMetricsEndpoint string // e.g., "http://127.0.0.1:54321/otel/v1/metrics"
+}
+
+// sentinel is stored in originals when a key/section was absent before patching.
+const sentinel = "\x00nil"
+
+// Manager reads, patches, and restores the Codex config.toml file.
+type Manager struct {
+	configPath string
+	backupPath string
+	original   []byte // saved original content for crash-recovery backup
+
+	// Surgical restore state: tracks what we changed so Restore only undoes
+	// what we touched. Keys map to original line/block content, or sentinel
+	// if the key/section was absent before patching.
+	origRootKeys    map[string]string // root key name -> original line or sentinel
+	origSections    map[string]string // section header (e.g. "profiles.databricks-proxy") -> original block or sentinel
+	origModelLine   string            // original "model = ..." line in [profiles.databricks-proxy], or sentinel
+	patchedModelVal string            // model value we wrote (for preserve-if-present check)
+}
+
+// NewManager creates a new config.toml manager.
+// configPath defaults to ~/.codex/config.toml if empty.
+func NewManager(configPath string) *Manager {
+	if configPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			log.Printf("databricks-codex: cannot determine home dir: %v", err)
+			configPath = ".codex/config.toml"
+		} else {
+			configPath = filepath.Join(home, ".codex", "config.toml")
+		}
+	}
+	return &Manager{
+		configPath:   configPath,
+		backupPath:   configPath + ".databricks-codex-backup",
+		origRootKeys: make(map[string]string),
+		origSections: make(map[string]string),
+	}
+}
+
+// ConfigPath returns the path to config.toml.
+func (m *Manager) ConfigPath() string {
+	return m.configPath
+}
+
+// Backup reads the current config.toml and saves the original content
+// both in memory and to a backup file for crash recovery.
+func (m *Manager) Backup() error {
+	data, err := os.ReadFile(m.configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			m.original = nil
+			return nil
+		}
+		return fmt.Errorf("read config.toml: %w", err)
+	}
+	m.original = data
+
+	if err := atomicWrite(m.backupPath, data); err != nil {
+		return fmt.Errorf("write backup: %w", err)
+	}
+	return nil
+}
+
+// managedRootKeys lists top-level keys we manage.
+var managedRootKeys = []string{"profile"}
+
+// managedSections lists section headers we manage.
+var managedSections = []string{
+	"profiles.databricks-proxy",
+	"model_providers.databricks-proxy",
+	"otel",
+}
+
+// Patch performs surgical patching of config.toml: it reads the existing file,
+// saves originals for keys/sections it will touch, then injects/updates only
+// managed keys and sections. All non-managed content is preserved byte-for-byte.
+func (m *Manager) Patch(cfg PatchConfig) error {
+	content := ""
+	if m.original != nil {
+		content = string(m.original)
+	} else if data, err := os.ReadFile(m.configPath); err == nil {
+		content = string(data)
+	}
+
+	// --- Save originals and patch root keys ---
+	content = m.patchRootKey(content, "profile", `"databricks-proxy"`)
+
+	// --- Parse sections for surgical section patching ---
+	content = m.patchSection(content, "profiles.databricks-proxy",
+		m.buildProfileSection(cfg))
+
+	content = m.patchSection(content, "model_providers.databricks-proxy",
+		m.buildProviderSection(cfg))
+
+	// Always handle the [otel] section: when both endpoints are set, patch
+	// it; when both are empty, remove it if it exists. This makes --no-otel
+	// (or --no-otel-metrics/--no-otel-logs that clears the last remaining
+	// signal) actually erase the section from config.toml — not just leave
+	// stale exporter lines behind.
+	if cfg.OTELLogsEndpoint != "" || cfg.OTELMetricsEndpoint != "" {
+		content = m.patchSection(content, "otel",
+			m.buildOTELSection(cfg))
+	} else {
+		content = m.removeSection(content, "otel")
+	}
+
+	if err := atomicWrite(m.configPath, []byte(content)); err != nil {
+		return fmt.Errorf("write patched config.toml: %w", err)
+	}
+	return nil
+}
+
+// buildProfileSection builds the [profiles.databricks-proxy] section body.
+// It implements preserve-if-present for the model key.
+func (m *Manager) buildProfileSection(cfg PatchConfig) string {
+	var b strings.Builder
+	b.WriteString("model_provider = \"databricks-proxy\"\n")
+
+	// Preserve-if-present: check if user already has a model line in this section.
+	existingModel := m.findModelInSection(string(m.original), "profiles.databricks-proxy")
+	if existingModel != "" {
+		m.origModelLine = existingModel
+	} else {
+		m.origModelLine = sentinel
+	}
+
+	if cfg.ModelExplicit {
+		// User explicitly passed --model: always write it.
+		b.WriteString(fmt.Sprintf("model = %q\n", cfg.Model))
+		m.patchedModelVal = cfg.Model
+	} else if existingModel != "" {
+		// Preserve user's existing model line in the profile section as-is.
+		b.WriteString(existingModel + "\n")
+	} else {
+		// No explicit flag, no model in the profile section.
+		// Check root-level model — since we switch the active profile to
+		// databricks-proxy, the root-level model would be ignored by Codex.
+		// Carry it into the profile section so the user's choice is respected.
+		rootModel := m.findRootModel(string(m.original))
+		if rootModel != "" {
+			b.WriteString(fmt.Sprintf("model = %q\n", rootModel))
+			m.patchedModelVal = rootModel
+		} else if cfg.Model != "" {
+			// Fall back to the resolved model (saved state or built-in default).
+			b.WriteString(fmt.Sprintf("model = %q\n", cfg.Model))
+			m.patchedModelVal = cfg.Model
+		}
+	}
+
+	return b.String()
+}
+
+// buildProviderSection builds the [model_providers.databricks-proxy] section body.
+func (m *Manager) buildProviderSection(cfg PatchConfig) string {
+	var b strings.Builder
+	b.WriteString("name = \"Databricks Proxy\"\n")
+	b.WriteString(fmt.Sprintf("base_url = %q\n", cfg.ProxyURL))
+	b.WriteString("api_key = \"databricks-proxy\"\n")
+	b.WriteString("wire_api = \"responses\"\n")
+	return b.String()
+}
+
+// buildOTELSection builds the [otel] section body.
+// Emits `exporter` (logs) and/or `metrics_exporter` for whichever endpoints
+// are non-empty. Both can coexist in the same [otel] block.
+//
+// Note: Codex's upstream `metrics_exporter` default is Statsig
+// (https://ab.chatgpt.com/otlp/v1/metrics). We do NOT defensively rewrite
+// this at the proxy layer; setting `metrics_exporter` here is the user's
+// explicit opt-in to route metrics through Databricks instead.
+func (m *Manager) buildOTELSection(cfg PatchConfig) string {
+	var b strings.Builder
+	b.WriteString("environment = \"production\"\n")
+	if cfg.OTELLogsEndpoint != "" {
+		b.WriteString(fmt.Sprintf("exporter = { otlp-http = { endpoint = %q, protocol = \"binary\" } }\n", cfg.OTELLogsEndpoint))
+	}
+	if cfg.OTELMetricsEndpoint != "" {
+		b.WriteString(fmt.Sprintf("metrics_exporter = { otlp-http = { endpoint = %q, protocol = \"binary\" } }\n", cfg.OTELMetricsEndpoint))
+	}
+	return b.String()
+}
+
+// patchRootKey finds a root-level key in the content, saves its original value,
+// and replaces or appends the managed value.
+func (m *Manager) patchRootKey(content, key, value string) string {
+	lines := strings.Split(content, "\n")
+	found := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isRootKey(trimmed, key) && !inAnySection(lines, i) {
+			m.origRootKeys[key] = line
+			lines[i] = fmt.Sprintf("%s = %s", key, value)
+			found = true
+			break
+		}
+	}
+	if !found {
+		m.origRootKeys[key] = sentinel
+		// Prepend the root key at the top (after any leading comments/blank lines
+		// but before the first section).
+		insertIdx := 0
+		for i, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "[") {
+				insertIdx = i
+				break
+			}
+			insertIdx = i + 1
+		}
+		newLine := fmt.Sprintf("%s = %s", key, value)
+		lines = insertAt(lines, insertIdx, newLine)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// removeSection finds a [section] in the content and removes it entirely
+// (header + body up to the next section header or EOF). The original block
+// is recorded in origSections so Restore() can put it back.
+//
+// If the section is not present, this is a no-op — and crucially, we do
+// NOT record a sentinel, because there's nothing to undo on Restore().
+func (m *Manager) removeSection(content, sectionName string) string {
+	header := "[" + sectionName + "]"
+	lines := strings.Split(content, "\n")
+
+	startIdx := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == header {
+			startIdx = i
+			break
+		}
+	}
+
+	if startIdx == -1 {
+		// Section absent — nothing to remove, nothing to track.
+		return content
+	}
+
+	// Find section end (next section header or EOF).
+	endIdx := len(lines)
+	for i := startIdx + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, "[[") {
+			endIdx = i
+			break
+		}
+	}
+
+	// Save original block so Restore() can put it back if needed.
+	m.origSections[sectionName] = strings.Join(lines[startIdx:endIdx], "\n")
+
+	// Also drop the trailing blank line that typically separates sections,
+	// so removing [otel] doesn't leave a double-blank gap behind. Only do
+	// this if endIdx is followed by a blank line (i.e. we're removing a
+	// mid-file section, not a trailing one).
+	if endIdx < len(lines) && strings.TrimSpace(lines[endIdx-1]) == "" {
+		// endIdx-1 is already a blank line inside the section we're
+		// removing — nothing extra to do.
+	} else if endIdx < len(lines) && strings.TrimSpace(lines[endIdx]) == "" {
+		// The line right after the section is blank — consume it.
+		endIdx++
+	}
+	// Also drop a blank line immediately BEFORE the section if present,
+	// so we don't leave a dangling separator.
+	if startIdx > 0 && strings.TrimSpace(lines[startIdx-1]) == "" {
+		startIdx--
+	}
+
+	newLines := make([]string, 0, len(lines))
+	newLines = append(newLines, lines[:startIdx]...)
+	newLines = append(newLines, lines[endIdx:]...)
+
+	return strings.Join(newLines, "\n")
+}
+
+// patchSection finds a [section] in the content, saves its original block,
+// and replaces or appends the managed section.
+func (m *Manager) patchSection(content, sectionName, body string) string {
+	header := "[" + sectionName + "]"
+	lines := strings.Split(content, "\n")
+
+	startIdx := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == header {
+			startIdx = i
+			break
+		}
+	}
+
+	if startIdx == -1 {
+		// Section absent — record sentinel, append.
+		m.origSections[sectionName] = sentinel
+		var sb strings.Builder
+		sb.WriteString(header + "\n")
+		sb.WriteString(body)
+		// Ensure content ends with newline before appending.
+		if !strings.HasSuffix(content, "\n") && content != "" {
+			content += "\n"
+		}
+		content += "\n" + sb.String()
+		return content
+	}
+
+	// Find section end (next section header or EOF).
+	endIdx := len(lines)
+	for i := startIdx + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, "[[") {
+			endIdx = i
+			break
+		}
+	}
+
+	// Save original block.
+	origBlock := strings.Join(lines[startIdx:endIdx], "\n")
+	m.origSections[sectionName] = origBlock
+
+	// Build replacement.
+	var replacement []string
+	replacement = append(replacement, header)
+	for _, line := range strings.Split(body, "\n") {
+		if line != "" {
+			replacement = append(replacement, line)
+		}
+	}
+
+	// Replace the section block.
+	newLines := make([]string, 0, len(lines))
+	newLines = append(newLines, lines[:startIdx]...)
+	newLines = append(newLines, replacement...)
+	newLines = append(newLines, lines[endIdx:]...)
+
+	return strings.Join(newLines, "\n")
+}
+
+// findRootModel returns the value of a root-level "model = ..." line (not inside any section).
+// Returns empty string if not found.
+func (m *Manager) findRootModel(content string) string {
+	if content == "" {
+		return ""
+	}
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isRootKey(trimmed, "model") && !inAnySection(lines, i) {
+			parts := strings.SplitN(trimmed, "=", 2)
+			if len(parts) == 2 {
+				val := strings.TrimSpace(parts[1])
+				val = strings.Trim(val, `"`)
+				return val
+			}
+		}
+	}
+	return ""
+}
+
+// findModelInSection looks for a "model = ..." line inside a named section.
+func (m *Manager) findModelInSection(content, sectionName string) string {
+	if content == "" {
+		return ""
+	}
+	header := "[" + sectionName + "]"
+	lines := strings.Split(content, "\n")
+	inSection := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == header {
+			inSection = true
+			continue
+		}
+		if inSection {
+			if strings.HasPrefix(trimmed, "[") {
+				break
+			}
+			if strings.HasPrefix(trimmed, "model") && strings.Contains(trimmed, "=") {
+				// Distinguish "model" from "model_provider"
+				afterKey := strings.TrimPrefix(trimmed, "model")
+				if len(afterKey) > 0 && (afterKey[0] == ' ' || afterKey[0] == '=') {
+					return line
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// Restore performs surgical restoration: only removes/restores keys and sections
+// that we patched. Non-managed content is untouched.
+func (m *Manager) Restore() error {
+	// If we never had an original file and we added everything, remove the file.
+	if m.original == nil && allSentinels(m.origRootKeys) && allSentinels(m.origSections) {
+		os.Remove(m.configPath)
+		os.Remove(m.backupPath)
+		return nil
+	}
+
+	data, err := os.ReadFile(m.configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			os.Remove(m.backupPath)
+			return nil
+		}
+		return fmt.Errorf("read config.toml for restore: %w", err)
+	}
+	content := string(data)
+
+	// Restore root keys.
+	for key, orig := range m.origRootKeys {
+		content = m.restoreRootKey(content, key, orig)
+	}
+
+	// Restore sections.
+	for sectionName, orig := range m.origSections {
+		content = m.restoreSection(content, sectionName, orig)
+	}
+
+	// Restore model line if it was absent before.
+	if m.origModelLine == sentinel {
+		content = m.removeModelFromSection(content, "profiles.databricks-proxy")
+	} else if m.origModelLine != "" && m.origModelLine != sentinel {
+		content = m.restoreModelInSection(content, "profiles.databricks-proxy", m.origModelLine)
+	}
+
+	// Clean up trailing whitespace.
+	content = strings.TrimRight(content, "\n") + "\n"
+
+	if err := atomicWrite(m.configPath, []byte(content)); err != nil {
+		return fmt.Errorf("restore config.toml: %w", err)
+	}
+	os.Remove(m.backupPath)
+	return nil
+}
+
+// restoreRootKey restores a single root key to its original state.
+func (m *Manager) restoreRootKey(content, key, orig string) string {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isRootKey(trimmed, key) && !inAnySection(lines, i) {
+			if orig == sentinel {
+				// Was absent — remove the line.
+				lines = removeAt(lines, i)
+			} else {
+				lines[i] = orig
+			}
+			return strings.Join(lines, "\n")
+		}
+	}
+	return content
+}
+
+// restoreSection restores a section to its original state.
+func (m *Manager) restoreSection(content, sectionName, orig string) string {
+	header := "[" + sectionName + "]"
+	lines := strings.Split(content, "\n")
+
+	startIdx := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == header {
+			startIdx = i
+			break
+		}
+	}
+	if startIdx == -1 {
+		return content
+	}
+
+	// Find section end.
+	endIdx := len(lines)
+	for i := startIdx + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, "[[") {
+			endIdx = i
+			break
+		}
+	}
+
+	if orig == sentinel {
+		// Section was absent — remove the entire block.
+		// Also remove a preceding blank line if present.
+		removeStart := startIdx
+		if removeStart > 0 && strings.TrimSpace(lines[removeStart-1]) == "" {
+			removeStart--
+		}
+		newLines := make([]string, 0, len(lines))
+		newLines = append(newLines, lines[:removeStart]...)
+		newLines = append(newLines, lines[endIdx:]...)
+		return strings.Join(newLines, "\n")
+	}
+
+	// Restore original block.
+	origLines := strings.Split(orig, "\n")
+	newLines := make([]string, 0, len(lines))
+	newLines = append(newLines, lines[:startIdx]...)
+	newLines = append(newLines, origLines...)
+	newLines = append(newLines, lines[endIdx:]...)
+	return strings.Join(newLines, "\n")
+}
+
+// removeModelFromSection removes the model line from a section.
+func (m *Manager) removeModelFromSection(content, sectionName string) string {
+	header := "[" + sectionName + "]"
+	lines := strings.Split(content, "\n")
+	inSection := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == header {
+			inSection = true
+			continue
+		}
+		if inSection {
+			if strings.HasPrefix(trimmed, "[") {
+				break
+			}
+			if strings.HasPrefix(trimmed, "model") && strings.Contains(trimmed, "=") {
+				afterKey := strings.TrimPrefix(trimmed, "model")
+				if len(afterKey) > 0 && (afterKey[0] == ' ' || afterKey[0] == '=') {
+					lines = removeAt(lines, i)
+					return strings.Join(lines, "\n")
+				}
+			}
+		}
+	}
+	return content
+}
+
+// restoreModelInSection restores the model line in a section to its original value.
+func (m *Manager) restoreModelInSection(content, sectionName, origLine string) string {
+	header := "[" + sectionName + "]"
+	lines := strings.Split(content, "\n")
+	inSection := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == header {
+			inSection = true
+			continue
+		}
+		if inSection {
+			if strings.HasPrefix(trimmed, "[") {
+				break
+			}
+			if strings.HasPrefix(trimmed, "model") && strings.Contains(trimmed, "=") {
+				afterKey := strings.TrimPrefix(trimmed, "model")
+				if len(afterKey) > 0 && (afterKey[0] == ' ' || afterKey[0] == '=') {
+					lines[i] = origLine
+					return strings.Join(lines, "\n")
+				}
+			}
+		}
+	}
+	return content
+}
+
+// RestoreFromBackup recovers from a crash by restoring from the backup file.
+// Returns false if no backup exists (clean state).
+func (m *Manager) RestoreFromBackup() bool {
+	data, err := os.ReadFile(m.backupPath)
+	if err != nil {
+		return false
+	}
+	log.Printf("databricks-codex: restoring config.toml from crash backup")
+	m.original = data
+	// For crash recovery, do a full restore from backup.
+	if m.original == nil {
+		os.Remove(m.configPath)
+	} else {
+		if err := atomicWrite(m.configPath, m.original); err != nil {
+			log.Printf("databricks-codex: crash restore failed: %v", err)
+		}
+	}
+	os.Remove(m.backupPath)
+	return true
+}
+
+// UpdateProxyURL updates only the base_url in the managed config.toml.
+// Used for multi-session handoff.
+func (m *Manager) UpdateProxyURL(newURL string) error {
+	data, err := os.ReadFile(m.configPath)
+	if err != nil {
+		return fmt.Errorf("read config for proxy URL update: %w", err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "base_url") && strings.Contains(trimmed, "=") {
+			lines[i] = fmt.Sprintf("base_url = %q", newURL)
+			break
+		}
+	}
+
+	return atomicWrite(m.configPath, []byte(strings.Join(lines, "\n")))
+}
+
+// --- Helpers ---
+
+// isRootKey checks if a trimmed line is a root-level assignment for the given key.
+func isRootKey(trimmed, key string) bool {
+	return strings.HasPrefix(trimmed, key+" ") || strings.HasPrefix(trimmed, key+"=")
+}
+
+// inAnySection returns true if line at idx is inside a [section] (i.e., there's
+// a section header somewhere above it with no intervening root-level context).
+func inAnySection(lines []string, idx int) bool {
+	for i := idx - 1; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, "[[") {
+			return true
+		}
+	}
+	return false
+}
+
+// allSentinels returns true if all values in the map are sentinel.
+func allSentinels(m map[string]string) bool {
+	for _, v := range m {
+		if v != sentinel {
+			return false
+		}
+	}
+	return true
+}
+
+// insertAt inserts a string at the given index in a slice.
+func insertAt(lines []string, idx int, s string) []string {
+	if idx >= len(lines) {
+		return append(lines, s)
+	}
+	lines = append(lines, "")
+	copy(lines[idx+1:], lines[idx:])
+	lines[idx] = s
+	return lines
+}
+
+// removeAt removes the element at idx from a slice.
+func removeAt(lines []string, idx int) []string {
+	return append(lines[:idx], lines[idx+1:]...)
+}
+
+// atomicWrite writes data to a temp file and renames it into place.
+func atomicWrite(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".config-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/codex/tomlconfig/tomlconfig_test.go
+++ b/internal/codex/tomlconfig/tomlconfig_test.go
@@ -1,0 +1,577 @@
+package tomlconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setup(t *testing.T, initialContent string) (*Manager, string) {
+	t.Helper()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	if initialContent != "" {
+		if err := os.WriteFile(configPath, []byte(initialContent), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m := NewManager(configPath)
+	if err := m.Backup(); err != nil {
+		t.Fatal(err)
+	}
+	return m, configPath
+}
+
+func readConfig(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestPatch_EmptyConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	m := NewManager(configPath)
+	if err := m.Backup(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := m.Patch(PatchConfig{
+		ProxyURL: "http://127.0.0.1:9999",
+		Model:    "databricks-gpt-5-5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `profile = "databricks-proxy"`) {
+		t.Error("expected profile root key")
+	}
+	if !strings.Contains(content, "[profiles.databricks-proxy]") {
+		t.Error("expected profiles section")
+	}
+	if !strings.Contains(content, `model = "databricks-gpt-5-5"`) {
+		t.Error("expected model in profile section")
+	}
+	if !strings.Contains(content, `base_url = "http://127.0.0.1:9999"`) {
+		t.Error("expected base_url in provider section")
+	}
+}
+
+func TestPatch_PreservesUserSections(t *testing.T) {
+	initial := `profile = "myprofile"
+
+[projects.myapp]
+sandbox_permissions = "full-auto"
+
+[profiles.myprofile]
+model_provider = "openai"
+model = "gpt-4"
+`
+	m, configPath := setup(t, initial)
+
+	err := m.Patch(PatchConfig{
+		ProxyURL: "http://127.0.0.1:9999",
+		Model:    "databricks-gpt-5-5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	// User section must survive.
+	if !strings.Contains(content, "[projects.myapp]") {
+		t.Error("expected [projects.myapp] to be preserved")
+	}
+	if !strings.Contains(content, `sandbox_permissions = "full-auto"`) {
+		t.Error("expected sandbox_permissions to be preserved")
+	}
+	// User's other profile must survive.
+	if !strings.Contains(content, "[profiles.myprofile]") {
+		t.Error("expected [profiles.myprofile] to be preserved")
+	}
+}
+
+func TestPatch_PreservesUserModel(t *testing.T) {
+	initial := `profile = "databricks-proxy"
+
+[profiles.databricks-proxy]
+model_provider = "databricks-proxy"
+model = "custom-user-model"
+
+[model_providers.databricks-proxy]
+name = "Databricks Proxy"
+base_url = "http://old-proxy:1234"
+api_key = "databricks-proxy"
+wire_api = "responses"
+`
+	m, configPath := setup(t, initial)
+
+	// ModelExplicit=false: should preserve user's model.
+	err := m.Patch(PatchConfig{
+		ProxyURL:      "http://127.0.0.1:9999",
+		Model:         "databricks-gpt-5-5",
+		ModelExplicit: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `model = "custom-user-model"`) {
+		t.Errorf("expected user model to be preserved, got:\n%s", content)
+	}
+}
+
+func TestPatch_OverridesModelWhenExplicit(t *testing.T) {
+	initial := `profile = "databricks-proxy"
+
+[profiles.databricks-proxy]
+model_provider = "databricks-proxy"
+model = "custom-user-model"
+
+[model_providers.databricks-proxy]
+name = "Databricks Proxy"
+base_url = "http://old-proxy:1234"
+api_key = "databricks-proxy"
+wire_api = "responses"
+`
+	m, configPath := setup(t, initial)
+
+	err := m.Patch(PatchConfig{
+		ProxyURL:      "http://127.0.0.1:9999",
+		Model:         "databricks-gpt-5-4-mini",
+		ModelExplicit: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `model = "databricks-gpt-5-4-mini"`) {
+		t.Errorf("expected model to be overridden to databricks-gpt-5-4-mini, got:\n%s", content)
+	}
+	if strings.Contains(content, `model = "custom-user-model"`) {
+		t.Errorf("expected custom-user-model to be replaced, got:\n%s", content)
+	}
+}
+
+func TestRestore_RemovesAddedKeys(t *testing.T) {
+	// Start with a config that has NO databricks-proxy sections.
+	initial := `[projects.myapp]
+sandbox_permissions = "full-auto"
+`
+	m, configPath := setup(t, initial)
+
+	err := m.Patch(PatchConfig{
+		ProxyURL: "http://127.0.0.1:9999",
+		Model:    "databricks-gpt-5-5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify patch added sections.
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, "[profiles.databricks-proxy]") {
+		t.Fatal("patch should have added profiles section")
+	}
+
+	// Restore.
+	if err := m.Restore(); err != nil {
+		t.Fatal(err)
+	}
+
+	content = readConfig(t, configPath)
+	if strings.Contains(content, "[profiles.databricks-proxy]") {
+		t.Error("expected [profiles.databricks-proxy] to be removed after restore")
+	}
+	if strings.Contains(content, "[model_providers.databricks-proxy]") {
+		t.Error("expected [model_providers.databricks-proxy] to be removed after restore")
+	}
+	if strings.Contains(content, `profile = "databricks-proxy"`) {
+		t.Error("expected profile root key to be removed after restore")
+	}
+	// User section must survive.
+	if !strings.Contains(content, "[projects.myapp]") {
+		t.Error("expected [projects.myapp] to survive restore")
+	}
+}
+
+func TestRestore_RestoresOriginalValues(t *testing.T) {
+	initial := `profile = "myprofile"
+
+[profiles.databricks-proxy]
+model_provider = "databricks-proxy"
+model = "original-model"
+
+[model_providers.databricks-proxy]
+name = "Databricks Proxy"
+base_url = "http://old-proxy:1234"
+api_key = "databricks-proxy"
+wire_api = "responses"
+
+[projects.myapp]
+sandbox_permissions = "full-auto"
+`
+	m, configPath := setup(t, initial)
+
+	err := m.Patch(PatchConfig{
+		ProxyURL:      "http://127.0.0.1:9999",
+		Model:         "new-model",
+		ModelExplicit: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Restore.
+	if err := m.Restore(); err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `profile = "myprofile"`) {
+		t.Errorf("expected original profile to be restored, got:\n%s", content)
+	}
+	if !strings.Contains(content, `model = "original-model"`) {
+		t.Errorf("expected original model to be restored, got:\n%s", content)
+	}
+	if !strings.Contains(content, "[projects.myapp]") {
+		t.Errorf("expected user section preserved, got:\n%s", content)
+	}
+}
+
+func TestRestore_PreservesUnmanagedContent(t *testing.T) {
+	initial := `custom_key = "custom_value"
+
+[projects.myapp]
+sandbox_permissions = "full-auto"
+
+[notice]
+shown = true
+`
+	m, configPath := setup(t, initial)
+
+	err := m.Patch(PatchConfig{
+		ProxyURL:         "http://127.0.0.1:9999",
+		Model:            "databricks-gpt-5-5",
+		OTELLogsEndpoint: "http://127.0.0.1:9999/otel/v1/logs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.Restore(); err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `custom_key = "custom_value"`) {
+		t.Errorf("expected custom_key to survive, got:\n%s", content)
+	}
+	if !strings.Contains(content, "[projects.myapp]") {
+		t.Errorf("expected [projects.myapp] to survive, got:\n%s", content)
+	}
+	if !strings.Contains(content, "[notice]") {
+		t.Errorf("expected [notice] to survive, got:\n%s", content)
+	}
+	// OTEL section should be removed (it was absent before).
+	if strings.Contains(content, "[otel]") {
+		t.Errorf("expected [otel] to be removed after restore, got:\n%s", content)
+	}
+}
+
+func TestRestore_NoOriginalFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	m := NewManager(configPath)
+	if err := m.Backup(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := m.Patch(PatchConfig{
+		ProxyURL: "http://127.0.0.1:9999",
+		Model:    "databricks-gpt-5-5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.Restore(); err != nil {
+		t.Fatal(err)
+	}
+
+	// File should be removed since it didn't exist before.
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Error("expected config.toml to be removed after restore when it didn't exist before")
+	}
+}
+
+func TestPatch_RespectsRootLevelModel(t *testing.T) {
+	initial := `model = databricks-gpt-5-3
+
+[projects./Users/me/myproject]
+trust_level = trusted
+`
+	m, configPath := setup(t, initial)
+
+	// No --model flag (ModelExplicit=false), no model in [profiles.databricks-proxy].
+	// Should pick up the root-level model.
+	err := m.Patch(PatchConfig{
+		ProxyURL:      "http://127.0.0.1:9999",
+		Model:         "databricks-gpt-5-5",
+		ModelExplicit: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `model = "databricks-gpt-5-3"`) {
+		t.Errorf("expected root-level model to be carried into profile section, got:\n%s", content)
+	}
+	if strings.Contains(content, `model = "databricks-gpt-5-5"`) {
+		t.Errorf("expected fallback model NOT to be used when root-level model exists, got:\n%s", content)
+	}
+}
+
+func TestPatch_RootLevelModelOverriddenByExplicitFlag(t *testing.T) {
+	initial := `model = databricks-gpt-5-3
+
+[projects./Users/me/myproject]
+trust_level = trusted
+`
+	m, configPath := setup(t, initial)
+
+	// --model flag explicitly set: should override root-level model.
+	err := m.Patch(PatchConfig{
+		ProxyURL:      "http://127.0.0.1:9999",
+		Model:         "databricks-gpt-5-4-mini",
+		ModelExplicit: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `model = "databricks-gpt-5-4-mini"`) {
+		t.Errorf("expected explicit --model to win over root-level model, got:\n%s", content)
+	}
+}
+
+func TestPatch_WithOTEL(t *testing.T) {
+	m, configPath := setup(t, "")
+
+	err := m.Patch(PatchConfig{
+		ProxyURL:         "http://127.0.0.1:9999",
+		Model:            "databricks-gpt-5-5",
+		OTELLogsEndpoint: "http://127.0.0.1:9999/otel/v1/logs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, "[otel]") {
+		t.Error("expected [otel] section")
+	}
+	if !strings.Contains(content, `endpoint = "http://127.0.0.1:9999/otel/v1/logs"`) {
+		t.Error("expected OTEL endpoint in config")
+	}
+}
+
+func TestPatch_WithOTELMetricsOnly(t *testing.T) {
+	m, configPath := setup(t, "")
+
+	err := m.Patch(PatchConfig{
+		ProxyURL:            "http://127.0.0.1:9999",
+		Model:               "databricks-gpt-5-5",
+		OTELMetricsEndpoint: "http://127.0.0.1:9999/otel/v1/metrics",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, "[otel]") {
+		t.Error("expected [otel] section")
+	}
+	if !strings.Contains(content, `metrics_exporter = { otlp-http = { endpoint = "http://127.0.0.1:9999/otel/v1/metrics"`) {
+		t.Errorf("expected metrics_exporter key in [otel] section, got:\n%s", content)
+	}
+	// Specifically: there should be no bare `exporter = { otlp-http = { endpoint = "http://...logs"`
+	if strings.Contains(content, `endpoint = "http://127.0.0.1:9999/otel/v1/logs"`) {
+		t.Errorf("expected no logs exporter when only metrics endpoint provided, got:\n%s", content)
+	}
+}
+
+func TestPatch_WithBothOTELExporters(t *testing.T) {
+	m, configPath := setup(t, "")
+
+	err := m.Patch(PatchConfig{
+		ProxyURL:            "http://127.0.0.1:9999",
+		Model:               "databricks-gpt-5-5",
+		OTELLogsEndpoint:    "http://127.0.0.1:9999/otel/v1/logs",
+		OTELMetricsEndpoint: "http://127.0.0.1:9999/otel/v1/metrics",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `endpoint = "http://127.0.0.1:9999/otel/v1/logs"`) {
+		t.Errorf("expected logs endpoint in [otel] section, got:\n%s", content)
+	}
+	if !strings.Contains(content, `endpoint = "http://127.0.0.1:9999/otel/v1/metrics"`) {
+		t.Errorf("expected metrics endpoint in [otel] section, got:\n%s", content)
+	}
+}
+
+func TestPatch_NoOTELSectionWhenBothEmpty(t *testing.T) {
+	m, configPath := setup(t, "")
+
+	err := m.Patch(PatchConfig{
+		ProxyURL: "http://127.0.0.1:9999",
+		Model:    "databricks-gpt-5-5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if strings.Contains(content, "[otel]") {
+		t.Errorf("expected no [otel] section when both endpoints empty, got:\n%s", content)
+	}
+}
+
+// TestPatch_OTELReWriteAddsMetricsExporter exercises the EnsureConfig regression
+// flagged in PR review: an existing [otel] section with only `exporter` should
+// gain `metrics_exporter` on a subsequent Patch with both endpoints set.
+func TestPatch_OTELReWriteAddsMetricsExporter(t *testing.T) {
+	m, configPath := setup(t, "")
+
+	// First patch: logs only.
+	if err := m.Patch(PatchConfig{
+		ProxyURL:         "http://127.0.0.1:9999",
+		Model:            "databricks-gpt-5-5",
+		OTELLogsEndpoint: "http://127.0.0.1:9999/otel/v1/logs",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second patch: same proxy URL, now with metrics too.
+	if err := m.Patch(PatchConfig{
+		ProxyURL:            "http://127.0.0.1:9999",
+		Model:               "databricks-gpt-5-5",
+		OTELLogsEndpoint:    "http://127.0.0.1:9999/otel/v1/logs",
+		OTELMetricsEndpoint: "http://127.0.0.1:9999/otel/v1/metrics",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `metrics_exporter = { otlp-http = { endpoint = "http://127.0.0.1:9999/otel/v1/metrics"`) {
+		t.Errorf("expected metrics_exporter after re-patch, got:\n%s", content)
+	}
+	if !strings.Contains(content, `endpoint = "http://127.0.0.1:9999/otel/v1/logs"`) {
+		t.Errorf("expected logs endpoint to still be present after re-patch, got:\n%s", content)
+	}
+}
+
+// TestPatch_RemovesOTELSectionWhenEndpointsEmpty exercises the --no-otel
+// regression: a previously-written [otel] section must be removed entirely
+// when a subsequent Patch comes in with both endpoints empty.
+func TestPatch_RemovesOTELSectionWhenEndpointsEmpty(t *testing.T) {
+	m, configPath := setup(t, "")
+
+	// First patch: OTel enabled.
+	if err := m.Patch(PatchConfig{
+		ProxyURL:            "http://127.0.0.1:9999",
+		Model:               "databricks-gpt-5-5",
+		OTELLogsEndpoint:    "http://127.0.0.1:9999/otel/v1/logs",
+		OTELMetricsEndpoint: "http://127.0.0.1:9999/otel/v1/metrics",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	before := readConfig(t, configPath)
+	if !strings.Contains(before, "[otel]") {
+		t.Fatalf("setup error: expected [otel] section after first patch, got:\n%s", before)
+	}
+
+	// Second patch: OTel disabled (both endpoints empty). Section must be gone.
+	if err := m.Patch(PatchConfig{
+		ProxyURL: "http://127.0.0.1:9999",
+		Model:    "databricks-gpt-5-5",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	after := readConfig(t, configPath)
+	if strings.Contains(after, "[otel]") {
+		t.Errorf("expected [otel] section to be removed after empty-endpoints patch, got:\n%s", after)
+	}
+	if strings.Contains(after, "exporter = { otlp-http") {
+		t.Errorf("expected no stale exporter line after removal, got:\n%s", after)
+	}
+	if strings.Contains(after, "metrics_exporter") {
+		t.Errorf("expected no stale metrics_exporter line after removal, got:\n%s", after)
+	}
+	// And [profiles.databricks-proxy] should still be intact.
+	if !strings.Contains(after, "[profiles.databricks-proxy]") {
+		t.Errorf("expected [profiles.databricks-proxy] to survive [otel] removal, got:\n%s", after)
+	}
+}
+
+func TestUpdateProxyURL(t *testing.T) {
+	m, configPath := setup(t, "")
+
+	err := m.Patch(PatchConfig{
+		ProxyURL: "http://127.0.0.1:9999",
+		Model:    "databricks-gpt-5-5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.UpdateProxyURL("http://127.0.0.1:8888"); err != nil {
+		t.Fatal(err)
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `base_url = "http://127.0.0.1:8888"`) {
+		t.Errorf("expected updated base_url, got:\n%s", content)
+	}
+}
+
+func TestRestoreFromBackup(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	backupPath := configPath + ".databricks-codex-backup"
+
+	original := `profile = "myprofile"
+`
+	os.WriteFile(backupPath, []byte(original), 0o600)
+	os.WriteFile(configPath, []byte(`profile = "databricks-proxy"`), 0o600)
+
+	m := NewManager(configPath)
+	restored := m.RestoreFromBackup()
+	if !restored {
+		t.Error("expected RestoreFromBackup to return true")
+	}
+
+	content := readConfig(t, configPath)
+	if !strings.Contains(content, `profile = "myprofile"`) {
+		t.Errorf("expected original content restored from backup, got:\n%s", content)
+	}
+
+	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
+		t.Error("expected backup file to be removed after restore")
+	}
+}


### PR DESCRIPTION
Closes #201. Part of epic #196.

## Summary

Folds the standalone `databricks-codex` launcher into the monorepo as a thin `cmd/databricks-codex` `package main` over `internal/core.Run` + a codex `internal/profile.Profile`, ending the external `require github.com/IceRhymers/databricks-claude v1.0.2` version skew. Codex now compiles against `internal/core` directly. Mirrors the claude thin-main pattern landed in #208/#209.

## What's here

- **`internal/codex/tomlconfig`** — byte-identical port of the `config.toml` patcher (zero-dep, sentinel-guarded surgical patch — the parity-critical component).
- **`cmd/databricks-codex`** — thin `main` dispatches `completion`/`update`/`hooks`/`config`/`serve`, then `buildCodexLaunchPlan → core.Run(CodexProfile(patcher), plan, codexArgs)`.
- **Option A codex Profile** — field-bearing `codexSettingsPatcher` derives `base_url` + OTEL endpoints from `req.ProxyURL` and delegates to `tomlconfig`; `BuildEnv=nil` (codex writes no settings.json env block); one-arg `CodexProfile(patcher)`. Chosen over threading through `PatchRequest.Env` (which would invert that field's documented "settings.json env block" contract and double-source proxyURL).
- **`serve`** is a headless/session-only sibling entrypoint (not via `core.Run`); **no daemon install**. `codexDaemon` is inert API-shape wiring returning `profile.ErrDaemonUnsupported` (codex `serve` is a leaf — no install/uninstall/status).
- **F2 parity** — wrapper-mode and `serve` share one `config.toml` writer via a single `newCodexPatcher` constructor; `TestCodexConfig_CrossPathByteIdentical` locks byte-identical output.
- Preserved: gateway `/ai-gateway/openai/v1`, `wire_api="responses"`, `hooks.json` + `[features] hooks=true` (no SessionEnd — Codex CLI has none). Hooks/config.toml TOCTOU **carried forward unchanged**. Adopts the monorepo `internal/cmd` (codex's copy deleted — differences were comments + the completion import path only).
- Makefile builds **both** binaries (plain codex `go build`, no credential-helper alias / `.pkg` / MDM surface); `CLAUDE.md` / `AGENTS.md` / `README.md` updated.

## Acceptance criteria

- [x] `go build ./cmd/databricks-codex` from `internal/core` + codex Profile; **no** external `databricks-claude` require.
- [x] config.toml patch / gateway path / `wire_api="responses"` / model-provider block match the standalone repo (golden tests).
- [x] codex daemon(=serve-only)/hook behavior preserved via codex's own `DaemonStrategy`(inert)/`HookInstaller` — not claude's.
- [x] codex tests ported + green (161 in `cmd/databricks-codex`, 18 in `internal/codex/tomlconfig`), plus new profile/patch-golden/OTEL-erase/self-heal/cross-path goldens.
- [x] Zero external deps (no `go.sum`, empty `require`). Full module green (23 pkgs / 0 FAIL), `go vet` clean, no claude regression.

## Notes for review

- Byte-parity `tomlconfig` port is a verbatim copy; goldens now act as a drift guard.
- One pre-existing standalone bug fixed by the port: the `--model` completion description said `databricks-claude-sonnet-4-5`; corrected to `databricks-gpt-5-5` to match `defaultModel()`/`--help`. (Changes zsh completion output vs standalone — intentional.)
- Consensus-planned (Architect + Critic), then implemented and reviewed (code-reviewer APPROVE, verifier READY-FOR-PR).

## Out of scope

- Archiving the standalone `databricks-codex` repo (epic).
- Multiplexer (#H), opencode fold-in (separate issue).
- homebrew-tap `databricks-codex` formula + dropped standalone CHANGELOG/release-please history (cross-repo/epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)