### PR TITLE
fix(release): dispatch package-manager updates for the distributed binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,10 +120,21 @@ jobs:
             dist/databricks-claude.pkg \
             dist/databricks-claude-trust.mobileconfig
 
+  # One lockstep release builds all four binaries (see BINS in the Makefile),
+  # so every package-manager dispatch fans out per tool. fail-fast is off: a
+  # tool whose formula/manifest lags shouldn't strand the others.
   update-homebrew:
     needs: [release-please, build-and-upload]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tool:
+          - databricks-agents
+          - databricks-claude
+          - databricks-codex
+          - databricks-opencode
     steps:
       - name: Dispatch formula update to homebrew-tap
         env:
@@ -131,13 +142,23 @@ jobs:
         run: |
           gh api repos/IceRhymers/homebrew-tap/dispatches \
             -f event_type=formula-update \
-            -f "client_payload[tool]=databricks-claude" \
+            -f "client_payload[tool]=${{ matrix.tool }}" \
             -f "client_payload[tag]=${{ needs.release-please.outputs.tag_name }}" \
             -f "client_payload[version]=${{ needs.release-please.outputs.tag_name }}"
   update-scoop:
     needs: [release-please, build-and-upload]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # databricks-agents is absent on purpose: scoop-bucket has no manifest
+        # for the multiplexer and update-manifests.yml doesn't listen for
+        # update-databricks-agents yet. Add it here once the bucket does.
+        binary:
+          - databricks-claude
+          - databricks-codex
+          - databricks-opencode
     steps:
       - name: Dispatch manifest update to scoop-bucket
         env:
@@ -146,6 +167,6 @@ jobs:
           VERSION="${{ needs.release-please.outputs.tag_name }}"
           VERSION="${VERSION#v}"
           gh api repos/IceRhymers/scoop-bucket/dispatches \
-            -f event_type=update-databricks-claude \
-            -f "client_payload[binary]=databricks-claude" \
+            -f event_type=update-${{ matrix.binary }} \
+            -f "client_payload[binary]=${{ matrix.binary }}" \
             -f "client_payload[version]=${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,9 +120,12 @@ jobs:
             dist/databricks-claude.pkg \
             dist/databricks-claude-trust.mobileconfig
 
-  # One lockstep release builds all four binaries (see BINS in the Makefile),
-  # so every package-manager dispatch fans out per tool. fail-fast is off: a
-  # tool whose formula/manifest lags shouldn't strand the others.
+  # `make dist` builds all four binaries, but only the distributed ones are
+  # dispatched. databricks-codex and databricks-opencode are intentionally
+  # absent: their standalone repos are archived and we are not publishing new
+  # artifacts for them, so their tap formulae stay frozen at their last
+  # standalone versions. Dispatching for them would fail the tap's
+  # update-formula.yml on every release forever.
   update-homebrew:
     needs: [release-please, build-and-upload]
     if: needs.release-please.outputs.release_created == 'true'
@@ -133,8 +136,6 @@ jobs:
         tool:
           - databricks-agents
           - databricks-claude
-          - databricks-codex
-          - databricks-opencode
     steps:
       - name: Dispatch formula update to homebrew-tap
         env:
@@ -152,13 +153,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # databricks-agents is absent on purpose: scoop-bucket has no manifest
-        # for the multiplexer and update-manifests.yml doesn't listen for
-        # update-databricks-agents yet. Add it here once the bucket does.
+        # Same freeze as above for codex/opencode. databricks-agents is absent
+        # for a different reason: scoop-bucket has no manifest for the
+        # multiplexer and update-manifests.yml doesn't listen for
+        # update-databricks-agents. Add it here once the bucket does.
         binary:
           - databricks-claude
-          - databricks-codex
-          - databricks-opencode
     steps:
       - name: Dispatch manifest update to scoop-bucket
         env:


### PR DESCRIPTION
Closes #233. Takes option **(a)**, the per-tool fan-out, which keeps the tap and bucket keyed on the `client_payload` shape they already consume.

**Scope narrowed after review:** codex and opencode are frozen — their standalone repos are archived and no new artifacts will be published for them (homebrew-tap#51 closed as won't-fix). So the fan-out covers only what we actually distribute.

## What changed

Both `update-homebrew` and `update-scoop` become matrix jobs instead of hardcoding `databricks-claude`.

- **`update-homebrew`** → `databricks-agents`, `databricks-claude`. The multiplexer is the new thing that needs bumping; claude keeps working as before.
- **`update-scoop`** → `databricks-claude` only. The bucket has no `databricks-agents.json` manifest and `update-manifests.yml` doesn't listen for `update-databricks-agents`; dispatching it today would be silently swallowed. Left as an inline comment for when the bucket is ready.
- **codex/opencode excluded from both**, with an inline comment explaining the freeze. This is load-bearing: the tap's `update-formula.yml` now hard-fails on a formula whose URLs don't point at this monorepo (homebrew-tap#54), and those two intentionally never will. Dispatching for them would produce a red leg on every release forever.
- **`fail-fast: false`**, so one lagging formula doesn't strand the other.

## Prerequisite before the next release

The homebrew fan-out will dispatch `tool=databricks-agents` at the next release, which needs the tap side ready:

- IceRhymers/homebrew-tap#54 — sources assets from this monorepo instead of the archived per-tool repos.
- IceRhymers/homebrew-tap#52 — adds `databricks-agents.rb`. Blocked until a release publishes `databricks-agents-*` assets.

No release has published those yet: the consolidation PRs (#201, #202, #203, #204) all landed *after* v1.2.0 shipped on 2026-06-03, so every existing release contains only `databricks-claude-*`. Release-please #234 (`chore: release 1.3.0`) will be the first.

**Suggested order:** merge this → merge homebrew-tap#54 → merge #234 (publishes the agents artifacts) → land homebrew-tap#52 with the real SHAs. The agents dispatch from 1.3.0 will fail since the formula won't exist yet; with `fail-fast: false` that's an isolated red leg and claude still bumps cleanly. Alternatively hold #234 until #52 is staged.

## Verification

YAML parses; both matrices asserted against their downstream consumers. The dispatch itself can't be exercised without cutting a release.