### PR TITLE
consolidation: shared `update` subcommand runner in internal/core/updater (#217)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ The tool-agnostic proxy/auth/gateway/token/state engine every launcher runs. Pro
 | `internal/core/refcount` | Atomic session reference counter with conditional-exit support |
 | `internal/core/state` | JSON-file state persistence helpers (atomic temp-file + rename) |
 | `internal/core/tokencache` | Mutex-guarded token cache with 5-min refresh buffer and fallback-on-error |
-| `internal/core/updater` | GitHub release checker with 24-hour cache and numeric semver comparison |
+| `internal/core/updater` | GitHub release checker with 24-hour cache and numeric semver comparison. Also hosts `RunUpdateCommand` (#217) — the shared `update` subcommand runner all three launchers' `update` blocks collapse to (`os.Exit(updater.RunUpdateCommand(buildUpdaterConfig(), os.Stderr))`); it returns the exit code rather than calling `os.Exit`, and writes to an injected `io.Writer`, so it's testable in-process. The pure `formatUpdate` renders a completed `Result`. `buildUpdaterConfig` stays per-launcher — `CacheFile` and `BinaryName` differ; `RepoSlug` is uniform (`IceRhymers/databricks-claude`) since #217 repointed codex and opencode off their abandoned standalone repos, pinned by a `TestBuildUpdaterConfig_RepoSlug` per launcher. `cacheEntry.repo_slug` scopes a cached answer to the repo that produced it, so the repoint takes effect immediately rather than after the 24h TTL. |
 
 ### Library packages (`pkg/`)
 

--- a/cmd/databricks-claude/main.go
+++ b/cmd/databricks-claude/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -61,29 +60,7 @@ func main() {
 
 	// update — force-check for a newer release and print instructions.
 	if len(os.Args) >= 2 && os.Args[1] == "update" {
-		if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
-			fmt.Fprintln(os.Stderr, "databricks-claude: update check disabled via DATABRICKS_NO_UPDATE_CHECK")
-			os.Exit(0)
-		}
-		cfg := buildUpdaterConfig()
-		cfg.CacheTTL = 0 // force fresh check
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		r, err := updater.Check(ctx, cfg)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "databricks-claude: update check failed: %v\n", err)
-			os.Exit(1)
-		}
-		if !r.UpdateAvailable {
-			fmt.Fprintf(os.Stderr, "databricks-claude v%s is already the latest version\n", Version)
-			os.Exit(0)
-		}
-		if r.IsHomebrew {
-			fmt.Fprintf(os.Stderr, "Update available: v%s. Run: brew upgrade databricks-claude\n", r.LatestVersion)
-		} else {
-			fmt.Fprintf(os.Stderr, "Update available: v%s. Download from: %s\n", r.LatestVersion, r.ReleaseURL)
-		}
-		os.Exit(0)
+		os.Exit(updater.RunUpdateCommand(buildUpdaterConfig(), os.Stderr))
 	}
 
 	// Wire the MDM reader so ResolveDatabricksCLI can consult the MDM-managed

--- a/cmd/databricks-claude/main_test.go
+++ b/cmd/databricks-claude/main_test.go
@@ -1323,3 +1323,12 @@ func TestSubcommandFlagsParseable(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildUpdaterConfig_RepoSlug pins the update check to this monorepo's remote.
+// The pre-monorepo standalone repo is abandoned; a silent rot back to it makes
+// `update` recommend a downgrade onto dead code.
+func TestBuildUpdaterConfig_RepoSlug(t *testing.T) {
+	if got := buildUpdaterConfig().RepoSlug; got != "IceRhymers/databricks-claude" {
+		t.Errorf("RepoSlug = %q, want %q", got, "IceRhymers/databricks-claude")
+	}
+}

--- a/cmd/databricks-codex/main.go
+++ b/cmd/databricks-codex/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -64,29 +63,7 @@ func main() {
 
 	// update — force-check for a newer release and print instructions.
 	if len(os.Args) >= 2 && os.Args[1] == "update" {
-		if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
-			fmt.Fprintln(os.Stderr, "databricks-codex: update check disabled via DATABRICKS_NO_UPDATE_CHECK")
-			os.Exit(0)
-		}
-		cfg := buildUpdaterConfig()
-		cfg.CacheTTL = 0 // force fresh check
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		r, err := updater.Check(ctx, cfg)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "databricks-codex: update check failed: %v\n", err)
-			os.Exit(1)
-		}
-		if !r.UpdateAvailable {
-			fmt.Fprintf(os.Stderr, "databricks-codex v%s is already the latest version\n", Version)
-			os.Exit(0)
-		}
-		if r.IsHomebrew {
-			fmt.Fprintf(os.Stderr, "Update available: v%s. Run: brew upgrade databricks-codex\n", r.LatestVersion)
-		} else {
-			fmt.Fprintf(os.Stderr, "Update available: v%s. Download from: %s\n", r.LatestVersion, r.ReleaseURL)
-		}
-		os.Exit(0)
+		os.Exit(updater.RunUpdateCommand(buildUpdaterConfig(), os.Stderr))
 	}
 
 	a, err := parseArgs(os.Args[1:])
@@ -325,7 +302,7 @@ Passthrough to codex:
 func buildUpdaterConfig() updater.Config {
 	home, _ := os.UserHomeDir()
 	return updater.Config{
-		RepoSlug:       "IceRhymers/databricks-codex",
+		RepoSlug:       "IceRhymers/databricks-claude",
 		CurrentVersion: Version,
 		BinaryName:     "databricks-codex",
 		CacheFile:      filepath.Join(home, ".codex", ".update-check.json"),

--- a/cmd/databricks-codex/main_test.go
+++ b/cmd/databricks-codex/main_test.go
@@ -921,3 +921,12 @@ func TestResolveModel_DefaultIsGpt5_5(t *testing.T) {
 		t.Errorf("resolveModel default = %q, want %q", got, want)
 	}
 }
+
+// TestBuildUpdaterConfig_RepoSlug pins the update check to this monorepo's remote.
+// The pre-monorepo standalone repo is abandoned; a silent rot back to it makes
+// `update` recommend a downgrade onto dead code.
+func TestBuildUpdaterConfig_RepoSlug(t *testing.T) {
+	if got := buildUpdaterConfig().RepoSlug; got != "IceRhymers/databricks-claude" {
+		t.Errorf("RepoSlug = %q, want %q", got, "IceRhymers/databricks-claude")
+	}
+}

--- a/cmd/databricks-opencode/main.go
+++ b/cmd/databricks-opencode/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -53,29 +52,7 @@ func main() {
 
 	// update — force-check for a newer release and print instructions.
 	if len(os.Args) >= 2 && os.Args[1] == "update" {
-		if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
-			fmt.Fprintln(os.Stderr, "databricks-opencode: update check disabled via DATABRICKS_NO_UPDATE_CHECK")
-			os.Exit(0)
-		}
-		cfg := buildUpdaterConfig()
-		cfg.CacheTTL = 0 // force fresh check
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		r, err := updater.Check(ctx, cfg)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "databricks-opencode: update check failed: %v\n", err)
-			os.Exit(1)
-		}
-		if !r.UpdateAvailable {
-			fmt.Fprintf(os.Stderr, "databricks-opencode v%s is already the latest version\n", Version)
-			os.Exit(0)
-		}
-		if r.IsHomebrew {
-			fmt.Fprintf(os.Stderr, "Update available: v%s. Run: brew upgrade databricks-opencode\n", r.LatestVersion)
-		} else {
-			fmt.Fprintf(os.Stderr, "Update available: v%s. Download from: %s\n", r.LatestVersion, r.ReleaseURL)
-		}
-		os.Exit(0)
+		os.Exit(updater.RunUpdateCommand(buildUpdaterConfig(), os.Stderr))
 	}
 
 	a, err := parseArgs(os.Args[1:])
@@ -270,7 +247,7 @@ func handleHelp() {
 func buildUpdaterConfig() updater.Config {
 	cacheDir, _ := opencodeConfigDir()
 	return updater.Config{
-		RepoSlug:       "IceRhymers/databricks-opencode",
+		RepoSlug:       "IceRhymers/databricks-claude",
 		CurrentVersion: Version,
 		BinaryName:     "databricks-opencode",
 		CacheFile:      cacheDir + "/.update-check.json",

--- a/cmd/databricks-opencode/main_test.go
+++ b/cmd/databricks-opencode/main_test.go
@@ -877,3 +877,12 @@ func TestConfigShowSubcommandKnownFlags(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildUpdaterConfig_RepoSlug pins the update check to this monorepo's remote.
+// The pre-monorepo standalone repo is abandoned; a silent rot back to it makes
+// `update` recommend a downgrade onto dead code.
+func TestBuildUpdaterConfig_RepoSlug(t *testing.T) {
+	if got := buildUpdaterConfig().RepoSlug; got != "IceRhymers/databricks-claude" {
+		t.Errorf("RepoSlug = %q, want %q", got, "IceRhymers/databricks-claude")
+	}
+}

--- a/internal/core/updater/runupdate_test.go
+++ b/internal/core/updater/runupdate_test.go
@@ -1,0 +1,279 @@
+package updater
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// formatUpdate — pure; Result constructed directly, no server needed.
+// Assertions are exact full-output equality (trailing newline included), since
+// the literal-parity gate normalizes the newline representation away and can no
+// longer catch a genuinely dropped "\n".
+// ---------------------------------------------------------------------------
+
+func TestFormatUpdate_NoUpdate(t *testing.T) {
+	cfg := Config{BinaryName: "databricks-test", CurrentVersion: "1.0.0"}
+	var buf bytes.Buffer
+
+	code := formatUpdate(cfg, Result{UpdateAvailable: false}, &buf)
+
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	want := "databricks-test v1.0.0 is already the latest version\n"
+	if got := buf.String(); got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+}
+
+func TestFormatUpdate_Homebrew(t *testing.T) {
+	cfg := Config{BinaryName: "databricks-test", CurrentVersion: "1.0.0"}
+	var buf bytes.Buffer
+
+	code := formatUpdate(cfg, Result{
+		UpdateAvailable: true,
+		LatestVersion:   "2.0.0",
+		IsHomebrew:      true,
+		ReleaseURL:      "https://github.com/test/repo/releases/tag/v2.0.0",
+	}, &buf)
+
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	want := "Update available: v2.0.0. Run: brew upgrade databricks-test\n"
+	if got := buf.String(); got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+}
+
+func TestFormatUpdate_Download(t *testing.T) {
+	cfg := Config{BinaryName: "databricks-test", CurrentVersion: "1.0.0"}
+	var buf bytes.Buffer
+
+	code := formatUpdate(cfg, Result{
+		UpdateAvailable: true,
+		LatestVersion:   "2.0.0",
+		IsHomebrew:      false,
+		ReleaseURL:      "https://github.com/test/repo/releases/tag/v2.0.0",
+	}, &buf)
+
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	want := "Update available: v2.0.0. Download from: https://github.com/test/repo/releases/tag/v2.0.0\n"
+	if got := buf.String(); got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunUpdateCommand — integration; uses the rewriteTransport + http.DefaultClient
+// swap pattern from updater_test.go.
+// ---------------------------------------------------------------------------
+
+// TestRunUpdateCommand_Disabled asserts the env kill-switch short-circuits before
+// Check — a regression here would make it leak a network call.
+func TestRunUpdateCommand_Disabled(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	t.Setenv("DATABRICKS_NO_UPDATE_CHECK", "1")
+
+	var buf bytes.Buffer
+	code := RunUpdateCommand(Config{
+		RepoSlug:       "test/repo",
+		CurrentVersion: "1.0.0",
+		BinaryName:     "databricks-test",
+		CacheFile:      filepath.Join(t.TempDir(), "cache.json"),
+		CacheTTL:       24 * time.Hour,
+	}, &buf)
+
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	want := "databricks-test: update check disabled via DATABRICKS_NO_UPDATE_CHECK\n"
+	if got := buf.String(); got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+	if n := calls.Load(); n != 0 {
+		t.Errorf("HTTP calls = %d, want 0 (kill-switch must short-circuit Check)", n)
+	}
+}
+
+func TestRunUpdateCommand_CheckError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	var buf bytes.Buffer
+	code := RunUpdateCommand(Config{
+		RepoSlug:       "test/repo",
+		CurrentVersion: "1.0.0",
+		BinaryName:     "databricks-test",
+		CacheFile:      filepath.Join(t.TempDir(), "cache.json"),
+		CacheTTL:       24 * time.Hour,
+	}, &buf)
+
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
+	}
+	if got := buf.String(); !strings.HasPrefix(got, "databricks-test: update check failed:") {
+		t.Errorf("output = %q, want prefix %q", got, "databricks-test: update check failed:")
+	}
+}
+
+// TestRunUpdateCommand_SuccessPath drives a success path through the exported
+// function the launchers actually call. Without this, the RunUpdateCommand ->
+// formatUpdate wiring is unpinned: replacing the call with `return 0` — so
+// `update` prints nothing at all — would leave the rest of the suite green.
+func TestRunUpdateCommand_SuccessPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(githubRelease{
+			TagName: "v2.0.0",
+			HTMLURL: "https://github.com/test/repo/releases/tag/v2.0.0",
+		})
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	var buf bytes.Buffer
+	code := RunUpdateCommand(Config{
+		RepoSlug:       "test/repo",
+		CurrentVersion: "1.0.0",
+		BinaryName:     "databricks-test",
+		CacheFile:      filepath.Join(t.TempDir(), "cache.json"),
+		CacheTTL:       24 * time.Hour,
+	}, &buf)
+
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	// IsHomebrew is environment-dependent (it inspects os.Executable), so assert
+	// on the branch-invariant prefix rather than pinning one of the two forms.
+	if got := buf.String(); !strings.HasPrefix(got, "Update available: v2.0.0. ") || !strings.HasSuffix(got, "\n") {
+		t.Errorf("output = %q, want %q + a branch suffix + newline", got, "Update available: v2.0.0. ")
+	}
+}
+
+// TestCheck_CacheSlugMismatch pins the #217 repoint actually taking effect for an
+// existing user. A cache entry written by the old (abandoned) repo must not be
+// served for the new one — otherwise `update` keeps recommending a downgrade onto
+// dead code for up to CacheTTL after the upgrade.
+func TestCheck_CacheSlugMismatch(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		json.NewEncoder(w).Encode(githubRelease{
+			TagName: "v1.2.0",
+			HTMLURL: "https://github.com/IceRhymers/databricks-claude/releases/tag/v1.2.0",
+		})
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	cacheFile := filepath.Join(t.TempDir(), "cache.json")
+
+	// Seed a *fresh* entry from the abandoned standalone repo, exactly as a
+	// pre-upgrade databricks-codex would have written it.
+	data, _ := json.Marshal(cacheEntry{
+		CheckedAt:     timeNow().UTC().Format(time.RFC3339),
+		RepoSlug:      "IceRhymers/databricks-codex",
+		LatestVersion: "2.0.0",
+		ReleaseURL:    "https://github.com/IceRhymers/databricks-codex/releases/tag/v2.0.0",
+	})
+	os.WriteFile(cacheFile, data, 0o600)
+
+	res, err := Check(context.Background(), Config{
+		RepoSlug:       "IceRhymers/databricks-claude",
+		CurrentVersion: "1.2.0",
+		BinaryName:     "databricks-codex",
+		CacheFile:      cacheFile,
+		CacheTTL:       24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("HTTP calls = %d, want 1 (a foreign-repo entry must be a miss)", calls.Load())
+	}
+	if res.LatestVersion != "1.2.0" {
+		t.Errorf("LatestVersion = %q, want %q (served the abandoned repo's cached answer)", res.LatestVersion, "1.2.0")
+	}
+	if res.UpdateAvailable {
+		t.Error("UpdateAvailable = true; the stale v2.0.0 downgrade recommendation survived")
+	}
+}
+
+// TestCheck_CacheEntryPredatingRepoSlug covers the on-disk entries that exist in
+// the wild today: written before the repo_slug field, they decode it as "" and
+// must be refetched once rather than trusted.
+func TestCheck_CacheEntryPredatingRepoSlug(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		json.NewEncoder(w).Encode(githubRelease{TagName: "v1.2.0"})
+	}))
+	defer srv.Close()
+
+	origClient := http.DefaultClient
+	http.DefaultClient = srv.Client()
+	http.DefaultClient.Transport = rewriteTransport{target: srv.URL}
+	defer func() { http.DefaultClient = origClient }()
+
+	cacheFile := filepath.Join(t.TempDir(), "cache.json")
+	os.WriteFile(cacheFile, []byte(`{
+  "checked_at": "`+timeNow().UTC().Format(time.RFC3339)+`",
+  "latest_version": "2.0.0",
+  "release_url": "https://github.com/IceRhymers/databricks-codex/releases/tag/v2.0.0",
+  "asset_url": ""
+}`), 0o600)
+
+	res, err := Check(context.Background(), Config{
+		RepoSlug:       "IceRhymers/databricks-claude",
+		CurrentVersion: "1.2.0",
+		BinaryName:     "databricks-codex",
+		CacheFile:      cacheFile,
+		CacheTTL:       24 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("HTTP calls = %d, want 1 (a field-less legacy entry must be a miss)", calls.Load())
+	}
+	if res.LatestVersion != "1.2.0" {
+		t.Errorf("LatestVersion = %q, want %q", res.LatestVersion, "1.2.0")
+	}
+}

--- a/internal/core/updater/updater.go
+++ b/internal/core/updater/updater.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -33,8 +34,17 @@ type Result struct {
 }
 
 // cacheEntry is the on-disk JSON schema for the cache file.
+//
+// RepoSlug records which repository the entry was fetched from. A cached answer
+// is only valid for the repo that produced it, so Check treats a slug mismatch
+// as a miss. Entries written before this field existed decode it as "" and are
+// therefore refetched once — which is the point: #217 repointed codex's and
+// opencode's RepoSlug away from their abandoned standalone repos, and without
+// this the stale entry would keep recommending a downgrade onto dead code for
+// up to CacheTTL after the upgrade.
 type cacheEntry struct {
 	CheckedAt     string `json:"checked_at"`
+	RepoSlug      string `json:"repo_slug"`
 	LatestVersion string `json:"latest_version"`
 	ReleaseURL    string `json:"release_url"`
 	AssetURL      string `json:"asset_url"`
@@ -64,8 +74,8 @@ func Check(ctx context.Context, cfg Config) (Result, error) {
 		cfg.CacheTTL = 24 * time.Hour
 	}
 
-	// Try reading cache first.
-	if entry, err := readCache(cfg.CacheFile); err == nil {
+	// Try reading cache first. An entry from a different repo is a miss, not a hit.
+	if entry, err := readCache(cfg.CacheFile); err == nil && entry.RepoSlug == cfg.RepoSlug {
 		checkedAt, parseErr := time.Parse(time.RFC3339, entry.CheckedAt)
 		if parseErr == nil && timeNow().Before(checkedAt.Add(cfg.CacheTTL)) {
 			return buildResult(cfg.CurrentVersion, entry.LatestVersion, entry.ReleaseURL, entry.AssetURL), nil
@@ -88,6 +98,7 @@ func Check(ctx context.Context, cfg Config) (Result, error) {
 	// Write cache (best-effort; errors returned to caller).
 	if err := writeCache(cfg.CacheFile, cacheEntry{
 		CheckedAt:     timeNow().UTC().Format(time.RFC3339),
+		RepoSlug:      cfg.RepoSlug,
 		LatestVersion: latestVersion,
 		ReleaseURL:    rel.HTMLURL,
 		AssetURL:      assetURL,
@@ -247,6 +258,43 @@ func PrintUpdateNotice(cfg Config) {
 	} else {
 		fmt.Fprintf(os.Stderr, "%s: update available (v%s). Run: %s update\n", cfg.BinaryName, r.LatestVersion, cfg.BinaryName)
 	}
+}
+
+// RunUpdateCommand implements the shared `update` subcommand: a forced check that
+// prints upgrade instructions to w and returns the process exit code.
+func RunUpdateCommand(cfg Config, w io.Writer) int {
+	if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
+		fmt.Fprintf(w, "%s: update check disabled via DATABRICKS_NO_UPDATE_CHECK\n", cfg.BinaryName)
+		return 0
+	}
+	// TODO(#223): this is a no-op — Check reinterprets CacheTTL==0 as 24h, so
+	// `update` reads a cached result rather than forcing a fresh check. Preserved
+	// verbatim from the launchers; fixing it is a behavior change, not a consolidation.
+	cfg.CacheTTL = 0
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	r, err := Check(ctx, cfg)
+	if err != nil {
+		fmt.Fprintf(w, "%s: update check failed: %v\n", cfg.BinaryName, err)
+		return 1
+	}
+	return formatUpdate(cfg, r, w)
+}
+
+// formatUpdate renders a completed check. Pure: no I/O beyond w, no clock, no env.
+// Uses cfg.BinaryName for the display name and the Homebrew formula name, mirroring
+// PrintUpdateNotice.
+func formatUpdate(cfg Config, r Result, w io.Writer) int {
+	if !r.UpdateAvailable {
+		fmt.Fprintf(w, "%s v%s is already the latest version\n", cfg.BinaryName, cfg.CurrentVersion)
+		return 0
+	}
+	if r.IsHomebrew {
+		fmt.Fprintf(w, "Update available: v%s. Run: brew upgrade %s\n", r.LatestVersion, cfg.BinaryName)
+	} else {
+		fmt.Fprintf(w, "Update available: v%s. Download from: %s\n", r.LatestVersion, r.ReleaseURL)
+	}
+	return 0
 }
 
 // writeCache writes the cache file atomically (temp + rename).

--- a/internal/core/updater/updater_test.go
+++ b/internal/core/updater/updater_test.go
@@ -94,9 +94,20 @@ func TestCheck_CacheMiss(t *testing.T) {
 		t.Errorf("AssetURL = %q, want download URL", res.AssetURL)
 	}
 
-	// Verify cache was written.
-	if _, err := os.Stat(cacheFile); err != nil {
+	// Verify cache was written, including repo_slug. Without the slug assertion
+	// the write side is unpinned: an entry missing it mismatches on every read,
+	// turning the cache write-only and putting a GitHub API call on every
+	// startup (PrintUpdateNotice) against an unauthenticated 60/hr/IP limit.
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
 		t.Fatalf("cache file not created: %v", err)
+	}
+	var written cacheEntry
+	if err := json.Unmarshal(data, &written); err != nil {
+		t.Fatalf("parsing written cache: %v", err)
+	}
+	if written.RepoSlug != "test/repo" {
+		t.Errorf("written repo_slug = %q, want %q", written.RepoSlug, "test/repo")
 	}
 }
 
@@ -120,9 +131,11 @@ func TestCheck_CacheHit(t *testing.T) {
 	cacheDir := t.TempDir()
 	cacheFile := filepath.Join(cacheDir, "cache.json")
 
-	// Seed fresh cache.
+	// Seed fresh cache. RepoSlug must match the Config below — a foreign-repo
+	// entry is a miss (see TestCheck_CacheSlugMismatch).
 	entry := cacheEntry{
 		CheckedAt:     timeNow().UTC().Format(time.RFC3339),
+		RepoSlug:      "test/repo",
 		LatestVersion: "0.12.0",
 		ReleaseURL:    "https://github.com/test/repo/releases/tag/v0.12.0",
 		AssetURL:      "https://dl.example.com/cached",
@@ -179,9 +192,12 @@ func TestCheck_CacheExpired(t *testing.T) {
 	cacheDir := t.TempDir()
 	cacheFile := filepath.Join(cacheDir, "cache.json")
 
-	// Seed stale cache (25 hours old).
+	// Seed stale cache (25 hours old). RepoSlug matches the Config below, so
+	// expiry is the only reason this can miss — otherwise the test would pass
+	// on a slug mismatch and stop covering the TTL logic it exists to cover.
 	entry := cacheEntry{
 		CheckedAt:     timeNow().Add(-25 * time.Hour).UTC().Format(time.RFC3339),
+		RepoSlug:      "test/repo",
 		LatestVersion: "0.11.0",
 		ReleaseURL:    "https://github.com/test/repo/releases/tag/v0.11.0",
 		AssetURL:      "https://dl.example.com/old",


### PR DESCRIPTION
Closes #217. Part of the pre-merge consolidation pass under #196.

## ⚠️ This PR contains a behavior change, not just a consolidation

Two things ship here. Reviewing them separately is probably easiest:

1. **The consolidation** (#217 as scoped) — mechanical, behavior-preserving.
2. **A P1 bug fix** the consolidation surfaced — the update check now queries a **different GitHub repo** for codex and opencode. This was deliberately pulled into scope rather than deferred.

## 1. The consolidation

The `update` early-exit block was copy-pasted near-verbatim across all three launchers (~24 lines × 3), differing only in tool-name string literals. Extracted `RunUpdateCommand(cfg Config, w io.Writer) int` + a pure `formatUpdate` into `internal/core/updater`; each launcher collapses to:

```go
if len(os.Args) >= 2 && os.Args[1] == "update" {
    os.Exit(updater.RunUpdateCommand(buildUpdaterConfig(), os.Stderr))
}
```

**Signature note — deliberate divergence from the issue.** The issue suggested `(cfg, version, toolName, w)`. Both extra params already exist on `Config` (`CurrentVersion`, `BinaryName`) at all three call sites, and `PrintUpdateNotice` already uses `BinaryName` for both the message prefix and the formula name.

The counter-argument was considered and rejected on reversibility: `BinaryName` is currently the *artifact* identity (`matchAsset` builds `databricks-codex-linux-amd64` from it), and this adds a *presentation* role, which lockstep #204 could eventually split. But this is an `internal/` package with three call sites — adding the param the day the formula actually diverges is trivial. Speculative generality now is the worse bet.

Returning the exit code rather than calling `os.Exit`, and writing to an injected `io.Writer`, is what makes the runner testable in-process at all.

## 2. The P1 fix (behavior change)

**codex and opencode were pointing their update checks at their abandoned pre-monorepo standalone repos.** Verified live:

| | version |
|---|---|
| monorepo (this repo) | v1.2.0 |
| standalone `IceRhymers/databricks-codex` | **v2.0.0** |

Because lockstep #204 moved codex *backward* (2.0.0 → 1.2.0), `CompareVersions("1.2.0","2.0.0") == -1` fires **forever**. So `databricks-codex update` today reports `Update available: v2.0.0` and recommends `brew upgrade databricks-codex` — a **downgrade onto abandoned code**.

All three now point at `IceRhymers/databricks-claude`, pinned by a `TestBuildUpdaterConfig_RepoSlug` per launcher so it cannot silently rot again — which is exactly how it got here.

**Safety checks before adopting:**
- **Today:** codex `CurrentVersion` 1.2.0 vs monorepo v1.2.0 → `CompareVersions == 0` → "already the latest version". The downgrade advice dies.
- **Future:** `make dist` loops `$(BINS)` = all four binaries and `release.yml` uploads `dist/*`, so the next release carries `databricks-codex-*` assets. (v1.2.0 predates #204, which is why it only has claude assets.)
- **If an asset were still missing:** no impact — the download branch prints `ReleaseURL` (the release page), not `AssetURL`. Nothing in the update path downloads or executes anything; it only prints advice.

### The fix needed a second piece to actually work

`cacheEntry` had no repo identity, and `Check` returns a fresh cached entry *before* consulting `RepoSlug`. So an existing codex user who ran `update` within the last 24h would keep getting the abandoned repo's answer **after** upgrading — the fix would have been inert for a day on exactly the population it targets.

`cacheEntry` now records `repo_slug`; a mismatch is a cache miss. Entries predating the field decode `""` → mismatch → refetched once.

## Behavior parity

All five output strings and four exit-code paths are byte-identical to the three inlined blocks. Verified mechanically, not by eye — the literals are extracted from `HEAD` and diffed against the shared runner:

```
$ diff /tmp/parity-head.txt /tmp/parity-new.txt
$ echo $?
0
```

The gate normalizes the `Fprintln`→`Fprintf` newline representation (same runtime bytes, different literal), so the tests assert **exact full-output equality including the trailing `\n`** to cover what the gate deliberately normalizes away.

## Known-remaining gap (not fixable here)

`release.yml:133` dispatches `client_payload[tool]=databricks-claude` only, so the tap's `databricks-codex` / `databricks-opencode` formulas are updated by nobody and still track the standalone repos. This PR fixes the version *comparison*; the `brew upgrade` advice still resolves against a stale formula until that's fixed. Filed as **#224** (different repo, release-infra change).

## Honest note on a preserved bug

`cfg.CacheTTL = 0 // force fresh check` is a **no-op** — `Check` reinterprets `0` as 24h and `buildUpdaterConfig` already sets 24h, so `update` reads a cached result. Preserved verbatim (fixing it is a behavior change), but the comment now says so instead of lying. Tracked in **#223**, which also covers the two README lines it falsifies. Consolidation makes that fix a one-liner in one place.

## Testing

- `go build ./...`, `go vet ./...` clean; **26 packages green**
- 8 new updater cases + 3 RepoSlug pins
- **Every new assertion mutation-tested** — reverting the slug guard fails both cache tests; dropping the write-side `repo_slug` fails `TestCheck_CacheMiss`; gutting `formatUpdate` fails the wiring test; removing the env guard fails the kill-switch's HTTP-call counter
- Smoke on all three: `DATABRICKS_NO_UPDATE_CHECK=1 ./databricks-<tool> update` → rc=0 + correct message
- `TestCheck_CacheExpired`'s seeded entry needed the matching slug, or it would have passed for the wrong reason and silently stopped covering the TTL logic it exists to cover

Reviewed by independent code-review and security-review passes; the security pass rated the diff **net risk-reducing** (it removes two dangling references to abandoned repos, which would become attacker-registrable if those namespaces were ever freed).

Filed separately, out of scope: #223, #224, #225 (`/databricks-agents` build artifact is not gitignored — live hazard in any worktree where `make build` ran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)